### PR TITLE
deploy: fix bash error

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -25,8 +25,7 @@ docker push mergifyio/engine:latest
 # TODO(sileht): nginx cache the ip of the engine container, when the
 # engine container is recreated, nginx still try to connect to the old one
 # So we temporary restart the nginx container each time we deploy mergify
-ssh $PRODUCTION_HOST -p $PRODUCTION_PORT bash -c "
-set -euxo pipefail;
+ssh $PRODUCTION_HOST -p $PRODUCTION_PORT bash -c "set -euxo pipefail;
 cd mergify-engine-docker;
 ENV=prod docker-compose -f docker-compose.yaml pull engine;
 ENV=prod docker-compose -f docker-compose.yaml up -d;


### PR DESCRIPTION
When deploying, the output shows:
bash: -c: option requires an argument

This does not prevent the command to be executed. This happened because the
first line is empty, so just remove the \n before the first command to make
this disappear.