### PR TITLE
Move out MergifyPull v1 stuff to v1 engine

### DIFF
--- a/mergify_engine/mergify_pull.py
+++ b/mergify_engine/mergify_pull.py
@@ -13,10 +13,6 @@
 # under the License.
 
 import collections
-import copy
-import enum
-import fnmatch
-import functools
 
 import attr
 
@@ -27,8 +23,6 @@ import github
 import tenacity
 
 from mergify_engine import check_api
-from mergify_engine import config
-from mergify_engine import utils
 
 # NOTE(sileht): Github mergeable_state is undocumented, here my finding by
 # testing and and some info from other project:
@@ -46,53 +40,14 @@ from mergify_engine import utils
 # https://developer.github.com/v4/enum/mergestatestatus/
 
 
-# Use IntEnum to be able to sort pull requests based on this state.
-class MergifyState(enum.IntEnum):
-    NOT_READY = 0
-    NEED_BRANCH_UPDATE = 10
-    ALMOST_READY = 20
-    READY = 30
-
-    def __str__(self):
-        return self._name_.lower().replace("_", "-")
-
-
-class StatusState(enum.Enum):
-    FAILURE = "failure"
-    SUCCESS = "success"
-    PENDING = "pending"
-
-    def __str__(self):
-        return self.value
-
-
 GenericCheck = collections.namedtuple("GenericCheck", ["context", "state"])
 
 
-@functools.total_ordering
-@attr.s(cmp=False)
+@attr.s()
 class MergifyPull(object):
     # NOTE(sileht): Use from_cache/from_event not the constructor directly
     g_pull = attr.ib()
     installation_id = attr.ib()
-    _complete = attr.ib(init=False, default=False)
-    _reviews_required = attr.ib(init=False, default=None)
-
-    # Cached attributes
-    _reviews_ok = attr.ib(init=False, default=None)
-    _reviews_ko = attr.ib(init=False, default=None)
-    _required_statuses = attr.ib(
-        init=False, default=None,
-        validator=attr.validators.optional(
-            attr.validators.instance_of(StatusState)),
-    )
-    _mergify_state = attr.ib(
-        init=False, default=None,
-        validator=attr.validators.optional(
-            attr.validators.instance_of(MergifyState)),
-    )
-    _github_state = attr.ib(init=False, default=None)
-    _github_description = attr.ib(init=False, default=None)
 
     @classmethod
     def from_raw(cls, installation_id, installation_token, pull_raw):
@@ -112,92 +67,6 @@ class MergifyPull(object):
     def __attrs_post_init__(self):
         self.log = daiquiri.getLogger(__name__, pull_request=self)
         self._ensure_mergable_state()
-
-    def _ensure_complete(self):
-        if not self._complete:  # pragma: no cover
-            raise RuntimeError("%s: used an incomplete MergifyPull")
-
-    @property
-    def status(self):
-        # TODO(sileht): Should be removed at some point. When the cache
-        # will not have mergify_engine_status key anymore
-        return {"mergify_state": self.mergify_state,
-                "github_state": self.github_state,
-                "github_description": self.github_description}
-
-    @property
-    def mergify_state(self):
-        self._ensure_complete()
-        return self._mergify_state
-
-    @property
-    def github_state(self):
-        self._ensure_complete()
-        return self._github_state
-
-    @property
-    def github_description(self):
-        self._ensure_complete()
-        return self._github_description
-
-    def complete(self, cache, branch_rule, collaborators):
-        need_to_be_saved = False
-
-        protection = branch_rule["protection"]
-        if protection["required_pull_request_reviews"]:
-            self._reviews_required = protection[
-                "required_pull_request_reviews"][
-                    "required_approving_review_count"]
-        else:
-            self._reviews_required = 0
-
-        if "mergify_engine_reviews_ok" in cache:
-            self._reviews_ok = cache["mergify_engine_reviews_ok"]
-            self._reviews_ko = cache["mergify_engine_reviews_ko"]
-        else:
-            need_to_be_saved = True
-            self._reviews_ok, self._reviews_ko = self._compute_approvals(
-                branch_rule, collaborators)
-
-        if "mergify_engine_required_statuses" in cache:
-            self._required_statuses = StatusState(cache[
-                "mergify_engine_required_statuses"])
-        else:
-            need_to_be_saved = True
-            self._required_statuses = self._compute_required_statuses(
-                branch_rule)
-
-        if "mergify_engine_status" in cache:
-            s = cache["mergify_engine_status"]
-            self._mergify_state = MergifyState(s["mergify_state"])
-            self._github_state = s["github_state"]
-            self._github_description = s["github_description"]
-        else:
-            need_to_be_saved = True
-            (self._mergify_state, self._github_state,
-             self._github_description) = self._compute_status(
-                 branch_rule, collaborators)
-
-        self._complete = True
-        return need_to_be_saved
-
-    def refresh(self, branch_rule, collaborators):
-        # NOTE(sileht): Redownload the PULL to ensure we don't have
-        # any etag floating around
-        self._ensure_mergable_state(force=True)
-        return self.complete({}, branch_rule, collaborators)
-
-    def jsonify(self):
-        raw = copy.copy(self.g_pull.raw_data)
-        raw["mergify_engine_reviews_ok"] = self._reviews_ok
-        raw["mergify_engine_reviews_ko"] = self._reviews_ko
-        raw["mergify_engine_required_statuses"] = self._required_statuses.value
-        raw["mergify_engine_status"] = {
-            "mergify_state": self._mergify_state.value,
-            "github_description": self._github_description,
-            "github_state": self._github_state
-        }
-        return raw
 
     def _get_perm(self, login):
         return self.g_pull.base.repo.get_collaborator_permission(login)
