### PR TITLE
backport: allow action to be expandable

### DIFF
--- a/mergify_engine/rules/__init__.py
+++ b/mergify_engine/rules/__init__.py
@@ -103,7 +103,9 @@ PullRequestRulesSchema = voluptuous.Schema([{
                                     "merge", "squash", None),
             voluptuous.Required("strict", default=False): bool,
         },
-        "backport": [str],
+        "backport": {
+            "branches": [str],
+        },
     },
 }])
 

--- a/mergify_engine/rules/convert.py
+++ b/mergify_engine/rules/convert.py
@@ -85,7 +85,9 @@ def _convert_merge_rule(rule, branch_name=None):
                     default_conditions + ["label=%s" % bp_label, "merged"]
                 ),
                 "actions": {
-                    "backport": [bp_branch_name],
+                    "backport": {
+                        "branches": [bp_branch_name],
+                    },
                 },
             })
 

--- a/mergify_engine/tests/unit/rules/test_convert.py
+++ b/mergify_engine/tests/unit/rules/test_convert.py
@@ -68,7 +68,9 @@ def test_convert_simple():
                            "label=backport-to-3.0",
                            "merged"],
             "actions": {
-                "backport": ["stable/3.0"],
+                "backport": {
+                    "branches": ["stable/3.0"],
+                },
             },
         },
         {
@@ -77,10 +79,11 @@ def test_convert_simple():
                            "label=backport-to-3.1",
                            "merged"],
             "actions": {
-                "backport": ["stable/3.1"],
+                "backport": {
+                    "branches": ["stable/3.1"],
+                },
             },
         },
-
         {
             "name": "^stable/.* branch",
             "conditions": ["base~=^stable/.*",
@@ -102,7 +105,9 @@ def test_convert_simple():
                            "label=backport-to-3.0",
                            "merged"],
             "actions": {
-                "backport": ["stable/3.0"],
+                "backport": {
+                    "branches": ["stable/3.0"],
+                },
             }
         },
         {
@@ -112,7 +117,9 @@ def test_convert_simple():
                            "label=backport-to-3.1",
                            "merged"],
             "actions": {
-                "backport": ["stable/3.1"],
+                "backport": {
+                    "branches": ["stable/3.1"],
+                },
             },
         },
 

--- a/mergify_engine/tests/unit/test_config.py
+++ b/mergify_engine/tests/unit/test_config.py
@@ -397,7 +397,7 @@ def test_pull_request_rule_schema_invalid():
                 "actions": {
                     "backport": True,
                 },
-            }, r"expected a list for dictionary value "
+            }, r"expected a dictionary for dictionary value "
                r"@ data\[0\]\['actions'\]\['backport'\]"),
             ({
                 "name": "hello",


### PR DESCRIPTION
The current format is too restrictive. List the branches in a branches subkey
so we can add more options if needed to the backport action.