### PR TITLE
doc: some cleanup

### DIFF
--- a/doc/source/conditions.rst
+++ b/doc/source/conditions.rst
@@ -62,6 +62,9 @@ Here's the list of pull request attribute that rules can be matched against:
    * - ``approved-reviews-by``
      - array of string
      - The list of GitHub user or team login that approved the pull request.
+       Team logins are prefixed with the ``@`` character.
+       This will match only reviewers with ``admin`` or ``write`` permission
+       on the repository.
    * - ``author``
      - string
      - The GitHub login of the author of the pull request.
@@ -75,6 +78,9 @@ Here's the list of pull request attribute that rules can be matched against:
      - array of string
      - The list of GitHub user or team login that have requested changes in a
        review for the pull request.
+       Team logins are prefixed with the ``@`` character.
+       This will match only reviewers with ``admin`` or ``write`` permission
+       on the repository.
    * - ``closed``
      - Boolean
      - Whether the pull request is closed.
@@ -82,10 +88,16 @@ Here's the list of pull request attribute that rules can be matched against:
      - array of string
      - The list of GitHub user or team login that have commented in a review
        for the pull request.
+       Team logins are prefixed with the ``@`` character.
+       This will match only reviewers with ``admin`` or ``write`` permission
+       on the repository.
    * - ``dismissed-reviews-by``
      - array of string
      - The list of GitHub user or team login that have their review dismissed
        in the pull request.
+       Team logins are prefixed with the ``@`` character.
+       This will match only reviewers with ``admin`` or ``write`` permission
+       on the repository.
    * - ``files``
      - string
      - The files that are modified, deleted or added by the pull request.
@@ -111,6 +123,8 @@ Here's the list of pull request attribute that rules can be matched against:
      - array of string
      - The list of GitHub user or team login that were requested to review the
        pull request. Team logins are prefixed with the ``@`` character.
+       This will match only reviewers with ``admin`` or ``write`` permission
+       on the repository.
    * - ``status-success``
      - array of string
      - The list of status checks that successfuly passed for the pull request.

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -22,7 +22,7 @@ it.
       - name: automatic merge when CI passes and 2 reviews
         conditions:
           - "#approved-reviews-by>=2"
-          - status-success=continuous-integration/travis-ci
+          - status-success=continuous-integration/travis-ci/pr
           - base=master
         actions:
           merge:
@@ -38,7 +38,7 @@ merged — even if's approved.
       - name: automatic merge when CI passes and 2 reviews
         conditions:
           - "#approved-reviews-by>=2"
-          - status-success=continuous-integration/travis-ci
+          - status-success=continuous-integration/travis-ci/pr
           - base=master
           - label!=work-in-progress
         actions:
@@ -100,7 +100,7 @@ Therefore, you could write a rule such as:
       - name: automatic merge for Dependabot pull requests on master
         conditions:
           - author=dependabot[bot]
-          - status-success=continuous-integration/travis-ci
+          - status-success=continuous-integration/travis-ci/pr
           - base=master
         actions:
           merge:
@@ -124,7 +124,7 @@ To automate the merge in this case, you could write some rules along those:
     pull_request_rules:
       - name: automatic merge for master when reviewed and CI passes
         conditions:
-          - status-success=continuous-integration/travis-ci
+          - status-success=continuous-integration/travis-ci/pr
           - "#approved-reviews-by>=2"
           - base=master
         actions:
@@ -132,7 +132,7 @@ To automate the merge in this case, you could write some rules along those:
             method: merge
       - name: automatic merge for stable branches
         conditions:
-          - status-success=continuous-integration/travis-ci
+          - status-success=continuous-integration/travis-ci/pr
           - "#approved-reviews-by>=1"
           - base~=^stable/
         actions:
@@ -151,7 +151,7 @@ code. In that case, you can add a condition using a ``label``:
     pull_request_rules:
       - name: automatic merge for master when reviewed and CI passes
         conditions:
-          - status-success=continuous-integration/travis-ci
+          - status-success=continuous-integration/travis-ci/pr
           - "#approved-reviews-by>=2"
           - base=master
           - label=ready-to-merge
@@ -172,7 +172,7 @@ labelled as ``work-in-progress`` should not be merged:
     pull_request_rules:
       - name: automatic merge for master when reviewed and CI passes
         conditions:
-          - status-success=continuous-integration/travis-ci
+          - status-success=continuous-integration/travis-ci/pr
           - "#approved-reviews-by>=2"
           - base=master
           - label!=work-in-progress

--- a/doc/source/getting-started.rst
+++ b/doc/source/getting-started.rst
@@ -49,7 +49,7 @@ A more realistic example of a ``.mergify.yml`` file would look like this:
     pull_request_rules:
       - name: automatic merge on CI success and review
         conditions:
-          - status-success=continuous-integration/travis-ci
+          - status-success=continuous-integration/travis-ci/pr
           - "#approved-reviews-by>=2"
         actions:
           merge:
@@ -64,9 +64,9 @@ match in order for the engine to execute the configured actions. In this
 example, there are 2 conditions to be met for the rule to be applied to a pull
 request:
 
-- ``status-success=continuous-integration/travis-ci``: the ``status-success``
+- ``status-success=continuous-integration/travis-ci/pr``: the ``status-success``
   variable contains all the check services that successfully run on this pull
-  request. In this case, it must contains ``continuous-integration/travis-ci``
+  request. In this case, it must contains ``continuous-integration/travis-ci/pr``
   for the rule to match: that would mean that the Travis CI reported a success
   status check.
 

--- a/doc/source/strict-workflow.rst
+++ b/doc/source/strict-workflow.rst
@@ -82,7 +82,7 @@ To enable it on a pull request, you can write a ``mergify.yml`` like this:
       - name: automatic merge with strict
         conditions:
           - "#approved-reviews-by>=2"
-          - status-success=continuous-integration/travis-ci
+          - status-success=continuous-integration/travis-ci/pr
         actions:
           merge:
             method: merge


### PR DESCRIPTION
Always use "continuous-integration/travis-ci/pr", as
"continuous-integration/travis-ci" is not a valid CI.

Precise everywhere that team need to be prefixed by '@'