### PR TITLE
tasks: do not ignore private repositories w/o sub but report them

### DIFF
--- a/mergify_engine/debug.py
+++ b/mergify_engine/debug.py
@@ -82,8 +82,8 @@ def report(url):
 
     cached_sub = sub_utils.get_subscription(redis, install_id)
     db_sub = sub_utils._retrieve_subscription_from_db(install_id)
-    print("* SUBSCRIBED (cache/db): %s / %s" % (cached_sub["subscribed"],
-                                                db_sub["subscribed"]))
+    print("* SUBSCRIBED (cache/db): %s / %s" % (cached_sub["subscription"],
+                                                db_sub["subscription"]))
     print("* SUB DETAIL: %s" % db_sub["subscription_reason"])
 
     try:

--- a/mergify_engine/prom_exporter.py
+++ b/mergify_engine/prom_exporter.py
@@ -75,7 +75,7 @@ def collect_metrics():
 
             LOG.info("Get subscription", account=account)
             subscribed = sub_utils.get_subscription(
-                redis, _id)["subscribed"]
+                redis, _id)["subscription"]
 
             installations[(subscribed, target_type)] += 1
 

--- a/mergify_engine/sub_utils.py
+++ b/mergify_engine/sub_utils.py
@@ -103,13 +103,11 @@ def _retrieve_subscription_from_db(installation_id):
     if resp.status_code == 404:
         sub = {
             "token": None,
-            "subscribed": False,
             # FIXME we need to know if install is unknown or token is wrong
             "subscription_reason": "404 returned by engine",
         }
     elif resp.status_code == 200:
         sub = resp.json()
-        sub["subscribed"] = sub["subscription"] is not None
         sub["token"] = sub["token"]["access_token"]
         del sub["subscription"]
     else:  # pragma: no cover

--- a/mergify_engine/tests/functional/base.py
+++ b/mergify_engine/tests/functional/base.py
@@ -195,7 +195,9 @@ class FunctionalTestBase(testtools.TestCase):
         # NOTE(sileht): Prepare a fresh redis
         self.redis = utils.get_redis_for_cache()
         self.redis.flushall()
-        self.subscription = {"token": config.MAIN_TOKEN, "subscribed": False}
+        self.subscription = {"token": config.MAIN_TOKEN,
+                             "subscription": False,
+                             "subscription_reason": "You're not nice"}
         self.redis.set("subscription-cache-%s" % config.INSTALLATION_ID,
                        sub_utils._encrypt(self.subscription))
 
@@ -262,7 +264,9 @@ class FunctionalTestBase(testtools.TestCase):
             if int(install_id) == config.INSTALLATION_ID:
                 return real_get_subscription(r, install_id)
             else:
-                return {"token": None, "subscribed": False}
+                return {"token": None,
+                        "subscription": False,
+                        "subscription_reason": "We're just testing"}
 
         self.useFixture(fixtures.MockPatch(
             "mergify_engine.branch_updater.sub_utils.get_subscription",


### PR DESCRIPTION
This changes the logic of event handling to stop checking subscription at
filtering time. Now the event is processed and the subscription is checked with
a new API that reports the status and the reason behind it, allowing to report
details about why Mergify is active — or not.

This also merges several check report under the name "Status".