### PR TITLE
Make web.py dummier

### DIFF
--- a/mergify_engine/queue.py
+++ b/mergify_engine/queue.py
@@ -1,0 +1,51 @@
+# -*- encoding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import rq
+import uhashring
+
+from mergify_engine import config
+from mergify_engine import utils
+from mergify_engine import worker
+
+# TODO(sileht): Make the ring dynamic
+global RING
+nodes = []
+for fqdn, w in sorted(config.TOPOLOGY.items()):
+    nodes.extend(map(lambda x: "%s-%003d" % (fqdn, x), range(w)))
+
+RING = uhashring.HashRing(nodes=nodes)
+
+
+def get_queue(slug, subscription):
+    global RING
+    name = "%s-%s" % (RING.get_node(slug),
+                      "high" if subscription["subscribed"] else "low")
+    return rq.Queue(name, connection=utils.get_redis_for_rq())
+
+
+# Lightweight pickle object for rq
+def dispatch(message_kind, *args, **kwargs):
+    method = getattr(worker.MergifyWorker, "job_%s" % message_kind)
+    return method(*args, **kwargs)
+
+
+def route(repo, subscription, message_kind, *args, **kwargs):
+    q = get_queue(repo, subscription)
+    q.enqueue(dispatch, message_kind, *args, **kwargs)
+
+
+def publish(message_kind, *args, **kwargs):
+    q = rq.Queue("incoming-events", connection=utils.get_redis_for_rq())
+    q.enqueue(dispatch, message_kind, *args, **kwargs)

--- a/mergify_engine/tests/test_engine.py
+++ b/mergify_engine/tests/test_engine.py
@@ -281,7 +281,8 @@ class TestEngineScenario(testtools.TestCase):
                                            subscription, user, repo)
         self.processor = self.engine.get_processor()
 
