### PR TITLE
debug: handle error on `is_behind()`

### DIFF
--- a/mergify_engine/debug.py
+++ b/mergify_engine/debug.py
@@ -52,7 +52,11 @@ def report(url):
     mp = mergify_pull.MergifyPull(g, p, install_id)
     print("* PULL REQUEST:")
     pprint.pprint(mp.to_dict(), width=160)
-    print("is_behind: %s" % mp.is_behind())
+    try:
+        print("is_behind: %s" % mp.is_behind())
+    except github.GithubException as e:
+        print("Unable to know if pull request branch is behind: %s" % e)
+
     print("mergeable_state: %s" % mp.g_pull.mergeable_state)
 
     print("* MERGIFY STATUSES:")


### PR DESCRIPTION
This can happens if the branch has been deleted, e.g.:

github.GithubException.GithubException: 404 {'message': 'Branch not found', 'documentation_url': 'https://developer.github.com/v3/repos/branches/#get-branch'}