### PR TITLE
actions: use neutral as conclusion when canceling action

### DIFF
--- a/mergify_engine/actions/__init__.py
+++ b/mergify_engine/actions/__init__.py
@@ -23,7 +23,7 @@ import attr
 class Action(abc.ABC):
     config = attr.ib()
     cancelled_check_report = (
-        "cancelled", "The rule doesn't match anymore, this action "
+        "neutral", "The rule doesn't match anymore, this action "
         "has been cancelled", "")
 
     # If an action can't be twice in a rule this must be set to true


### PR DESCRIPTION
The `cancelled` conclusion is a red cross mark on GitHub, meaning something's
wrong for users. Actually there's nothing wrong, so using neutral should avoid
having PR marked as "failed" because of something just changed.

Fixes #409