### PR TITLE
rules: fix white space parsing

### DIFF
--- a/mergify_engine/rules/parser.py
+++ b/mergify_engine/rules/parser.py
@@ -19,8 +19,7 @@ import pyparsing
 git_branch = pyparsing.CharsNotIn("~^: []\\")
 regexp = pyparsing.CharsNotIn("")
 github_login = pyparsing.CharsNotIn(" /")
-text = pyparsing.dblQuotedString | pyparsing.CharsNotIn(" ")
-status_check = pyparsing.CharsNotIn(" ")
+text = pyparsing.CharsNotIn("")
 milestone = pyparsing.CharsNotIn(" ")
 
 regex_operators = pyparsing.Literal("~=")
@@ -86,8 +85,8 @@ review_changes_requested_by = (
 review_commented_by = (
     "commented-reviews-by" + _match_with_operator(github_login)
 )
-status_success = "status-success" + _match_with_operator(status_check)
-status_failure = "status-failure" + _match_with_operator(status_check)
+status_success = "status-success" + _match_with_operator(text)
+status_failure = "status-failure" + _match_with_operator(text)
 
 search = (
     pyparsing.Optional(

--- a/mergify_engine/tests/unit/rules/test_parser.py
+++ b/mergify_engine/tests/unit/rules/test_parser.py
@@ -34,6 +34,8 @@ def test_search():
             ("#assignee=3", {"=": ("#assignee", 3)}),
             ("#assignee>1", {">": ("#assignee", 1)}),
             ("#assignee>=2", {">=": ("#assignee", 2)}),
+            ("status-success=my ci has spaces", {"=": ("status-success",
+                                                       "my ci has spaces")}),
     ):
         assert result == tuple(parser.search.parseString(
             line, parseAll=True))[0]


### PR DESCRIPTION
This changes the status success/failure to match against any string that follow
the operator. The text parsing is now done with whatever chars are after the
operator.