### PR TITLE
merged_by can be none event if PR is merged

### DIFF
--- a/mergify_engine/actions/merge/helpers.py
+++ b/mergify_engine/actions/merge/helpers.py
@@ -22,7 +22,8 @@ LOG = daiquiri.getLogger(__name__)
 
 def merge_report(pull):
     if pull.g_pull.merged:
-        if pull.g_pull.merged_by.login == 'mergify[bot]':
+        if (pull.g_pull.merged_by and
+                pull.g_pull.merged_by.login == 'mergify[bot]'):
             mode = "automatically"
         else:
             mode = "manually"

--- a/mergify_engine/tasks/engine/__init__.py
+++ b/mergify_engine/tasks/engine/__init__.py
@@ -88,8 +88,9 @@ def create_metrics(event_type, data):
           data["pull_request"]["merged"]):
 
         pull_request_merged.apply_async()
-        if data["pull_request"]["merged_by"]["login"] in ["mergify[bot]",
-                                                          "mergify-test[bot]"]:
+        if (data["pull_request"]["merged_by"] and
+                data["pull_request"]["merged_by"]["login"]
+                in ["mergify[bot]", "mergify-test[bot]"]):
             pull_request_merged_by_mergify.apply_async()
 
 


### PR DESCRIPTION
That doesn't look logic, but well we have received some events with
this...

Closes: MERGIFY-ENGINE-PP, MERGIFY-ENGINE-PQ