### PR TITLE
merge: allow to have status check about the mergeability

### DIFF
--- a/doc/source/actions.rst
+++ b/doc/source/actions.rst
@@ -179,6 +179,12 @@ The ``merge`` action merges the pull request into its base branch. The
      - Value Type
      - Default
      - Value Description
+   * - ``summary_status``
+     - boolean
+     - ``False``
+     - If ``True``, this rule will be used to set the status of ``Mergify —
+       Summary``. This status must not be used in GitHub Branch Protection
+       as it can block Mergify to merge pull requests.
    * - ``method``
      - string
      - ``merge``

--- a/mergify_engine/actions/merge.py
+++ b/mergify_engine/actions/merge.py
@@ -85,7 +85,8 @@ class MergeAction(actions.Action):
         voluptuous.Required("strict", default=False):
         voluptuous.Any(bool, "smart"),
         voluptuous.Required("strict_method", default="merge"):
-        voluptuous.Any("rebase", "merge")
+        voluptuous.Any("rebase", "merge"),
+        voluptuous.Required("summary_status", default=False): bool
     }
 
     def run(self, installation_id, installation_token,

--- a/mergify_engine/tests/functional/test_engine_v2.py
+++ b/mergify_engine/tests/functional/test_engine_v2.py
@@ -554,7 +554,7 @@ class TestEngineV2Scenario(base.FunctionalTestBase):
             ("check_run", {"check_run": {"conclusion": None}}),
         ])
 
-        # We can run celery beat inside tests, so run the task manually
+        # We can't run celery beat inside tests, so run the task manually
         run_smart_strict_workflow_periodic_task()
 
         self.push_events([
@@ -624,7 +624,7 @@ class TestEngineV2Scenario(base.FunctionalTestBase):
             ("check_run", {"check_run": {"conclusion": None}}),
         ])
 
-        # We can run celery beat inside tests, so run the task manually
+        # We can't run celery beat inside tests, so run the task manually
         run_smart_strict_workflow_periodic_task()
 
         self.push_events([


### PR DESCRIPTION
This restores a V1 engine functionality. User can configure Mergify to
set the Mergify Summary status with the combined state of all rules with
merge action.