### PR TITLE
Don't throw backtrace on 401

### DIFF
--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -49,6 +49,10 @@ def event_handler(event_type, subscription, data):
                              installation_token,
                              subscription,
                              user, repo).handle(event_type, data)
+    except github.GithubException.BadCredentialsException:
+        LOG.error("token for install %d is no longuer valid (%s)",
+                  data["installation"]["id"],
+                  data["repository"]["full_name"])
     except github.RateLimitExceededException:  # pragma: no cover
         LOG.error("rate limit reached for install %d (%s)",
                   data["installation"]["id"],


### PR DESCRIPTION
When an installation remove the access_token, we got some 401 in logs.

This change replace the backtrace by an error message.