### PR TITLE
Added requested-reviews-approved condition

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -199,3 +199,25 @@ as the pull request gets updated with new commits.
           - base=master
         actions:
           dismiss_reviews:
+
+Require All Requested Reviews to Be Approved
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If all requested reviews have been approved, then the number of
+``review-requested``, ``changes-requested-reviews-by``, and
+``commented-reviews-by`` will all be 0.
+
+.. code-block:: yaml
+
+    pull_request_rules:
+      - name: remove outdated reviews
+        conditions:
+          - "#review-requested=0"
+          - "#changes-requested-reviews-by=0"
+          - "#commented-reviews-by=0"
+        actions:
+            merge:
+              method: merge
+
+Note that if a requested review is dismissed, then it doesn't count as a review
+that would prevent the merge.


### PR DESCRIPTION
This pull request addresses #66 by adding a new boolean rule called `requested-reviews-approved`. A few notes:
* I don't know how to test or debug Mergify (I didn't see any CONTRIBUTING information that explains how to do this – let me know if I just missed it!). Any help with verifying that it works as expected would be helpful!
* Did I update everything that needs to be updated? I added the data in `mergify_engine/mergify_pull.py`, the search rule in `mergify_engine/rules/parser.py` and the docs in `doc/source/conditions.rst`. Anything else?
* Currently this condition ignores teams. (As I understand it, additional lookups would be needed to get the list of users for each team in order to confirm whether or not the entire team has approved).