### PR TITLE
Better smart queue error handling

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     cryptography
     pygithub>=1.40,!=1.43.4,!=1.43.5
     requests
-    redis<3,>=2.10.5
+    redis
     hiredis
     pyyaml
     voluptuous


### PR DESCRIPTION
If a repository hits the invalid mergeable state GitHub Bug, it
currently block other repo.

This change fixes that, so only the impacted repository is blocked.