### PR TITLE
rules: replace state with closed

### DIFF
--- a/mergify_engine/mergify_pull.py
+++ b/mergify_engine/mergify_pull.py
@@ -218,7 +218,7 @@ class MergifyPull(object):
                 self.g_pull.merged_by.login if self.g_pull.merged_by else ""
             ),
             "merged": self.g_pull.merged,
-            "state": self.g_pull.state,
+            "closed": self.g_pull.state == "closed",
             "milestone": (
                 self.g_pull.milestone.title if self.g_pull.milestone else ""
             ),

--- a/mergify_engine/rules/parser.py
+++ b/mergify_engine/rules/parser.py
@@ -65,8 +65,8 @@ def _token_to_dict(s, loc, toks):
 head = "head" + _match_with_operator(git_branch)
 base = "base" + _match_with_operator(git_branch)
 author = "author" + _match_with_operator(github_login)
-state = "state" + _match_with_operator(text)
 merged = _match_boolean("merged")
+closed = _match_boolean("closed")
 merged_by = "merged-by" + _match_with_operator(github_login)
 body = "body" + _match_with_operator(text)
 assignee = "assignee" + _match_with_operator(github_login)
@@ -98,7 +98,7 @@ search = (
     ) +
     pyparsing.Optional("#", default="") +
     (head | base | author | merged_by | body | assignee | label | locked |
-     state | merged | title | files | review_requests |
+     closed | merged | title | files | review_requests |
      review_approved_by | review_dismissed_by |
      review_changes_requested_by | review_commented_by |
      status_success | status_failure)


### PR DESCRIPTION
This is closed to what GitHub API v4 offers and makes more sense with the
`merged` filtering attribute.