@@ -263,48 +132,6 @@ class MergifyPull(object):
                                if s.state == "failure"],
         }
 
-    def _compute_approvals(self, branch_rule, collaborators):
-        """Compute approvals.
-
-        :param branch_rule: The rule for the considered branch.
-        :param collaborators: The list of collaborators.
-        :return: A tuple (users_with_review_ok, users_with_review_ko)
-        """
-        users_info = {}
-        reviews_ok = set()
-        reviews_ko = set()
-        for review in self.g_pull.get_reviews():
-            if review.user.id not in collaborators:
-                continue
-
-            users_info[review.user.login] = review.user.raw_data
-            if review.state == 'APPROVED':
-                reviews_ok.add(review.user.login)
-                if review.user.login in reviews_ko:
-                    reviews_ko.remove(review.user.login)
-
-            elif review.state in ["DISMISSED", "CHANGES_REQUESTED"]:
-                if review.user.login in reviews_ok:
-                    reviews_ok.remove(review.user.login)
-                if review.user.login in reviews_ko:
-                    reviews_ko.remove(review.user.login)
-                if review.state == "CHANGES_REQUESTED":
-                    reviews_ko.add(review.user.login)
-            elif review.state == 'COMMENTED':
-                pass
-            else:
-                self.log.error("review state unhandled",
-                               state=review.state)
-
-        return ([users_info[u] for u in reviews_ok],
-                [users_info[u] for u in reviews_ko])
-
-    @staticmethod
-    def _find_required_context(contexts, generic_check):
-        for c in contexts:
-            if generic_check.context.startswith(c):
-                return c
-
     def _get_combined_status(self):
         headers, data = self.g_pull.head.repo._requester.requestJsonAndCheck(
             "GET",
@@ -331,141 +158,6 @@ class MergifyPull(object):
         generic_checks |= set([GenericCheck(s.context, s.state)
                                for s in self._get_combined_status().statuses])
         return generic_checks
-
-    def _compute_required_statuses(self, branch_rule):
-        # return True is CIs succeed, False is their fail, None
-        # is we don't known yet.
-        # FIXME(sileht): I don't use a Enum yet to not
-        protection = branch_rule["protection"]
-        if not protection["required_status_checks"]:
-            return StatusState.SUCCESS
-
-        # NOTE(sileht): Due to the difference of both API we use only success
-        # bellow.
-        contexts = set(protection["required_status_checks"]["contexts"])
-        seen_contexts = set()
-
-        for check in self._get_checks():
-            required_context = self._find_required_context(contexts, check)
-            if required_context:
-                seen_contexts.add(required_context)
-                if check.state in ["pending", None]:
-                    return StatusState.PENDING
-                elif check.state != "success":
-                    return StatusState.FAILURE
-
-        if contexts - seen_contexts:
-            return StatusState.PENDING
-        else:
-            return StatusState.SUCCESS
-
-    def _disabled_by_rules(self, branch_rule):
-        labels = [l.name for l in self.g_pull.labels]
-
-        enabling_label = branch_rule["enabling_label"]
-        if enabling_label is not None and enabling_label not in labels:
-            return "Disabled — enabling label missing"
-
-        if branch_rule["disabling_label"] in labels:
-            return "Disabled — disabling label present"
-
-        g_pull_files = [f.filename for f in self.g_pull.get_files()]
-        for w in branch_rule["disabling_files"]:
-            filtered = fnmatch.filter(g_pull_files, w)
-            if filtered:
-                return ("Disabled — %s is modified"
-                        % filtered[0])
-        return None
-
-    def _compute_status(self, branch_rule, collaborators):
-        disabled = self._disabled_by_rules(branch_rule)
-
-        mergify_state = MergifyState.NOT_READY
-        github_state = "pending"
-        github_desc = None
-
-        if disabled:
-            github_state = "failure"
-            github_desc = disabled
-
-        elif self._reviews_ko:
-            github_desc = "Change requests need to be dismissed"
-
-        elif (self._reviews_required and
-              len(self._reviews_ok) < self._reviews_required):
-            github_desc = (
-                "%d/%d approvals required" %
-                (len(self._reviews_ok), self._reviews_required)
-            )
-
-        elif self.g_pull.mergeable_state in ["clean", "unstable", "has_hooks"]:
-            mergify_state = MergifyState.READY
-            github_state = "success"
-            github_desc = "Will be merged soon"
-
-        elif self.g_pull.mergeable_state == "blocked":
-            if self._required_statuses == StatusState.SUCCESS:
-                # FIXME(sileht) We are blocked but reviews are OK and CI passes
-                # So It's a Github bug or Github block the PR about something
-                # we don't yet support.
-
-                # We don't fully support require_code_owner_reviews, try so do
-                # some guessing.
-                protection = branch_rule["protection"]
-                if (protection["required_pull_request_reviews"] and
-                    protection["required_pull_request_reviews"]
-                    ["require_code_owner_reviews"] and
-                    (self.g_pull._rawData['requested_teams'] or
-                     self.g_pull._rawData['requested_reviewers'])):
-                    github_desc = "Waiting for code owner review"
-
-                else:
-                    # NOTE(sileht): assume it's the Github bug and the PR is
-                    # ready, if it's not the merge button will just fail.
-                    self.log.warning("mergeable_state is unexpected, "
-                                     "trying to merge the pull request")
-                    mergify_state = MergifyState.READY
-                    github_state = "success"
-                    github_desc = "Will be merged soon"
-
-            elif self._required_statuses == StatusState.PENDING:
-                # Maybe clean soon, or maybe this is the previous run selected
-                # PR that we just rebase, or maybe not. But we set the
-                # mergify_state to ALMOST_READY to ensure we do not rebase
-                # multiple self.g_pull request in //
-                mergify_state = MergifyState.ALMOST_READY
-                github_desc = "Waiting for status checks success"
-            else:
-                github_desc = "Waiting for status checks success"
-
-        elif self.g_pull.mergeable_state == "behind":
-            # Not up2date, but ready to merge, is branch updatable
-            if not self.base_is_modifiable():
-                github_state = "failure"
-                github_desc = ("Pull request can't be updated with latest "
-                               "base branch changes, owner doesn't allow "
-                               "modification")
-            elif self._required_statuses == StatusState.SUCCESS:
-                mergify_state = MergifyState.NEED_BRANCH_UPDATE
-                github_desc = ("Pull request will be updated with latest base "
-                               "branch changes soon")
-            else:
-                github_desc = "Waiting for status checks success"
-
-        elif self.g_pull.mergeable_state == "dirty":
-            github_desc = "Merge conflict need to be solved"
-
-        elif self.g_pull.mergeable_state == "unknown":
-            # Should not really occur, but who known
-            github_desc = "Pull request state reported unknown by Github"
-        else:  # pragma: no cover
-            raise RuntimeError("%s: Unexpected mergify_state" % self)
-
-        if github_desc is None:  # pragma: no cover
-            # Seatbelt
-            raise RuntimeError("%s: github_desc have not been set" % self)
-
-        return (mergify_state, github_state, github_desc)
 
     UNUSABLE_STATES = ["unknown", None]
 
@@ -514,14 +206,6 @@ class MergifyPull(object):
         self._wait_for_sha_change(old_sha)
         self._ensure_mergable_state()
 
-    def __lt__(self, other):
-        return ((self.mergify_state, self.g_pull.updated_at) >
-                (other.mergify_state, other.g_pull.updated_at))
-
-    def __eq__(self, other):
-        return ((self.mergify_state, self.g_pull.updated_at) ==
-                (other.mergify_state, other.g_pull.updated_at))
-
     def base_is_modifiable(self):
         return (self.g_pull.raw_data["maintainer_can_modify"] or
                 self.g_pull.head.repo.id == self.g_pull.base.repo.id)
@@ -562,48 +246,6 @@ class MergifyPull(object):
                 return self._merge_failed(e)
         return True
 
-    def post_check_status(self, state, msg, context=None):
-
-        redis = utils.get_redis_for_cache()
-        context = "pr" if context is None else context
-        msg_key = "%s/%s/%d/%s" % (self.installation_id,
-                                   self.g_pull.base.repo.full_name,
-                                   self.g_pull.number, context)
-
-        if len(msg) >= 140:
-            description = msg[0:137] + "..."
-            redis.hset("status", msg_key, msg.encode('utf8'))
-            target_url = "%s/check_status_msg/%s" % (config.BASE_URL, msg_key)
-        else:
-            description = msg
-            target_url = None
-
-        self.log.info("set status", state=state, description=description)
-        # NOTE(sileht): We can't use commit.create_status() because
-        # if use the head repo instead of the base repo
-        try:
-            self.g_pull._requester.requestJsonAndCheck(
-                "POST",
-                self.g_pull.base.repo.url + "/statuses/" +
-                self.g_pull.head.sha,
-                input={'state': state,
-                       'description': description,
-                       'target_url': target_url,
-                       'context': "%s/%s" % (config.CONTEXT, context)},
-                headers={'Accept':
-                         'application/vnd.github.machine-man-preview+json'}
-            )
-        except github.GithubException as e:  # pragma: no cover
-            self.log.error("set status failed",
-                           error=e.data["message"], exc_info=True)
-
-    def set_and_post_error(self, github_description):
-        self._mergify_state = MergifyState.NOT_READY
-        self._github_state = "failure"
-        self._github_description = github_description
-        self.post_check_status(self.github_state,
-                               self.github_description)
-
     def is_behind(self):
         branch = self.g_pull.base.repo.get_branch(self.g_pull.base.ref)
         for commit in self.g_pull.get_commits():
@@ -614,26 +256,11 @@ class MergifyPull(object):
 
     def __str__(self):
         return ("%(login)s/%(repo)s/pull/%(number)d@%(branch)s "
-                "s:%(pr_state)s/%(statuses)s "
-                "r:%(approvals)s/%(required_approvals)s "
-                "-> %(mergify_state)s (%(github_state)s/%(github_desc)s)" % {
+                "s:%(pr_state)s" % {
                     "login": self.g_pull.base.user.login,
                     "repo": self.g_pull.base.repo.name,
                     "number": self.g_pull.number,
                     "branch": self.g_pull.base.ref,
                     "pr_state": ("merged" if self.g_pull.merged else
                                  (self.g_pull.mergeable_state or "none")),
-                    "statuses": str(self._required_statuses),
-                    "approvals": ("notset" if self._reviews_ok is None
-                                  else len(self._reviews_ok)),
-                    "required_approvals": ("notset"
-                                           if self._reviews_required is None
-                                           else self._reviews_required),
-                    "mergify_state": str(self._mergify_state),
-                    "github_state": ("notset"
-                                     if self._github_state is None
-                                     else self._github_state),
-                    "github_desc": ("notset"
-                                    if self._github_description is None
-                                    else self._github_description),
                 })

--- a/mergify_engine/tasks/engine/v1.py
+++ b/mergify_engine/tasks/engine/v1.py
@@ -12,6 +12,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import copy
+import enum
+import fnmatch
+import functools
 import itertools
 import json
 from concurrent import futures
@@ -65,12 +69,394 @@ def handle(installation_id, installation_token, subscription,
 @app.task
 def _handle(installation_id, installation_token, subscription,
             branch_rules, event_type, data, event_pull_raw):
-    pull = mergify_pull.MergifyPull.from_raw(installation_id,
-                                             installation_token,
-                                             event_pull_raw)
+    pull = MergifyPullV1.from_raw(installation_id,
+                                  installation_token,
+                                  event_pull_raw)
     MergifyEngine(installation_id, installation_token, subscription,
                   pull.g_pull.base.repo).handle(
                       branch_rules, event_type, data, pull)
+
+
+# Use IntEnum to be able to sort pull requests based on this state.
+class MergifyState(enum.IntEnum):
+    NOT_READY = 0
+    NEED_BRANCH_UPDATE = 10
+    ALMOST_READY = 20
+    READY = 30
+
+    def __str__(self):
+        return self._name_.lower().replace("_", "-")
+
+
+class StatusState(enum.Enum):
+    FAILURE = "failure"
+    SUCCESS = "success"
+    PENDING = "pending"
+
+    def __str__(self):
+        return self.value
+
+
+@functools.total_ordering
+@attr.s(cmp=False)
+class MergifyPullV1(mergify_pull.MergifyPull):
+    _complete = attr.ib(init=False, default=False)
+    _reviews_required = attr.ib(init=False, default=None)
+
+    # Cached attributes
+    _reviews_ok = attr.ib(init=False, default=None)
+    _reviews_ko = attr.ib(init=False, default=None)
+    _required_statuses = attr.ib(
+        init=False, default=None,
+        validator=attr.validators.optional(
+            attr.validators.instance_of(StatusState)),
+    )
+    _mergify_state = attr.ib(
+        init=False, default=None,
+        validator=attr.validators.optional(
+            attr.validators.instance_of(MergifyState)),
+    )
+    _github_state = attr.ib(init=False, default=None)
+    _github_description = attr.ib(init=False, default=None)
+
+    def __lt__(self, other):
+        return ((self.mergify_state, self.g_pull.updated_at) >
+                (other.mergify_state, other.g_pull.updated_at))
+
+    def __eq__(self, other):
+        return ((self.mergify_state, self.g_pull.updated_at) ==
+                (other.mergify_state, other.g_pull.updated_at))
+
+    def jsonify(self):
+        raw = copy.copy(self.g_pull.raw_data)
+        raw["mergify_engine_reviews_ok"] = self._reviews_ok
+        raw["mergify_engine_reviews_ko"] = self._reviews_ko
+        raw["mergify_engine_required_statuses"] = self._required_statuses.value
+        raw["mergify_engine_status"] = {
+            "mergify_state": self._mergify_state.value,
+            "github_description": self._github_description,
+            "github_state": self._github_state
+        }
+        return raw
+
+    def _ensure_complete(self):
+        if not self._complete:  # pragma: no cover
+            raise RuntimeError("%s: used an incomplete MergifyPullV1")
+
+    @property
+    def status(self):
+        # TODO(sileht): Should be removed at some point. When the cache
+        # will not have mergify_engine_status key anymore
+        return {"mergify_state": self.mergify_state,
+                "github_state": self.github_state,
+                "github_description": self.github_description}
+
+    @property
+    def mergify_state(self):
+        self._ensure_complete()
+        return self._mergify_state
+
+    @property
+    def github_state(self):
+        self._ensure_complete()
+        return self._github_state
+
+    @property
+    def github_description(self):
+        self._ensure_complete()
+        return self._github_description
+
+    def complete(self, cache, branch_rule, collaborators):
+        need_to_be_saved = False
+
+        protection = branch_rule["protection"]
+        if protection["required_pull_request_reviews"]:
+            self._reviews_required = protection[
+                "required_pull_request_reviews"][
+                    "required_approving_review_count"]
+        else:
+            self._reviews_required = 0
+
+        if "mergify_engine_reviews_ok" in cache:
+            self._reviews_ok = cache["mergify_engine_reviews_ok"]
+            self._reviews_ko = cache["mergify_engine_reviews_ko"]
+        else:
+            need_to_be_saved = True
+            self._reviews_ok, self._reviews_ko = self._compute_approvals(
+                branch_rule, collaborators)
+
+        if "mergify_engine_required_statuses" in cache:
+            self._required_statuses = StatusState(cache[
+                "mergify_engine_required_statuses"])
+        else:
+            need_to_be_saved = True
+            self._required_statuses = self._compute_required_statuses(
+                branch_rule)
+
+        if "mergify_engine_status" in cache:
+            s = cache["mergify_engine_status"]
+            self._mergify_state = MergifyState(s["mergify_state"])
+            self._github_state = s["github_state"]
+            self._github_description = s["github_description"]
+        else:
+            need_to_be_saved = True
+            (self._mergify_state, self._github_state,
+             self._github_description) = self._compute_status(
+                 branch_rule, collaborators)
+
+        self._complete = True
+        return need_to_be_saved
+
+    def refresh(self, branch_rule, collaborators):
+        # NOTE(sileht): Redownload the PULL to ensure we don't have
+        # any etag floating around
+        self._ensure_mergable_state(force=True)
+        return self.complete({}, branch_rule, collaborators)
+
+    def _compute_approvals(self, branch_rule, collaborators):
+        """Compute approvals.
+
+        :param branch_rule: The rule for the considered branch.
+        :param collaborators: The list of collaborators.
+        :return: A tuple (users_with_review_ok, users_with_review_ko)
+        """
+        users_info = {}
+        reviews_ok = set()
+        reviews_ko = set()
+        for review in self.g_pull.get_reviews():
+            if review.user.id not in collaborators:
+                continue
+
+            users_info[review.user.login] = review.user.raw_data
+            if review.state == 'APPROVED':
+                reviews_ok.add(review.user.login)
+                if review.user.login in reviews_ko:
+                    reviews_ko.remove(review.user.login)
+
+            elif review.state in ["DISMISSED", "CHANGES_REQUESTED"]:
+                if review.user.login in reviews_ok:
+                    reviews_ok.remove(review.user.login)
+                if review.user.login in reviews_ko:
+                    reviews_ko.remove(review.user.login)
+                if review.state == "CHANGES_REQUESTED":
+                    reviews_ko.add(review.user.login)
+            elif review.state == 'COMMENTED':
+                pass
+            else:
+                self.log.error("review state unhandled",
+                               state=review.state)
+
+        return ([users_info[u] for u in reviews_ok],
+                [users_info[u] for u in reviews_ko])
+
+    @staticmethod
+    def _find_required_context(contexts, generic_check):
+        for c in contexts:
+            if generic_check.context.startswith(c):
+                return c
+
+    def _compute_required_statuses(self, branch_rule):
+        # return True is CIs succeed, False is their fail, None
+        # is we don't known yet.
+        # FIXME(sileht): I don't use a Enum yet to not
+        protection = branch_rule["protection"]
+        if not protection["required_status_checks"]:
+            return StatusState.SUCCESS
+
+        # NOTE(sileht): Due to the difference of both API we use only success
+        # bellow.
+        contexts = set(protection["required_status_checks"]["contexts"])
+        seen_contexts = set()
+
+        for check in self._get_checks():
+            required_context = self._find_required_context(contexts, check)
+            if required_context:
+                seen_contexts.add(required_context)
+                if check.state in ["pending", None]:
+                    return StatusState.PENDING
+                elif check.state != "success":
+                    return StatusState.FAILURE
+
+        if contexts - seen_contexts:
+            return StatusState.PENDING
+        else:
+            return StatusState.SUCCESS
+
+    def _disabled_by_rules(self, branch_rule):
+        labels = [l.name for l in self.g_pull.labels]
+
+        enabling_label = branch_rule["enabling_label"]
+        if enabling_label is not None and enabling_label not in labels:
+            return "Disabled — enabling label missing"
+
+        if branch_rule["disabling_label"] in labels:
+            return "Disabled — disabling label present"
+
+        g_pull_files = [f.filename for f in self.g_pull.get_files()]
+        for w in branch_rule["disabling_files"]:
+            filtered = fnmatch.filter(g_pull_files, w)
+            if filtered:
+                return ("Disabled — %s is modified"
+                        % filtered[0])
+        return None
+
+    def _compute_status(self, branch_rule, collaborators):
+        disabled = self._disabled_by_rules(branch_rule)
+
+        mergify_state = MergifyState.NOT_READY
+        github_state = "pending"
+        github_desc = None
+
+        if disabled:
+            github_state = "failure"
+            github_desc = disabled
+
+        elif self._reviews_ko:
+            github_desc = "Change requests need to be dismissed"
+
+        elif (self._reviews_required and
+              len(self._reviews_ok) < self._reviews_required):
+            github_desc = (
+                "%d/%d approvals required" %
+                (len(self._reviews_ok), self._reviews_required)
+            )
+
+        elif self.g_pull.mergeable_state in ["clean", "unstable", "has_hooks"]:
+            mergify_state = MergifyState.READY
+            github_state = "success"
+            github_desc = "Will be merged soon"
+
+        elif self.g_pull.mergeable_state == "blocked":
+            if self._required_statuses == StatusState.SUCCESS:
+                # FIXME(sileht) We are blocked but reviews are OK and CI passes
+                # So It's a Github bug or Github block the PR about something
+                # we don't yet support.
+
+                # We don't fully support require_code_owner_reviews, try so do
+                # some guessing.
+                protection = branch_rule["protection"]
+                if (protection["required_pull_request_reviews"] and
+                    protection["required_pull_request_reviews"]
+                    ["require_code_owner_reviews"] and
+                    (self.g_pull._rawData['requested_teams'] or
+                     self.g_pull._rawData['requested_reviewers'])):
+                    github_desc = "Waiting for code owner review"
+
+                else:
+                    # NOTE(sileht): assume it's the Github bug and the PR is
+                    # ready, if it's not the merge button will just fail.
+                    self.log.warning("mergeable_state is unexpected, "
+                                     "trying to merge the pull request")
+                    mergify_state = MergifyState.READY
+                    github_state = "success"
+                    github_desc = "Will be merged soon"
+
+            elif self._required_statuses == StatusState.PENDING:
+                # Maybe clean soon, or maybe this is the previous run selected
+                # PR that we just rebase, or maybe not. But we set the
+                # mergify_state to ALMOST_READY to ensure we do not rebase
+                # multiple self.g_pull request in //
+                mergify_state = MergifyState.ALMOST_READY
+                github_desc = "Waiting for status checks success"
+            else:
+                github_desc = "Waiting for status checks success"
+
+        elif self.g_pull.mergeable_state == "behind":
+            # Not up2date, but ready to merge, is branch updatable
+            if not self.base_is_modifiable():
+                github_state = "failure"
+                github_desc = ("Pull request can't be updated with latest "
+                               "base branch changes, owner doesn't allow "
+                               "modification")
+            elif self._required_statuses == StatusState.SUCCESS:
+                mergify_state = MergifyState.NEED_BRANCH_UPDATE
+                github_desc = ("Pull request will be updated with latest base "
+                               "branch changes soon")
+            else:
+                github_desc = "Waiting for status checks success"
+
+        elif self.g_pull.mergeable_state == "dirty":
+            github_desc = "Merge conflict need to be solved"
+
+        elif self.g_pull.mergeable_state == "unknown":
+            # Should not really occur, but who known
+            github_desc = "Pull request state reported unknown by Github"
+        else:  # pragma: no cover
+            raise RuntimeError("%s: Unexpected mergify_state" % self)
+
+        if github_desc is None:  # pragma: no cover
+            # Seatbelt
+            raise RuntimeError("%s: github_desc have not been set" % self)
+
+        return (mergify_state, github_state, github_desc)
+
+    def post_check_status(self, state, msg, context=None):
+
+        redis = utils.get_redis_for_cache()
+        context = "pr" if context is None else context
+        msg_key = "%s/%s/%d/%s" % (self.installation_id,
+                                   self.g_pull.base.repo.full_name,
+                                   self.g_pull.number, context)
+
+        if len(msg) >= 140:
+            description = msg[0:137] + "..."
+            redis.hset("status", msg_key, msg.encode('utf8'))
+            target_url = "%s/check_status_msg/%s" % (config.BASE_URL, msg_key)
+        else:
+            description = msg
+            target_url = None
+
+        self.log.info("set status", state=state, description=description)
+        # NOTE(sileht): We can't use commit.create_status() because
+        # if use the head repo instead of the base repo
+        try:
+            self.g_pull._requester.requestJsonAndCheck(
+                "POST",
+                self.g_pull.base.repo.url + "/statuses/" +
+                self.g_pull.head.sha,
+                input={'state': state,
+                       'description': description,
+                       'target_url': target_url,
+                       'context': "%s/%s" % (config.CONTEXT, context)},
+                headers={'Accept':
+                         'application/vnd.github.machine-man-preview+json'}
+            )
+        except github.GithubException as e:  # pragma: no cover
+            self.log.error("set status failed",
+                           error=e.data["message"], exc_info=True)
+
+    def set_and_post_error(self, github_description):
+        self._mergify_state = MergifyState.NOT_READY
+        self._github_state = "failure"
+        self._github_description = github_description
+        self.post_check_status(self.github_state,
+                               self.github_description)
+
+    def __str__(self):
+        return ("%(login)s/%(repo)s/pull/%(number)d@%(branch)s "
+                "s:%(pr_state)s/%(statuses)s "
+                "r:%(approvals)s/%(required_approvals)s "
+                "-> %(mergify_state)s (%(github_state)s/%(github_desc)s)" % {
+                    "login": self.g_pull.base.user.login,
+                    "repo": self.g_pull.base.repo.name,
+                    "number": self.g_pull.number,
+                    "branch": self.g_pull.base.ref,
+                    "pr_state": ("merged" if self.g_pull.merged else
+                                 (self.g_pull.mergeable_state or "none")),
+                    "statuses": str(self._required_statuses),
+                    "approvals": ("notset" if self._reviews_ok is None
+                                  else len(self._reviews_ok)),
+                    "required_approvals": ("notset"
+                                           if self._reviews_required is None
+                                           else self._reviews_required),
+                    "mergify_state": str(self._mergify_state),
+                    "github_state": ("notset"
+                                     if self._github_state is None
+                                     else self._github_state),
+                    "github_desc": ("notset"
+                                    if self._github_description is None
+                                    else self._github_description),
+                })
 
 
 @attr.s
@@ -213,7 +599,7 @@ class MergifyEngine(Caching):
             return
 
         # First, remove informations we don't want to get from cache, so their
-        # will be recomputed by MergifyPull.complete()
+        # will be recomputed by MergifyPullV1.complete()
         if event_type == "refresh":
             cache = {}
             old_status = None
@@ -284,7 +670,7 @@ class Processor(Caching):
 
     def _load_from_cache_and_complete(self, data, branch_rule, collaborators):
         data = json.loads(data)
-        pull = mergify_pull.MergifyPull(
+        pull = MergifyPullV1(
             github.PullRequest.PullRequest(self.repository._requester, {},
                                            data, completed=True),
             self.installation_id)
@@ -304,7 +690,7 @@ class Processor(Caching):
         while queue:
             p = queue.pop(0)
 
-            if p.mergify_state == mergify_pull.MergifyState.NOT_READY:
+            if p.mergify_state == MergifyState.NOT_READY:
                 continue
 
             expected_state = p.mergify_state
@@ -341,7 +727,7 @@ class Processor(Caching):
                      branch=branch)
             return
 
-        if p.mergify_state == mergify_pull.MergifyState.READY:
+        if p.mergify_state == MergifyState.READY:
             p.post_check_status("success", "Merged")
 
             if p.merge(branch_rule["merge_strategy"]["method"],
@@ -353,10 +739,10 @@ class Processor(Caching):
                 self._cache_save_pull(p)
                 raise tenacity.TryAgain
 
-        elif p.mergify_state == mergify_pull.MergifyState.ALMOST_READY:
+        elif p.mergify_state == MergifyState.ALMOST_READY:
             LOG.info("waiting for final statuses completion", pull_request=p)
 
-        elif p.mergify_state == mergify_pull.MergifyState.NEED_BRANCH_UPDATE:
+        elif p.mergify_state == MergifyState.NEED_BRANCH_UPDATE:
             if branch_updater.update(p, self._subscription["token"]):
                 # Wait for the synchronize event now
                 LOG.info("branch updated", pull_request=p)


### PR DESCRIPTION
Many methods and attributes are used only by v1 engine.
This change moves them there.