### PR TITLE
Use check API to post configuration error

### DIFF
--- a/mergify_engine/tasks/engine/v1.py
+++ b/mergify_engine/tasks/engine/v1.py
@@ -108,7 +108,6 @@ class MergifyEngine(Caching):
 
     def handle(self, config, event_type, event_pull, data):
         # Everything start here
-
         incoming_pull = mergify_pull.MergifyPull(event_pull,
                                                  self.installation_id)
         incoming_branch = incoming_pull.g_pull.base.ref


### PR DESCRIPTION
This allows to postpone creation of MergifyPull in engine v1.
making possible