### PR TITLE
Do not only trust GitHub maintainer_can_modify field

### DIFF
--- a/mergify_engine/engine.py
+++ b/mergify_engine/engine.py
@@ -248,7 +248,7 @@ class MergifyEngine(object):
                         "No user access_token setuped for rebasing")
                     LOG.info("%s -> branch not updatable, token missing",
                              p.pretty())
-                elif not p.maintainer_can_modify:
+                elif not p.base_is_modifiable:
                     p.mergify_engine_github_post_check_status(
                         self._redis, self._installation_id, "failure",
                         "PR owner doesn't allow modification")

--- a/mergify_engine/gh_pr.py
+++ b/mergify_engine/gh_pr.py
@@ -122,6 +122,11 @@ def mergify_engine_merge(self, rule):
         # to repoduce the issue
 
 
+def base_is_modifiable(self):
+    return (self.raw_data["maintainer_can_modify"] or
+            self.head.repo.id == self.base.repo.id)
+
+
 def from_event(repo, data):
     # TODO(sileht): do it only once in handle()
     # NOTE(sileht): Convert event payload, into pygithub object
@@ -142,14 +147,11 @@ def from_cache(repo, data, **extra):
 def monkeypatch_github():
     p = github.PullRequest.PullRequest
 
-    # Missing attribute
-    p.maintainer_can_modify = property(
-        lambda p: p.raw_data["maintainer_can_modify"])
-
     p.pretty = pretty
     p.fullify = gh_pr_fullifier.fullify
     p.jsonify = gh_pr_fullifier.jsonify
 
+    p.mergify_base_is_modifiable = base_is_modifiable
     p.mergify_engine_merge = mergify_engine_merge
     p.mergify_engine_github_post_check_status = \
         mergify_engine_github_post_check_status

--- a/mergify_engine/gh_pr_fullifier.py
+++ b/mergify_engine/gh_pr_fullifier.py
@@ -135,7 +135,7 @@ def compute_weight_and_status(pull, **extra):
         status_desc = "Waiting for CI success"
     elif pull.mergeable_state == "behind":
         # Not up2date, but ready to merge, is branch updatable
-        if not pull.maintainer_can_modify:
+        if not pull.base_is_modifiable:
             weight = -1
             status_desc = ("Pull request can't be updated with latest "
                            "base branch changes, owner doesn't allow "


### PR DESCRIPTION
This implements a new field called `base_is_modifiable` which shows if the base
of a PR can be modified for the strict workflow. The current field provided by
GitHub does not cover the case where the base branch comes from the same repo
than the target branch, and not from a fork — see #51. This should fix it.

Fixes #51