### PR TITLE
test: fix record

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,26 +24,13 @@ commands =
 
 [testenv:record]
 setenv =
-   MERGIFYENGINE_RECORD_MODE = once
+   MERGIFYENGINE_RECORD=1
    MERGIFYENGINE_SETTINGS=test.yml
 whitelist_externals =
-    rm
     git
 commands =
-    pifpaf run redis -- pytest -v --pyargs mergify_engine -x -k {posargs:not-exists} -s
+    {[testenv]commands}
     git add mergify_engine/tests/fixtures/cassettes/
-
-[testenv:record-all]
-setenv =
-   MERGIFYENGINE_RECORD_MODE = all
-   MERGIFYENGINE_SETTINGS=test.yml
-whitelist_externals =
-   rm
-   mkdir
-   git
-commands =
-   {[testenv]commands}
-   git add mergify_engine/tests/fixtures/cassettes
 
 [testenv:test]
 deps = uwsgi


### PR DESCRIPTION
Since I move the cassette removal from tox to test itself.
record-all and record target are almost the same.

The only diff is the -s flag passed for record.

So merge them