### PR TITLE
Change approved computing to ignore negative, improve reporting

### DIFF
--- a/mergify_engine/engine.py
+++ b/mergify_engine/engine.py
@@ -172,7 +172,6 @@ class MergifyEngine(object):
             elif event_type == "pull_request_review":
                 cache.pop("mergify_engine_reviews", None)
                 cache.pop("mergify_engine_approvals", None)
-                cache.pop("mergify_engine_approved", None)
             elif (event_type == "pull_request" and
                   data["action"] == "synchronize"):
                     cache.pop("mergify_engine_combined_status", None)

--- a/mergify_engine/tests/test_engine.py
+++ b/mergify_engine/tests/test_engine.py
@@ -510,7 +510,7 @@ class TestEngineScenario(testtools.TestCase):
 
         self.assertEqual(1, pulls[1].number)
         self.assertEqual(-1, pulls[1].mergify_engine['weight'])
-        self.assertEqual("Waiting for approvals",
+        self.assertEqual("0/1 approvals required",
                          pulls[1].mergify_engine['status_desc'])
 
         # Check the merged pull request is gone

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ install_requires =
     redis
     hiredis
     rq
-    six
     pyyaml
     mock
     futures


### PR DESCRIPTION
It does not seem like GitHub cares about negative review, so it's likely
Mergify should do the same by default. Another option could be added to not
block merge on negative reviews.

Also, send a better description on the number of approval that Mergify is
waiting for.