### PR TITLE
Add status neutral or success

### DIFF
--- a/doc/source/conditions.rst
+++ b/doc/source/conditions.rst
@@ -155,13 +155,13 @@ Here's the list of pull request attribute that rules can be matched against:
        `continuous-integration/travis-ci/pr` or of a *check run* such as
        `Travis CI - Pull Request`. See `About status check name`_ for more
        details.
-  * - ``status-neutral-or-success``
-    - array of string
-    - The list of status checks that either successfully passed or are neutral
-      for the pull request. This is the name of a *status check* such as
-      `continuous-integration/travis-ci/pr` or of a *check run* such as
-      `Travis CI - Pull Request`. See `About status check name`_ for more
-      details.
+   * - ``status-neutral-or-success``
+     - array of string
+     - The list of status checks that either successfully passed or are neutral
+       for the pull request. This is the name of a *status check* such as
+       `continuous-integration/travis-ci/pr` or of a *check run* such as
+       `Travis CI - Pull Request`. See `About status check name`_ for more
+       details.
    * - ``status-failure``
      - array of string
      - The list of status checks that failed for the pull request.

--- a/doc/source/conditions.rst
+++ b/doc/source/conditions.rst
@@ -143,7 +143,7 @@ Here's the list of pull request attribute that rules can be matched against:
        on the repository.
    * - ``status-success``
      - array of string
-     - The list of status checks that successfuly passed for the pull request.
+     - The list of status checks that successfully passed for the pull request.
        This is the name of a *status check* such as
        `continuous-integration/travis-ci/pr` or of a *check run* such as
        `Travis CI - Pull Request`. See `About status check name`_ for more

--- a/doc/source/conditions.rst
+++ b/doc/source/conditions.rst
@@ -155,6 +155,13 @@ Here's the list of pull request attribute that rules can be matched against:
        `continuous-integration/travis-ci/pr` or of a *check run* such as
        `Travis CI - Pull Request`. See `About status check name`_ for more
        details.
+  * - ``status-neutral-or-success``
+    - array of string
+    - The list of status checks that either successfully passed or are neutral
+      for the pull request. This is the name of a *status check* such as
+      `continuous-integration/travis-ci/pr` or of a *check run* such as
+      `Travis CI - Pull Request`. See `About status check name`_ for more
+      details.
    * - ``status-failure``
      - array of string
      - The list of status checks that failed for the pull request.

--- a/mergify_engine/mergify_pull.py
+++ b/mergify_engine/mergify_pull.py
@@ -172,7 +172,7 @@ class MergifyPull(object):
                                if s.state == "neutral"],
             "status-neutral-or-success": [s.context for s in statuses
                                           if s.state == "neutral" or
-                                             s.state == "success"],
+                                          s.state == "success"],
             # NOTE(sileht): Not handled for now
             # cancelled, timed_out, or action_required
         }

--- a/mergify_engine/mergify_pull.py
+++ b/mergify_engine/mergify_pull.py
@@ -171,8 +171,8 @@ class MergifyPull(object):
             "status-neutral": [s.context for s in statuses
                                if s.state == "neutral"],
             "status-neutral-or-success": [s.context for s in statuses
-                                          if s.state == "neutral"
-                                          or s.state == "success"],
+                                          if s.state == "neutral" or
+                                             s.state == "success"],
             # NOTE(sileht): Not handled for now
             # cancelled, timed_out, or action_required
         }

--- a/mergify_engine/mergify_pull.py
+++ b/mergify_engine/mergify_pull.py
@@ -170,6 +170,8 @@ class MergifyPull(object):
                                if s.state == "failure"],
             "status-neutral": [s.context for s in statuses
                                if s.state == "neutral"],
+            "status-neutral-or-success": [s.context for s in statuses
+                               if s.state == "neutral" or s.state == "success"],
             # NOTE(sileht): Not handled for now
             # cancelled, timed_out, or action_required
         }

