### PR TITLE
Create backport and close status only when PR is closed

### DIFF
--- a/mergify_engine/engine.py
+++ b/mergify_engine/engine.py
@@ -139,28 +139,31 @@ class MergifyEngine(object):
 
         if incoming_pull.state == "closed":
             self.cache_remove_pull(incoming_pull)
-            self.proceed_queue(incoming_pull.base.ref, **fullify_extra)
             LOG.info("Just update cache (pull_request closed)")
-            if incoming_pull.merged:
-                incoming_pull.mergify_engine_github_post_check_status(
-                    self._redis, self._installation_id, "success", "Merged")
-                backports.backports(self._r, incoming_pull,
-                                    branch_rule["automated_backport_labels"],
-                                    self._installation_token)
-            else:
-                incoming_pull.mergify_engine_github_post_check_status(
-                    self._redis, self._installation_id, "success",
-                    "Pull request closed unmerged")
 
-            if incoming_pull.head.ref.startswith("mergify/bp/%s" %
-                                                 incoming_pull.base.ref):
-                try:
-                    self._r.get_git_ref("heads/%s" % incoming_pull.head.ref
-                                        ).delete()
-                    LOG.info("%s: branch %s deleted", incoming_pull.pretty(),
-                             incoming_pull.head.ref)
-                except github.UnknownObjectException:
-                    pass
+            if event_type == "pull_request" and data["action"] == "closed":
+                self.proceed_queue(incoming_pull.base.ref, **fullify_extra)
+
+                if incoming_pull.merged:
+                    incoming_pull.mergify_engine_github_post_check_status(
+                        self._redis, self._installation_id, "success", "Merged")
+                    backports.backports(self._r, incoming_pull,
+                                        branch_rule["automated_backport_labels"],
+                                        self._installation_token)
+                else:
+                    incoming_pull.mergify_engine_github_post_check_status(
+                        self._redis, self._installation_id, "success",
+                        "Pull request closed unmerged")
+
+                if incoming_pull.head.ref.startswith("mergify/bp/%s" %
+                                                     incoming_pull.base.ref):
+                    try:
+                        self._r.get_git_ref("heads/%s" % incoming_pull.head.ref
+                                            ).delete()
+                        LOG.info("%s: branch %s deleted", incoming_pull.pretty(),
+                                 incoming_pull.head.ref)
+                    except github.UnknownObjectException:
+                        pass
 
             return
 


### PR DESCRIPTION
We currently post status "Merged", do backports and delete backport
branches each times we receive an event for a closed pull request.

We should do them only when the PR have just been merged and not
for status event that could come after.

Closes #80