### PR TITLE
Prevent requesting review from users who have already reviewed

### DIFF
--- a/mergify_engine/actions/request_reviews.py
+++ b/mergify_engine/actions/request_reviews.py
@@ -1,3 +1,5 @@
+import itertools
+
 import voluptuous
 
 from mergify_engine import actions
@@ -13,4 +15,15 @@ class RequestReviewsAction(actions.Action):
 
     def run(self, installation_id, installation_token, event_type, data,
             pull, missing_conditions):
-        pull.g_pull.create_review_request(self.config['users'])
+
+        # Using consolidated data to avoid already done API lookup
+        data = pull.to_dict()
+        reviews_keys = ("approved-reviews-by", "dismissed-reviews-by",
+                        "changes-requested-reviews-by", "commented-reviews-by")
+        existing_reviews = set(itertools.chain(
+            *[data[key] for key in reviews_keys]
+        ))
+        reviews_to_request = set(self.config['users']).difference(
+            existing_reviews
+        )
+        pull.g_pull.create_review_request(list(reviews_to_request))

--- a/mergify_engine/mergify_pull.py
+++ b/mergify_engine/mergify_pull.py
@@ -142,12 +142,13 @@ class MergifyPull(object):
             "files": [f.filename for f in self.g_pull.get_files()],
             "approved-reviews-by": [r.user.login for r in approvals
                                     if r.state == "APPROVED"],
-            "dismissed-reviews-by": [r.user for r in approvals
+            "dismissed-reviews-by": [r.user.login for r in approvals
                                      if r.state == "DISMISSED"],
             "changes-requested-reviews-by": [
-                r.user for r in approvals if r.state == "CHANGES_REQUESTED"
+                r.user.login for r in approvals
+                if r.state == "CHANGES_REQUESTED"
             ],
-            "commented-reviews-by": [r.user for r in comments
+            "commented-reviews-by": [r.user.login for r in comments
                                      if r.state == "COMMENTED"],
             "status-success": [s.context for s in statuses
                                if s.state == "success"],


### PR DESCRIPTION
This pull request filters out users who have already submitted a review from the `request_reviews` action.

It looks like the GitHub API happily accepts new review requests for users who have already review. Since Mergify runs whenever a PR is edited, this means that with the recently added `request_reviews` action, if a user reviews a PR, then Mergify will request another review from them within moments. This pull request should prevent that from happening. I don't think there's much more that can be done without more extensive configuration.