### PR TITLE
Revert "Check validity of token in subscription cache"

### DIFF
--- a/mergify_engine/branch_updater.py
+++ b/mergify_engine/branch_updater.py
@@ -53,8 +53,7 @@ def update(pull, installation_id, method="merge"):
 
     redis = utils.get_redis_for_cache()
 
-    subscription = sub_utils.get_subscription(redis, installation_id,
-                                              validate_token=True)
+    subscription = sub_utils.get_subscription(redis, installation_id)
 
     if not subscription:
         LOG.error("subscription to update branch is missing")

--- a/mergify_engine/sub_utils.py
+++ b/mergify_engine/sub_utils.py
@@ -129,18 +129,9 @@ def _save_subscription_to_cache(r, installation_id, sub):
     r.set("subscription-cache-%s" % installation_id, encrypted, ex=3600)
 
 
-def _is_token_valid(sub):
-    resp = requests.request(
-        "GET", "https://api.github.com/applications/%s/tokens/%s" %
-        (config.OAUTH_CLIENT_ID, sub["token"]),
-        auth=(config.OAUTH_CLIENT_ID, config.OAUTH_CLIENT_SECRET),
-    )
-    return resp.ok
-
-
-def get_subscription(r, installation_id, validate_token=False):
+def get_subscription(r, installation_id):
     sub = _retrieve_subscription_from_cache(r, installation_id)
-    if (not sub or (validate_token and not _is_token_valid(sub))):
+    if not sub:
         sub = _retrieve_subscription_from_db(installation_id)
         _save_subscription_to_cache(r, installation_id, sub)
     return sub

--- a/mergify_engine/tests/functional/base.py
+++ b/mergify_engine/tests/functional/base.py
@@ -258,10 +258,9 @@ class FunctionalTestBase(testtools.TestCase):
 
         real_get_subscription = sub_utils.get_subscription
 
-        def fake_subscription(r, install_id, validate_token=False):
+        def fake_subscription(r, install_id):
             if int(install_id) == config.INSTALLATION_ID:
-                # NOTE(sileht): Never call the website
-                return real_get_subscription(r, install_id, False)
+                return real_get_subscription(r, install_id)
             else:
                 return {"token": None, "subscribed": False}
 


### PR DESCRIPTION
This reverts commit 768dbdc0029b5895cc3c3976939caafab2181e22.