--- a/mergify_engine/mergify_pull.py
+++ b/mergify_engine/mergify_pull.py
@@ -171,7 +171,8 @@ class MergifyPull(object):
             "status-neutral": [s.context for s in statuses
                                if s.state == "neutral"],
             "status-neutral-or-success": [s.context for s in statuses
-                               if s.state == "neutral" or s.state == "success"],
+                                          if s.state == "neutral"
+                                          or s.state == "success"],
             # NOTE(sileht): Not handled for now
             # cancelled, timed_out, or action_required
         }

--- a/mergify_engine/rules/parser.py
+++ b/mergify_engine/rules/parser.py
@@ -110,7 +110,7 @@ search = (
     pyparsing.Optional("#", default="") +
     (head | base | author | merged_by | body | assignee | label | locked |
      closed | conflict | merged | title | files | milestone | review_requests |
-     review_approved_by | review_dismissed_by |
-     review_changes_requested_by | review_commented_by |
-     status_success | status_neutral | status_neutral_or_success | status_failure)
+     review_approved_by | review_dismissed_by | review_changes_requested_by |
+     review_commented_by | status_success | status_neutral |
+     status_neutral_or_success | status_failure)
 ).setParseAction(_token_to_dict)

--- a/mergify_engine/rules/parser.py
+++ b/mergify_engine/rules/parser.py
@@ -98,6 +98,7 @@ review_commented_by = (
 status_success = "status-success" + _match_with_operator(text)
 status_failure = "status-failure" + _match_with_operator(text)
 status_neutral = "status-neutral" + _match_with_operator(text)
+status_neutral_or_success = "status-neutral-or-success" + _match_with_operator(text)
 
 search = (
     pyparsing.Optional(
@@ -111,5 +112,5 @@ search = (
      closed | conflict | merged | title | files | milestone | review_requests |
      review_approved_by | review_dismissed_by |
      review_changes_requested_by | review_commented_by |
-     status_success | status_neutral | status_failure)
+     status_success | status_neutral | status_neutral_or_success | status_failure)
 ).setParseAction(_token_to_dict)

--- a/mergify_engine/rules/parser.py
+++ b/mergify_engine/rules/parser.py
@@ -98,7 +98,9 @@ review_commented_by = (
 status_success = "status-success" + _match_with_operator(text)
 status_failure = "status-failure" + _match_with_operator(text)
 status_neutral = "status-neutral" + _match_with_operator(text)
-status_neutral_or_success = "status-neutral-or-success" + _match_with_operator(text)
+status_neutral_or_success = (
+  "status-neutral-or-success" + _match_with_operator(text)
+)
 
 search = (
     pyparsing.Optional(

--- a/mergify_engine/rules/parser.py
+++ b/mergify_engine/rules/parser.py
@@ -99,7 +99,7 @@ status_success = "status-success" + _match_with_operator(text)
 status_failure = "status-failure" + _match_with_operator(text)
 status_neutral = "status-neutral" + _match_with_operator(text)
 status_neutral_or_success = (
-  "status-neutral-or-success" + _match_with_operator(text)
+    "status-neutral-or-success" + _match_with_operator(text)
 )
 
 search = (


### PR DESCRIPTION
Some checks (like LGTM analysis) return a status of Neutral to mean unchanged and Success to mean changed, but ok. Either of these statuses is fine, and should be allowed to pass. Currently (since afaik there is no way to manually "or" rules), the only way is to create two fully separate rules, each of which differs only in that one specifies `status-success` and the other specifies `status-neutral`, which is very redundant and bad for maintainability. This PR adds a new check, `status-neutral-or-success`, which, as it suggests, matches when the status is either `neutral` or `success`.

Alternatives considered:

1. Implement a formal way to "or" conditions together in a single rule -- doable, but could easily raise the parsing complexity a lot
2. Implement a way to have templated rules (see #502), and use that as an "or" instead -- also a good idea for other reasons
3. Just have multiple (slightly different) rules -- works, but is very hard to maintain

Fully implements #468