### PR TITLE
Fix retry mechanism of mergeable_state

### DIFF
--- a/mergify_engine/debug.py
+++ b/mergify_engine/debug.py
@@ -45,6 +45,7 @@ def report(url):
     r = g.get_repo(owner + "/" + repo)
     p = r.get_pull(int(pull_number))
 
+    print("* INSTALLATION ID: %s" % install_id)
     print("* CONFIGURATION:")
     print(r.get_contents(".mergify.yml").decoded_content.decode())
 


### PR DESCRIPTION
mergeable_state is computed asynchronously at GitHub, most of the time
wait a couple of seconds is enough.

This change handle the case where the couple of seconds is not enough by
retrying the whole celery tasks 5 seconds later.

Signed-off-by: Mehdi Abaakouk <sileht@sileht.net>