### PR TITLE
Force a title and body on the merge commit

### DIFF
--- a/mergify_engine/actions/merge/action.py
+++ b/mergify_engine/actions/merge/action.py
@@ -135,7 +135,13 @@ class MergeAction(actions.Action):
     @staticmethod
     def _merge(pull, method):
         try:
-            pull.g_pull.merge(sha=pull.g_pull.head.sha,
+            pull.g_pull.merge(commit_message=pull.g_pull.body,
+                              # TODO: trim the original title so the resulting
+                              # commit_title is not longer than 50 chars
+                              commit_title="{} (#{})".format(
+                                  pull.g_pull.title,
+                                  pull.g_pull.number),
+                              sha=pull.g_pull.head.sha,
                               merge_method=method)
         except github.GithubException as e:   # pragma: no cover
             if pull.g_pull.is_merged():


### PR DESCRIPTION
Instead of relying on the default commit title and message, this PR adopts the following convention:

 - unregarding the number of commits in the PR, and whatever the merge method, the merge commit will use the title and body of the PR.

This conmvention is not exactly the same than [GitHub's convention](https://github.com/sindresorhus/refined-github/issues/276):
 
 - if the PR has one commit, in some PR merge methods (e.q. squash and merge), then the merge commit title is not the PR title but the title in the only commit of the PR
 - if the PR has many commits, in some PR merge methods, the merge commit adopts the title and body from the PR.

I'm creating the PR as exploratory work. This change could eventually be extracted so users can template the message or tune different title/body depending on the merge method or ...

This is complementary to #392 and related to #37.