### PR TITLE
Use daiquiri and extra prepending to log

### DIFF
--- a/mergify_engine/branch_protection.py
+++ b/mergify_engine/branch_protection.py
@@ -15,11 +15,11 @@
 # under the License.
 
 import copy
-import logging
+import daiquiri
 
 import github
 
-LOG = logging.getLogger(__name__)
+LOG = daiquiri.getLogger(__name__)
 
 
 def is_configured(g_repo, branch, rule, data):
@@ -57,8 +57,9 @@ def is_configured(g_repo, branch, rule, data):
 
     configured = rule['protection'] == data
     if not configured:
-        LOG.warning("Branch %s of %s is misconfigured: %s != %s",
-                    branch, g_repo.full_name, data, rule['protection'])
+        LOG.warning("Misconfigured branch: %s != %s",
+                    data, rule['protection'],
+                    branch=branch, repository=g_repo.full_name)
     return configured
 
 

--- a/mergify_engine/branch_updater.py
+++ b/mergify_engine/branch_updater.py
@@ -14,12 +14,12 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import logging
+import daiquiri
 
 from mergify_engine import config
 from mergify_engine import utils
 
-LOG = logging.getLogger(__name__)
+LOG = daiquiri.getLogger(__name__)
 
 
 def update(pull, token, merge=True):
@@ -68,7 +68,7 @@ def update(pull, token, merge=True):
             git("rebase", "upstream/%s" % base_branch)
         git("push", "origin", head_branch)
     except Exception:  # pragma: no cover
-        LOG.error("%s: update branch fail", pull, exc_info=True)
+        LOG.error("update branch fail", pull_request=pull, exc_info=True)
         return False
     finally:
         git.cleanup()

--- a/mergify_engine/config.py
+++ b/mergify_engine/config.py
@@ -15,11 +15,13 @@
 # under the License.
 
 
-import logging
 import os
+
+import daiquiri
+
 import yaml
 
-LOG = logging.getLogger(__name__)
+LOG = daiquiri.getLogger(__name__)
 
 
 with open(os.getenv("MERGIFYENGINE_SETTINGS", "fake.yml")) as f:

--- a/mergify_engine/debug.py
+++ b/mergify_engine/debug.py
@@ -14,15 +14,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import logging
-
 import github
 
 from mergify_engine import config
 from mergify_engine import utils
-
-
-LOG = logging.getLogger(__name__)
 
 
 def create_jwt():

--- a/mergify_engine/initial_configuration.py
+++ b/mergify_engine/initial_configuration.py
@@ -12,14 +12,14 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import logging
 import yaml
 
+import daiquiri
 import github
 
 from mergify_engine import config
 
-LOG = logging.getLogger(__name__)
+LOG = daiquiri.getLogger(__name__)
 
 INITIAL_CONFIG_BRANCH = "mergify/initial-config"
 
@@ -97,7 +97,7 @@ See documentation: https://help.github.com/articles/checking-out-pull-requests-l
         base=repo.default_branch,
         head=INITIAL_CONFIG_BRANCH,
     )
-    LOG.info('Initial configuration created for repo %s', repo.full_name)
+    LOG.info('Initial configuration created', repository=repo.full_name)
 
 
 def create_pull_request_if_needed(installation_token, repo):
@@ -113,7 +113,7 @@ def create_pull_request_if_needed(installation_token, repo):
                 raise
             create_pull_request(installation_token, repo)
         else:
-            LOG.info("Initial configuration branch already exists for repo %s",
-                     repo.full_name)
+            LOG.info("Initial configuration branch already exists",
+                     repository=repo.full_name)
     else:
-        LOG.info("Mergify already configured for repo %s", repo.full_name)
+        LOG.info("Mergify already configured", repository=repo.full_name)

--- a/mergify_engine/rules.py
+++ b/mergify_engine/rules.py
@@ -16,14 +16,14 @@
 
 import collections
 import copy
-import logging
 import re
 
+import daiquiri
 import github
 import voluptuous
 import yaml
 
-LOG = logging.getLogger(__name__)
+LOG = daiquiri.getLogger(__name__)
 
 with open("default_rule.yml", "r") as f:
     DEFAULT_RULE = yaml.safe_load(f.read())
@@ -163,5 +163,5 @@ def get_branch_rule(g_repo, branch, ref=github.GithubObject.NotSet):
     if ".mergify.yml" not in rule["disabling_files"]:
         rule["disabling_files"].append(".mergify.yml")
 
-    LOG.info("Rule for %s branch: %s" % (branch, rule))
+    LOG.info("Fetched branch rule", branch=branch, rule=rule)
     return rule

--- a/mergify_engine/utils.py
+++ b/mergify_engine/utils.py
@@ -35,7 +35,7 @@ import requests
 
 from mergify_engine import config
 
-LOG = logging.getLogger(__name__)
+LOG = daiquiri.getLogger(__name__)
 
 
 global REDIS_CONNECTION_RQ

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ include_package_data = true
 
 install_requires =
     attrs
-    daiquiri
+    daiquiri>=1.5
     flask
     cryptography
     pygithub>=1.40


### PR DESCRIPTION
This changes the logging mechanism to leverage daiquiri and log a bit better.
- It passes most context information as keyword arguments so they are printed
  correctly on the line and can be embedded to Sentry
- It uses a log object per MergifyPull object so it's automatically prepended
  with information on the pull request logging