### PR TITLE
convert: remove 'merged' from conditions

### DIFF
--- a/mergify_engine/rules/convert.py
+++ b/mergify_engine/rules/convert.py
@@ -95,7 +95,7 @@ def _convert_merge_rule(rule, branch_name=None):
             rules.append({
                 "name": "backport %s%s" % (bp_branch_name, bp_suffix),
                 "conditions": (
-                    default_conditions + ["label=%s" % bp_label, "merged"]
+                    default_conditions + ["label=%s" % bp_label]
                 ),
                 "actions": {
                     "backport": {

--- a/mergify_engine/tests/unit/rules/test_convert.py
+++ b/mergify_engine/tests/unit/rules/test_convert.py
@@ -65,8 +65,7 @@ def test_convert_simple():
         {
             "name": "backport stable/3.0",
             "conditions": ["label!=no-mergify",
-                           "label=backport-to-3.0",
-                           "merged"],
+                           "label=backport-to-3.0"],
             "actions": {
                 "backport": {
                     "branches": ["stable/3.0"],
@@ -76,8 +75,7 @@ def test_convert_simple():
         {
             "name": "backport stable/3.1",
             "conditions": ["label!=no-mergify",
-                           "label=backport-to-3.1",
-                           "merged"],
+                           "label=backport-to-3.1"],
             "actions": {
                 "backport": {
                     "branches": ["stable/3.1"],
@@ -102,8 +100,7 @@ def test_convert_simple():
             "name": "backport stable/3.0 from ^stable/.*",
             "conditions": ["base~=^stable/.*",
                            "label!=no-mergify",
-                           "label=backport-to-3.0",
-                           "merged"],
+                           "label=backport-to-3.0"],
             "actions": {
                 "backport": {
                     "branches": ["stable/3.0"],
@@ -114,8 +111,7 @@ def test_convert_simple():
             "name": "backport stable/3.1 from ^stable/.*",
             "conditions": ["base~=^stable/.*",
                            "label!=no-mergify",
-                           "label=backport-to-3.1",
-                           "merged"],
+                           "label=backport-to-3.1"],
             "actions": {
                 "backport": {
                     "branches": ["stable/3.1"],


### PR DESCRIPTION
That is not needed since backport only affect merged PRs.