### PR TITLE
Delay incoming events

### DIFF
--- a/mergify_engine/web.py
+++ b/mergify_engine/web.py
@@ -119,7 +119,10 @@ def event_handler():
     event_id = flask.request.headers.get("X-GitHub-Delivery")
     data = flask.request.get_json()
 
-    github_events.job_filter_and_dispatch.delay(event_type, event_id, data)
+    github_events.job_filter_and_dispatch.apply_async(
+        args=[event_type, event_id, data],
+        countdown=30
+    )
     return "Event queued", 202
 
 


### PR DESCRIPTION
We have some races because we depends on some Github asynchronous
operations. This change adds a small delay to events to ensure this
operations have at least started. This will reduce a lot the retrying
tentative because the PR is in an unexpected state and mitigate some
races.