### PR TITLE
rules: add compile function and catch error

### DIFF
--- a/mergify_engine/rules/__init__.py
+++ b/mergify_engine/rules/__init__.py
@@ -48,6 +48,10 @@ def PullRequestRuleCondition(value):
         raise voluptuous.Invalid(
             message="Invalid condition '%s'. %s" % (value, str(e)),
             error_message=str(e))
+    except filter.InvalidQuery as e:
+        raise voluptuous.Invalid(
+            message="Invalid condition '%s'. %s" % (value, str(e)),
+            error_message=str(e))
 
 
 PullRequestRulesSchema = voluptuous.Schema([{

--- a/mergify_engine/tests/unit/rules/test_filter.py
+++ b/mergify_engine/tests/unit/rules/test_filter.py
@@ -76,6 +76,13 @@ def test_regexp():
     assert not f(foo="x")
 
 
+def test_regexp_invalid():
+    with pytest.raises(filter.InvalidArguments):
+        filter.Filter({
+            "~=": ("foo", "([^\s\w])(\s*\1+"),  # noqa
+        })
+
+
 def test_set_value_expanders():
     f = filter.Filter({
         "=": ("foo", "@bar"),

--- a/mergify_engine/tests/unit/rules/test_rules.py
+++ b/mergify_engine/tests/unit/rules/test_rules.py
@@ -1,0 +1,31 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright © 2019 Mergify
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+import pytest
+
+import voluptuous
+
+
+from mergify_engine import rules
+
+
+def test_valid_condition():
+    c = rules.PullRequestRuleCondition("head~=bar")
+    assert str(c) == "head~=bar"
+
+
+def test_invalid_condition_re():
+    with pytest.raises(voluptuous.Invalid):
+        rules.PullRequestRuleCondition("head~=(bar")

--- a/mergify_engine/tests/unit/test_config.py
+++ b/mergify_engine/tests/unit/test_config.py
@@ -74,6 +74,18 @@ def test_pull_request_rule_schema_invalid():
                 ],
                 "actions": {},
             }, "Invalid condition "),
+            (
+                {
+                    "name": "invalid regexp",
+                    "conditions": [
+                        "head~=(lol"
+                    ],
+                    "actions": {},
+                },
+                r"Invalid condition 'head~=\(lol'. Invalid arguments: "
+                r"missing \), "
+                r"unterminated subpattern at position 0 @ ",
+            ),
             ({
                 "name": "hello",
                 "conditions": [


### PR DESCRIPTION
This adds a compile function to the Filter class, making sure we can transform
passed values before evaluating a Filter. This allows to catch invalid regexp.
If a Filter is reused, we can save a little CPU by having the regexp compiled
too — fancy.

We also make sure we catch `filter.InvalidQuery` exceptions when parsing
conditions from the YAML file. That allows better error reporting for invalid
engine configuration.