### PR TITLE
Rework status checks

### DIFF
--- a/mergify_engine/engine.py
+++ b/mergify_engine/engine.py
@@ -181,12 +181,12 @@ class MergifyEngine(object):
                          if k.startswith("mergify_engine_"))
             cache.pop("mergify_engine_status", None)
             if event_type == "status":
-                cache.pop("mergify_engine_combined_status", None)
+                cache.pop("mergify_engine_required_statuses_succeed", None)
             elif event_type == "pull_request_review":
                 cache.pop("mergify_engine_approvals", None)
             elif (event_type == "pull_request" and
                   data["action"] == "synchronize"):
-                    cache.pop("mergify_engine_combined_status", None)
+                    cache.pop("mergify_engine_required_statuses_succeed", None)
 
         incoming_pull.fullify(cache, **fullify_extra)
         self.cache_save_pull(incoming_pull)

--- a/mergify_engine/gh_pr.py
+++ b/mergify_engine/gh_pr.py
@@ -27,7 +27,7 @@ LOG = logging.getLogger(__name__)
 
 def pretty(self):
     extra = getattr(self, "mergify_engine", {})
-    combined_status = extra.get("combined_status", "nc")
+    required_statuses_succeed = extra.get("required_statuses_succeed", "nc")
     status = extra.get("status", {})
     approvals = len(extra["approvals"][0]) if "approvals" in extra else "nc"
     return "%s/%s/pull/%s@%s (%s/%s/%s/%s/%s/%s)" % (
@@ -37,7 +37,7 @@ def pretty(self):
         self.base.ref,
         ("merged" if self.merged
          else (self.mergeable_state or "none")),
-        combined_status,
+        required_statuses_succeed,
         approvals,
         status.get("mergify_state", 'nc'),
         status.get("github_state", 'nc'),

--- a/mergify_engine/static/table.html
+++ b/mergify_engine/static/table.html
@@ -62,12 +62,14 @@
              </td>
              <td class="state" ng-if="pull.mergify_ui_travis_detail == null">
                  <a href="#" ng-click="toggle_info(pull, 'travis')">
-                    <span ng-if="pull.mergify_engine_combined_status == 'success'" title="Last test succeeded" class="good glyphicon glyphicon-ok"></span>
-                    <span ng-if="pull.mergify_engine_combined_status == 'failure'" title="Last test failed!" class="bad glyphicon glyphicon-remove"></span>
-                    <span ng-if="pull.mergify_engine_combined_status == 'error'" title="Last test error!" class="bad glyphicon glyphicon-remove"></span>
-                    <span ng-if="pull.mergify_engine_combined_status == 'pending'" title="Latest test pending" class="maybe glyphicon glyphicon-time"></span>
-                    <span ng-if="pull.mergify_engine_combined_status == 'working'" title="Latest test pending" class="maybe glyphicon glyphicon-cog"></span>
-                    <span ng-if="pull.mergify_engine_combined_status == 'unknown'" title="Latest test unknown" class="maybe glyphicon glyphicon-question-sign"></span>
+                    <!-- FIXME(sileht): We don't compute this anymore with the backend -->
+                    <span ng-if="pull.mergify_ui_combined_status == 'success'" title="Last test succeeded" class="good glyphicon glyphicon-ok"></span>
+                    <span ng-if="pull.mergify_ui_combined_status == 'failure'" title="Last test failed!" class="bad glyphicon glyphicon-remove"></span>
+                    <span ng-if="pull.mergify_ui_combined_status == 'error'" title="Last test error!" class="bad glyphicon glyphicon-remove"></span>
+                    <span ng-if="pull.mergify_ui_combined_status == 'pending'" title="Latest test pending" class="maybe glyphicon glyphicon-time"></span>
+                    <span ng-if="pull.mergify_ui_combined_status == 'working'" title="Latest test pending" class="maybe glyphicon glyphicon-cog"></span>
+                    <span ng-if="pull.mergify_ui_combined_status == 'unknown'" title="Latest test unknown" class="maybe glyphicon glyphicon-question-sign"></span>
+                    <span title="Latest test unknown" class="maybe glyphicon glyphicon-question-sign"></span>
                  </a>
              </td>
              <td class="mergeable">

--- a/mergify_engine/tests/test_engine.py
+++ b/mergify_engine/tests/test_engine.py
@@ -872,8 +872,8 @@ class TestEngineScenario(testtools.TestCase):
 
         pulls = self.engine.build_queue("master")
         self.assertEqual(2, len(pulls))
-        self.assertEqual("success", pulls[0].mergify_engine["combined_status"])
-        self.assertEqual("success", pulls[1].mergify_engine["combined_status"])
+        self.assertTrue(pulls[0].mergify_engine["required_statuses_succeed"])
+        self.assertTrue(pulls[1].mergify_engine["required_statuses_succeed"])
 
         master_sha = self.r_main.get_commits()[0].sha
 
@@ -972,8 +972,8 @@ class TestEngineScenario(testtools.TestCase):
 
         pulls = self.engine.build_queue("nostrict")
         self.assertEqual(2, len(pulls))
-        self.assertEqual("success", pulls[0].mergify_engine["combined_status"])
-        self.assertEqual("success", pulls[1].mergify_engine["combined_status"])
+        self.assertTrue(pulls[0].mergify_engine["required_statuses_succeed"])
+        self.assertTrue(pulls[1].mergify_engine["required_statuses_succeed"])
 
         self.create_review_and_push_event(p1, commits1[0])
         self.push_events(MERGE_EVENTS)


### PR DESCRIPTION
This change reworks the statuses checker to just track if all required
statuses succeed or not.

This also adds a small behavior change to match how context work at
Github.

When you put "continuous-integration" as context, this means Github
requires all statuses with the context starting with
"continuous-integration/"

We was doing an exact match before. Now we use "startswith(...)" like
Github does.