### PR TITLE
Allow to spawn multiple workers of the engine

### DIFF
--- a/fake.yml
+++ b/fake.yml
@@ -1,6 +1,8 @@
 ---
-WORKERS: 5
+TOPOLOGY:
+  localhost: 2
 
+FETCH_WORKERS: 5
 LOG_RATELIMIT: false
 DEBUG: true
 FLUSH_REDIS_ON_STARTUP: false

--- a/mergify_engine/engine.py
+++ b/mergify_engine/engine.py
@@ -224,7 +224,8 @@ class MergifyEngine(object):
 
         data = self._redis.hgetall(self.get_cache_key(branch))
 
-        with futures.ThreadPoolExecutor(max_workers=config.WORKERS) as tpe:
+        with futures.ThreadPoolExecutor(
+                max_workers=config.FETCH_WORKERS) as tpe:
             pulls = list(tpe.map(
                 lambda p: gh_pr.from_cache(self._r, json.loads(p), **extra),
                 data.values()))

--- a/mergify_engine/tests/test_engine.py
+++ b/mergify_engine/tests/test_engine.py
@@ -275,9 +275,11 @@ class TestEngineScenario(testtools.TestCase):
                                            access_token,
                                            subscription, user, repo)
 
-        queue = rq.Queue(connection=utils.get_redis_for_rq())
-        self.rq_worker = rq.SimpleWorker([queue],
-                                         connection=queue.connection)
+        self.rq_worker = rq.SimpleWorker(["localhost-000-high",
+                                          "localhost-001-high",
+                                          "localhost-000-low",
+                                          "localhost-001-low"],
+                                         connection=utils.get_redis_for_rq())
 
         if self._testMethodName != "test_creation_pull_of_initial_config":
             self.git("init")

--- a/mergify_engine/utils.py
+++ b/mergify_engine/utils.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import shutil
+import socket
 import subprocess
 import sys
 import tempfile
@@ -86,6 +87,11 @@ def setup_logging():
         ("urllib3.connectionpool", "WARN"),
         ("vcr", "WARN"),
     ])
+
+
+def get_fqdn():
+    return socket.getaddrinfo(socket.gethostname(), 0, 0, 0, 0,
+                              socket.AI_CANONNAME)[0][3]
 
 
 def compute_hmac(data):

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 cleanup(){
-    [ -n "$worker_pid" ] && kill -9 $worker_pid || true
+    [ -n "$worker0_pid" ] && kill -9 $worker0_pid || true
+    [ -n "$worker1_pid" ] && kill -9 $worker1_pid || true
     [ -n "$bridge_pid" ] && kill -9 $bridge_pid || true
     [ -n "$wsgi_pid" ] && kill -9 $wsgi_pid || true
 }
@@ -14,8 +15,11 @@ if [ "$MERGIFYENGINE_WEBHOOK_SECRET" == "X" ]; then
     exit 1
 fi
 
-python -u mergify_engine/worker.py &
-worker_pid="$!"
+mergify-rq-worker --fqdn localhost 0 &
+worker0_pid="$!"
+
+mergify-rq-worker --fqdn localhost 1 &
+worker1_pid="$!"
 
 uwsgi --http 127.0.0.1:8802 --plugin python3 --master --enable-threads --die-on-term --processes 4 --threads 4 --lazy-apps --thunder-lock --wsgi-file mergify_engine/wsgi.py &
 wsgi_pid="$!"

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     rq
     rq-dashboard
     pyyaml
+    uhashring
     voluptuous
     raven[flask]
 
@@ -49,6 +50,7 @@ docs =
 console_scripts =
     mergify-refresher = mergify_engine.refresher:main
     mergify-stats = mergify_engine.stats:main
+    mergify-rq-worker = mergify_engine.worker:main
 
 [build_wheel]
 universal = 1


### PR DESCRIPTION
This change allows to spawn multiple workers.

For now, all events for a repository should go in order to
the same worker.

This change uses a static hashring to describe all
workers/queues we can use to do that.

Each worker now have two queues, one for account with subscription
and one for free account.