### PR TITLE
Filter some exceptions with sentry

### DIFF
--- a/mergify_engine/__init__.py
+++ b/mergify_engine/__init__.py
@@ -12,14 +12,34 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import daiquiri
+
 import sentry_sdk
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.flask import FlaskIntegration
 
 from mergify_engine import config
+from mergify_engine import exception
+
+LOG = daiquiri.getLogger(__name__)
+
+
+def fixup_sentry_reporting(event, hint):
+    # NOTE(sileht): Block exceptions that celery will retry until
+    # the retries handler manually send the event.
+    is_celery_task = "celery-job" in event.get("extra", {})
+    is_exception = 'exc_info' in hint
+    if is_exception and is_celery_task:
+        exc_type, exc_value, tb = hint['exc_info']
+        backoff = exception.need_retry(exc_value)
+        if backoff and not getattr(exc_value, "retries_done", False):
+            return None
+
+    return event
+
 
 if config.SENTRY_URL:
-    sentry_sdk.init(config.SENTRY_URL, integrations=[
-        CeleryIntegration(),
-        FlaskIntegration(),
-    ])
+    sentry_sdk.init(config.SENTRY_URL,
+                    before_send=fixup_sentry_reporting,
+                    integrations=[CeleryIntegration(),
+                                  FlaskIntegration()])

--- a/mergify_engine/exception.py
+++ b/mergify_engine/exception.py
@@ -1,0 +1,40 @@
+# -*- encoding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import github
+
+import requests
+
+
+class MergeableStateUnknown(Exception):
+    pass
+
+
+def need_retry(exception):
+    if isinstance(exception, MergeableStateUnknown):
+        return 30
+    elif ((isinstance(exception, github.GithubException) and
+           exception.status >= 500) or
+          (isinstance(exception, requests.exceptions.HTTPError) and
+           exception.response.status_code >= 500) or
+          isinstance(exception, requests.exceptions.ConnectionError)):
+        return 30
+
+    elif (isinstance(exception, github.GithubException) and
+          exception.status == 403 and
+          ("You have triggered an abuse detection mechanism" in
+           exception.data["message"] or
+           exception.data["message"].startswith("API rate limit exceeded"))
+          ):
+        return 60 * 5

--- a/mergify_engine/mergify_pull.py
+++ b/mergify_engine/mergify_pull.py
@@ -25,12 +25,9 @@ import tenacity
 
 from mergify_engine import check_api
 from mergify_engine import config
+from mergify_engine import exception
 
 LOG = daiquiri.getLogger(__name__)
-
-
-class MergeableStateUnknown(Exception):
-    pass
 
 
 # NOTE(sileht): Github mergeable_state is undocumented, here my finding by
@@ -234,7 +231,7 @@ class MergifyPull(object):
     @tenacity.retry(wait=tenacity.wait_exponential(multiplier=0.2),
                     stop=tenacity.stop_after_attempt(5),
                     retry=tenacity.retry_if_exception_type(
-                        MergeableStateUnknown),
+                        exception.MergeableStateUnknown),
                     reraise=True)
     def _ensure_mergable_state(self, force=False):
         if self.g_pull.merged:
@@ -254,7 +251,7 @@ class MergifyPull(object):
                 self.g_pull.mergeable_state not in self.UNUSABLE_STATES):
             return
 
-        raise MergeableStateUnknown()
+        raise exception.MergeableStateUnknown()
 
     @tenacity.retry(wait=tenacity.wait_exponential(multiplier=0.2),
                     stop=tenacity.stop_after_attempt(5),


### PR DESCRIPTION
We currently send all exceptions to Sentry even those
that we retry with Celery.

This change ensures that exception that need to be retried
will not send event to sentry before all retries are done.