### PR TITLE
Workaround when check go in back in progress

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ deps = flake8
        flake8-docstrings
        flake8-rst-docstrings
        flake8-logging-format
+       pydocstyle<4  # flake8-docstrings not yet compatible with >=4
 commands = flake8
 
 [testenv:docs]


### PR DESCRIPTION
Github doesn't reset conclusion when status is back to in_progress
and we can't set 'null' ourself (Github returns a 4XX).

So manually set conclusion to None when status is in_progress to ensure
the engine take the right decision.