### PR TITLE
Validation test ui (CORS changed)

### DIFF
--- a/mergify_engine/web.py
+++ b/mergify_engine/web.py
@@ -25,6 +25,8 @@ import logging
 
 import flask
 
+from flask_cors import cross_origin
+
 from mergify_engine import rules
 from mergify_engine import utils
 from mergify_engine.tasks import github_events
@@ -67,6 +69,7 @@ def badge(owner, repo):
 
 
 @app.route("/validate", methods=["POST"])
+@cross_origin()
 def config_validator():
     try:
         rules.validate_user_config(flask.request.files['data'].stream)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     daiquiri>=1.5
     python-dotenv
     flask
+    flask_cors
     celery[redis]
     cryptography
     pygithub>=1.40,!=1.43.4,!=1.43.5


### PR DESCRIPTION
I have created a simple website to verify `.mergify.yml` configs. It basicly does the same thing, as your CURL Command, but CURL isn't nativly available on Windows and for beginner developers it also may be hard to use. My Website simply offers an input field where you can enter your config and then does a fetch to your domain to verify the config.

The Problem is that all modern browsers are blocking those request. So you need to explicitly allow requests from external domains. I have enabled those CORS Headers in your project for the routes `/validate` ~and `/convert`~ (**Edit:** I saw your pull request removing this feature completly).

I hope you like my work and will be happy to merge it. Otherwise, don't hestiate to close this pull, I've had some fun during development and that's what counting.

Demo: https://mergify.adrianjost.dev/
Repository: https://github.com/adrianjost/mergify-verify

[![image](https://user-images.githubusercontent.com/22987140/56078575-03dc2400-5dea-11e9-871b-e603e6c54541.png)](https://mergify.adrianjost.dev)