-        self.rq_worker = rq.SimpleWorker(["localhost-000-high",
+        self.rq_worker = rq.SimpleWorker(["incoming-events",
+                                          "localhost-000-high",
                                           "localhost-001-high",
                                           "localhost-000-low",
                                           "localhost-001-low"],

--- a/mergify_engine/web.py
+++ b/mergify_engine/web.py
@@ -24,14 +24,10 @@ import json
 import logging
 
 import flask
-import github
-import rq
 import rq_dashboard
-import uhashring
 
-from mergify_engine import config
+from mergify_engine import queue
 from mergify_engine import utils
-from mergify_engine import worker
 
 
 LOG = logging.getLogger(__name__)
@@ -42,21 +38,6 @@ app.config.from_object(rq_dashboard.default_settings)
 app.register_blueprint(rq_dashboard.blueprint, url_prefix="/rq")
 app.config["REDIS_URL"] = utils.get_redis_url()
 app.config["RQ_POLL_INTERVAL"] = 10000  # ms
-
-# TODO(sileht): Make the ring dynamic
-global RING
-nodes = []
-for fqdn, w in sorted(config.TOPOLOGY.items()):
-    nodes.extend(map(lambda x: "%s-%003d" % (fqdn, x), range(w)))
-
-RING = uhashring.HashRing(nodes=nodes)
-
-
-def get_queue(slug, subscription):
-    global RING
-    name = "%s-%s" % (RING.get_node(slug),
-                      "high" if subscription["subscribed"] else "low")
-    return rq.Queue(name, connection=utils.get_redis_for_rq())
 
 
 def authentification():  # pragma: no cover
@@ -90,110 +71,18 @@ def check_status_msg(key):
         flask.abort(404)
 
 
-@app.route("/refresh/<owner>/<repo>/<path:refresh_ref>",
-           methods=["POST"])
+@app.route("/refresh/<owner>/<repo>/<path:refresh_ref>", methods=["POST"])
 def refresh(owner, repo, refresh_ref):
     authentification()
-
-    integration = github.GithubIntegration(config.INTEGRATION_ID,
-                                           config.PRIVATE_KEY)
-    installation_id = utils.get_installation_id(integration, owner)
-    if not installation_id:  # pragma: no cover
-        flask.abort(400, "%s have not installed mergify_engine" % owner)
-
-    token = integration.get_access_token(installation_id).token
-    g = github.Github(token)
-    r = g.get_repo("%s/%s" % (owner, repo))
-    try:
-        r.get_contents(".mergify.yml")
-    except github.GithubException as e:  # pragma: no cover
-        if e.status == 404:
-            return "No .mergify.yml", 202
-        else:
-            raise
-
-    if refresh_ref == "full" or refresh_ref.startswith("branch/"):
-        if refresh_ref.startswith("branch/"):
-            branch = refresh_ref[7:]
-            pulls = r.get_pulls(base=branch)
-        else:
-            branch = '*'
-            pulls = r.get_pulls()
-        key = "queues~%s~%s~%s~%s~%s" % (installation_id, owner.lower(),
-                                         repo.lower(), r.private, branch)
-        utils.get_redis_for_cache().delete(key)
-    else:
-        try:
-            pull_number = int(refresh_ref[5:])
-        except ValueError:  # pragma: no cover
-            return "Invalid PR ref", 400
-        pulls = [r.get_pull(pull_number)]
-
-    subscription = utils.get_subscription(utils.get_redis_for_cache(),
-                                          installation_id)
-
-    if not subscription["token"]:  # pragma: no cover
-        return "", 202
-
-    if r.private and not subscription["subscribed"]:  # pragma: no cover
-        return "", 202
-
-    for p in pulls:
-        # Mimic the github event format
-        data = {
-            'repository': r.raw_data,
-            'installation': {'id': installation_id},
-            'pull_request': p.raw_data,
-        }
-        get_queue(r.full_name, subscription).enqueue(
-            worker.event_handler, "refresh", subscription, data)
-
-    return "", 202
+    queue.publish("refresh", owner, repo, refresh_ref)
+    return "Refresh queued", 202
 
 
 @app.route("/refresh", methods=["POST"])
 def refresh_all():
     authentification()
-
-    integration = github.GithubIntegration(config.INTEGRATION_ID,
-                                           config.PRIVATE_KEY)
-
-    counts = [0, 0, 0]
-    for install in utils.get_installations(integration):
-        counts[0] += 1
-        token = integration.get_access_token(install["id"]).token
-        g = github.Github(token)
-        i = g.get_installation(install["id"])
-
-        subscription = utils.get_subscription(utils.get_redis_for_cache(),
-                                              install["id"])
-        if not subscription["token"]:  # pragma: no cover
-            continue
-
-        for r in i.get_repos():
-            if r.private and not subscription["subscribed"]:
-                continue
-            try:
-                r.get_contents(".mergify.yml")
-            except github.GithubException as e:  # pragma: no cover
-                if e.status == 404:
-                    continue
-                else:
-                    raise
-
-            counts[1] += 1
-            for p in list(r.get_pulls()):
-                # Mimic the github event format
-                data = {
-                    'repository': r.raw_data,
-                    'installation': {'id': install["id"]},
-                    'pull_request': p.raw_data,
-                }
-                get_queue(r.full_name, subscription).enqueue(
-                    worker.event_handler, "refresh", subscription, data)
-
-    return ("Updated %s installations, %s repositories, "
-            "%s branches" % tuple(counts)), 202
+    queue.publish("refresh_all")
+    return "Refresh queued", 202
 
 
 # FIXME(sileht): rename this to new subscription something
@@ -211,8 +100,8 @@ def subscription_cache(installation_id):  # pragma: no cover
     # event.
     if subscription["token"] and subscription["subscribed"]:
         # FIXME(sileht): We should pass the slugs
-        get_queue(installation_id, subscription).enqueue(
-            worker.installation_handler, installation_id, "private")
+        queue.push(installation_id, subscription, "installations",
+                   installation_id, "private")
     return "Cache cleaned", 200
 
 
@@ -224,90 +113,8 @@ def event_handler():
     event_id = flask.request.headers.get("X-GitHub-Delivery")
     data = flask.request.get_json()
 
-    subscription = utils.get_subscription(
-        utils.get_redis_for_cache(), data["installation"]["id"])
-
-    if not subscription["token"]:
-        msg_action = "ignored (no token)"
-
-    elif event_type == "installation" and data["action"] == "created":
-        for repository in data["repositories"]:
-            if repository["private"] and not subscription["subscribed"]:  # noqa pragma: no cover
-                continue
-
-            get_queue(repository["full_name"], subscription).enqueue(
-                worker.installation_handler, data["installation"]["id"],
-                [repository])
-        msg_action = "pushed to backend"
-
-    elif event_type == "installation" and data["action"] == "deleted":
-        key = "queues~%s~*~*~*~*" % data["installation"]["id"]
-        utils.get_redis_for_cache().delete(key)
-        msg_action = "handled, cache cleaned"
-
-    elif (event_type == "installation_repositories" and
-          data["action"] == "added"):
-        for repository in data["repositories_added"]:
-            if repository["private"] and not subscription["subscribed"]:  # noqa pragma: no cover
-                continue
-
-            get_queue(repository["full_name"], subscription).enqueue(
-                worker.installation_handler, data["installation"]["id"],
-                [repository])
-
-        msg_action = "pushed to backend"
-
-    elif (event_type == "installation_repositories" and
-          data["action"] == "removed"):
-        for repository in data["repositories_removed"]:
-            if repository["private"] and not subscription["subscribed"]:  # noqa pragma: no cover
-                continue
-            key = "queues~%s~%s~%s~*~*" % (
-                data["installation"]["id"],
-                data["installation"]["account"]["login"].lower(),
-                repository["name"].lower()
-            )
-            utils.get_redis_for_cache().delete(key)
-        msg_action = "handled, cache cleaned"
-
-    elif event_type in ["installation", "installation_repositories"]:
-        msg_action = "ignored (action %s)" % data["action"]
-
-    elif event_type in ["pull_request", "pull_request_review", "status",
-                        "refresh"]:
-
-        if data["repository"]["private"] and not subscription["subscribed"]:
-            msg_action = "ignored (not public or subscribe)"
-
-        elif event_type == "status" and data["state"] == "pending":
-            msg_action = "ignored (state pending)"
-
-        elif event_type == "status" and data["context"] == "mergify/pr":
-            msg_action = "ignored (mergify status)"
-
-        elif (event_type == "pull_request" and data["action"] not in [
-                "opened", "reopened", "closed", "synchronize",
-                "labeled", "unlabeled"]):
-            msg_action = "ignored (action %s)" % data["action"]
-
-        else:
-            get_queue(data["repository"]["full_name"], subscription).enqueue(
-                worker.event_handler, event_type, subscription, data)
-            msg_action = "pushed to backend"
-
-    else:
-        msg_action = "ignored (unexpected event_type)"
-
-    if "repository" in data:
-        repo_name = data["repository"]["full_name"]
-    else:
-        repo_name = data["installation"]["account"]["login"]
-
-    LOG.info('[%s/%s] received "%s" event "%s", %s',
-             data["installation"]["id"], repo_name,
-             event_type, event_id, msg_action)
-
-    return "", 202
+    queue.publish("filter_and_dispatch", event_type, event_id, data)
+    return "Event queued", 202
 
 
 # NOTE(sileht): These endpoints are used for recording cassetes, we receive

--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -29,88 +29,10 @@ from mergify_engine import config
 from mergify_engine import engine
 from mergify_engine import exceptions
 from mergify_engine import initial_configuration
+from mergify_engine import queue
 from mergify_engine import utils
 
 LOG = logging.getLogger(__name__)
-
-
-def event_handler(event_type, subscription, data):
-    """Everything start here"""
-    integration = github.GithubIntegration(config.INTEGRATION_ID,
-                                           config.PRIVATE_KEY)
-    try:
-        installation_token = integration.get_access_token(
-            data["installation"]["id"]).token
-    except github.UnknownObjectException:
-        LOG.error("token for install %d does not exists anymore (%s)",
-                  data["installation"]["id"],
-                  data["repository"]["full_name"])
-        return
-
-    g = github.Github(installation_token)
-    try:
-        user = g.get_user(data["repository"]["owner"]["login"])
-        repo = user.get_repo(data["repository"]["name"])
-
-        engine.MergifyEngine(g, data["installation"]["id"],
-                             installation_token,
-                             subscription,
-                             user, repo).handle(event_type, data)
-    except github.BadCredentialsException:  # pragma: no cover
-        LOG.error("token for install %d is no longuer valid (%s)",
-                  data["installation"]["id"],
-                  data["repository"]["full_name"])
-    except github.RateLimitExceededException:  # pragma: no cover
-        LOG.error("rate limit reached for install %d (%s)",
-                  data["installation"]["id"],
-                  data["repository"]["full_name"])
-
-
-def installation_handler(installation_id, repositories):
-    """Create the initial configuration on an repository"""
-
-    integration = github.GithubIntegration(config.INTEGRATION_ID,
-                                           config.PRIVATE_KEY)
-    try:
-        installation_token = integration.get_access_token(
-            installation_id).token
-    except github.UnknownObjectException:  # pragma: no cover
-        LOG.error("token for install %d does not exists anymore",
-                  installation_id)
-        return
-
-    g = github.Github(installation_token)
-    try:
-        if isinstance(repositories, str):
-            installation = g.get_installation(installation_id)
-            if repositories == "private":
-                repositories = [repo for repo in installation.get_repos()
-                                if repo.private]
-            elif repositories == "all":
-                repositories = [repo for repo in installation.get_repos()]
-            else:
-                raise RuntimeError("Unexpected 'repositories' format: %s",
-                                   type(repositories))
-        elif isinstance(repositories, list):
-            # Some events return incomplete repository structure (like
-            # installation event). Complete them in this case
-            new_repos = []
-            for repository in repositories:
-                user = g.get_user(repository["full_name"].split("/")[0])
-                repo = user.get_repo(repository["name"])
-                new_repos.append(repo)
-            repositories = new_repos
-        else:  # pragma: no cover
-            raise RuntimeError("Unexpected 'repositories' format: %s",
-                               type(repositories))
-
-        for repository in repositories:
-            initial_configuration.create_pull_request_if_needed(
-                installation_token, repository)
-
-    except github.RateLimitExceededException:  # pragma: no cover
-        LOG.error("rate limit reached for install %d",
-                  installation_id)
 
 
 class MergifyWorker(rq.Worker):  # pragma: no cover
@@ -121,9 +43,11 @@ class MergifyWorker(rq.Worker):  # pragma: no cover
 
         self._redis = redis.StrictRedis.from_url(utils.get_redis_url())
 
+        # Queue order is the priority
         super(MergifyWorker, self).__init__(
             ["%s-high" % basename,
-             "%s-low" % basename],
+             "%s-low" % basename,
+             "incoming-events"],
             connection=self._redis)
 
         self.push_exc_handler(self._retry_handler)
@@ -146,9 +70,9 @@ class MergifyWorker(rq.Worker):  # pragma: no cover
         LOG.warn('job %s: failed %d times - retrying' % (job.id,
                                                          job.meta['failures']))
 
-        for queue in self.queues:
-            if queue.name == job.origin:
-                queue.enqueue_job(job, at_front=True)
+        for q in self.queues:
+            if q.name == job.origin:
+                q.enqueue_job(job, at_front=True)
             return False
 
         # Can't find queue, which should basically never happen as we only work
@@ -156,6 +80,279 @@ class MergifyWorker(rq.Worker):  # pragma: no cover
         LOG.warn('job %s: cannot find queue %s - moving to failed queue' %
                  (job.id, job.origin))
         return True
+
+    @staticmethod
+    def job_refresh(owner, repo, refresh_ref):
+        LOG.info("%s/%s/%s: refreshing" % (owner, repo, refresh_ref))
+
+        integration = github.GithubIntegration(config.INTEGRATION_ID,
+                                               config.PRIVATE_KEY)
+        installation_id = utils.get_installation_id(integration, owner)
+        if not installation_id:  # pragma: no cover
+            LOG.warning("%s/%s/%s: mergify not installed" % (owner, repo,
+                                                             refresh_ref))
+            return
+
+        token = integration.get_access_token(installation_id).token
+        g = github.Github(token)
+        r = g.get_repo("%s/%s" % (owner, repo))
+        try:
+            r.get_contents(".mergify.yml")
+        except github.GithubException as e:  # pragma: no cover
+            if e.status == 404:
+                LOG.warning("%s/%s/%s: mergify not configured" % (owner, repo,
+                                                                  refresh_ref))
+                return
+            else:
+                raise
+
+        if refresh_ref == "full" or refresh_ref.startswith("branch/"):
+            if refresh_ref.startswith("branch/"):
+                branch = refresh_ref[7:]
+                pulls = r.get_pulls(base=branch)
+            else:
+                branch = '*'
+                pulls = r.get_pulls()
+            key = "queues~%s~%s~%s~%s~%s" % (installation_id, owner.lower(),
+                                             repo.lower(), r.private, branch)
+            utils.get_redis_for_cache().delete(key)
+        else:
+            try:
+                pull_number = int(refresh_ref[5:])
+            except ValueError:  # pragma: no cover
+                LOG.info("%s/%s/%s: Invalid PR ref" % (owner, repo,
+                                                       refresh_ref))
+                return
+            pulls = [r.get_pull(pull_number)]
+
+        subscription = utils.get_subscription(utils.get_redis_for_cache(),
+                                              installation_id)
+
+        if not subscription["token"]:  # pragma: no cover
+            LOG.warning("%s/%s/%s: not public or subscribed" % (owner, repo,
+                                                                refresh_ref))
+            return
+
+        if r.private and not subscription["subscribed"]:  # pragma: no cover
+            LOG.warning("%s/%s/%s: mergify not installed" % (owner, repo,
+                                                             refresh_ref))
+            return
+
+        for p in pulls:
+            # Mimic the github event format
+            data = {
+                'repository': r.raw_data,
+                'installation': {'id': installation_id},
+                'pull_request': p.raw_data,
+            }
+            queue.route(r.full_name, subscription, "events",
+                        "refresh", subscription, data)
+
+    @staticmethod
+    def job_refresh_all():
+        integration = github.GithubIntegration(config.INTEGRATION_ID,
+                                               config.PRIVATE_KEY)
+
+        counts = [0, 0, 0]
+        for install in utils.get_installations(integration):
+            counts[0] += 1
+            token = integration.get_access_token(install["id"]).token
+            g = github.Github(token)
+            i = g.get_installation(install["id"])
+
+            subscription = utils.get_subscription(utils.get_redis_for_cache(),
+                                                  install["id"])
+            if not subscription["token"]:  # pragma: no cover
+                continue
+
+            for r in i.get_repos():
+                if r.private and not subscription["subscribed"]:
+                    continue
+                try:
+                    r.get_contents(".mergify.yml")
+                except github.GithubException as e:  # pragma: no cover
+                    if e.status == 404:
+                        continue
+                    else:
+                        raise
+
+                counts[1] += 1
+                for p in list(r.get_pulls()):
+                    # Mimic the github event format
+                    data = {
+                        'repository': r.raw_data,
+                        'installation': {'id': install["id"]},
+                        'pull_request': p.raw_data,
+                    }
+                    queue.route(r.full_name, subscription, "events",
+                                "refresh", subscription, data)
+
+        LOG.info("Refreshing %s installations, %s repositories, "
+                 "%s branches" % tuple(counts))
+
+    @staticmethod
+    def job_filter_and_dispatch(event_type, event_id, data):
+        subscription = utils.get_subscription(
+            utils.get_redis_for_cache(), data["installation"]["id"])
+
+        if not subscription["token"]:
+            msg_action = "ignored (no token)"
+
+        elif event_type == "installation" and data["action"] == "created":
+            for repository in data["repositories"]:
+                if repository["private"] and not subscription["subscribed"]:  # noqa pragma: no cover
+                    continue
+
+                queue.route(repository["full_name"], subscription,
+                            "installations",
+                            data["installation"]["id"], [repository])
+            msg_action = "pushed to backend"
+
+        elif event_type == "installation" and data["action"] == "deleted":
+            key = "queues~%s~*~*~*~*" % data["installation"]["id"]
+            utils.get_redis_for_cache().delete(key)
+            msg_action = "handled, cache cleaned"
+
+        elif (event_type == "installation_repositories" and
+              data["action"] == "added"):
+            for repository in data["repositories_added"]:
+                if repository["private"] and not subscription["subscribed"]:  # noqa pragma: no cover
+                    continue
+
+                queue.route(repository["full_name"], subscription,
+                            "installations",
+                            data["installation"]["id"], [repository])
+
+            msg_action = "pushed to backend"
+
+        elif (event_type == "installation_repositories" and
+              data["action"] == "removed"):
+            for repository in data["repositories_removed"]:
+                if repository["private"] and not subscription["subscribed"]:  # noqa pragma: no cover
+                    continue
+                key = "queues~%s~%s~%s~*~*" % (
+                    data["installation"]["id"],
+                    data["installation"]["account"]["login"].lower(),
+                    repository["name"].lower()
+                )
+                utils.get_redis_for_cache().delete(key)
+            msg_action = "handled, cache cleaned"
+
+        elif event_type in ["installation", "installation_repositories"]:
+            msg_action = "ignored (action %s)" % data["action"]
+
+        elif event_type in ["pull_request", "pull_request_review", "status"]:
+
+            if (data["repository"]["private"] and not
+                    subscription["subscribed"]):
+                msg_action = "ignored (not public or subscribe)"
+
+            elif event_type == "status" and data["state"] == "pending":
+                msg_action = "ignored (state pending)"
+
+            elif event_type == "status" and data["context"] == "mergify/pr":
+                msg_action = "ignored (mergify status)"
+
+            elif (event_type == "pull_request" and data["action"] not in [
+                    "opened", "reopened", "closed", "synchronize",
+                    "labeled", "unlabeled"]):
+                msg_action = "ignored (action %s)" % data["action"]
+
+            else:
+                queue.route(data["repository"]["full_name"], subscription,
+                            "events", event_type, subscription, data)
+                msg_action = "pushed to backend"
+
+        else:
+            msg_action = "ignored (unexpected event_type)"
+
+        if "repository" in data:
+            repo_name = data["repository"]["full_name"]
+        else:
+            repo_name = data["installation"]["account"]["login"]
+
+        LOG.info('[%s/%s] received "%s" event "%s", %s',
+                 data["installation"]["id"], repo_name,
+                 event_type, event_id, msg_action)
+
+    @staticmethod
+    def job_events(event_type, subscription, data):
+        """Everything start here"""
+        integration = github.GithubIntegration(config.INTEGRATION_ID,
+                                               config.PRIVATE_KEY)
+        try:
+            installation_token = integration.get_access_token(
+                data["installation"]["id"]).token
+        except github.UnknownObjectException:
+            LOG.error("token for install %d does not exists anymore (%s)",
+                      data["installation"]["id"],
+                      data["repository"]["full_name"])
+            return
+
+        g = github.Github(installation_token)
+        try:
+            user = g.get_user(data["repository"]["owner"]["login"])
+            repo = user.get_repo(data["repository"]["name"])
+
+            engine.MergifyEngine(g, data["installation"]["id"],
+                                 installation_token,
+                                 subscription,
+                                 user, repo).handle(event_type, data)
+        except github.BadCredentialsException:  # pragma: no cover
+            LOG.error("token for install %d is no longuer valid (%s)",
+                      data["installation"]["id"],
+                      data["repository"]["full_name"])
+        except github.RateLimitExceededException:  # pragma: no cover
+            LOG.error("rate limit reached for install %d (%s)",
+                      data["installation"]["id"],
+                      data["repository"]["full_name"])
+
+    @staticmethod
+    def job_installations(installation_id, repositories):
+        """Create the initial configuration on an repository"""
+
+        integration = github.GithubIntegration(config.INTEGRATION_ID,
+                                               config.PRIVATE_KEY)
+        try:
+            installation_token = integration.get_access_token(
+                installation_id).token
+        except github.UnknownObjectException:  # pragma: no cover
+            LOG.error("token for install %d does not exists anymore",
+                      installation_id)
+            return
+
+        g = github.Github(installation_token)
+        try:
+            if isinstance(repositories, str):
+                installation = g.get_installation(installation_id)
+                if repositories == "private":
+                    repositories = [repo for repo in installation.get_repos()
+                                    if repo.private]
+                elif repositories == "all":
+                    repositories = [repo for repo in installation.get_repos()]
+                else:
+                    raise RuntimeError("Unexpected 'repositories' format: %s",
+                                       type(repositories))
+            elif isinstance(repositories, list):
+                # Some events return incomplete repository structure (like
+                # installation event). Complete them in this case
+                new_repos = []
+                for repository in repositories:
+                    user = g.get_user(repository["full_name"].split("/")[0])
+                    repo = user.get_repo(repository["name"])
+                    new_repos.append(repo)
+                repositories = new_repos
+            else:  # pragma: no cover
+                raise RuntimeError("Unexpected 'repositories' format: %s",
+                                   type(repositories))
+
+            for repository in repositories:
+                initial_configuration.create_pull_request_if_needed(
+                    installation_token, repository)
+
+        except github.RateLimitExceededException:  # pragma: no cover
+            LOG.error("rate limit reached for install %d",
+                      installation_id)
 
 
 def main():  # pragma: no cover


### PR DESCRIPTION
This change moves all logic into MergifyWorker

Queue hash and methods pickled by rq are now in queue.py

web.py now just drops messages into redis and nothing more.

This allow us to retry anything without requiring to use the Github UI
to resend events.