### PR TITLE
smart: remove PR from queue only when merge is effective

### DIFF
--- a/mergify_engine/actions/merge/action.py
+++ b/mergify_engine/actions/merge/action.py
@@ -70,7 +70,11 @@ class MergeAction(actions.Action):
         if self.config["strict"] and pull.is_behind():
             return self._sync_with_base_branch(pull, installation_id)
         else:
-            return self._merge(pull, installation_id)
+            try:
+                return self._merge(pull, installation_id)
+            finally:
+                if self.config["strict"] == "smart":
+                    queue.remove_pull(pull)
 
     def cancel(
         self,
@@ -153,9 +157,6 @@ class MergeAction(actions.Action):
             )
 
     def _merge(self, pull, installation_id):
-        if self.config["strict"] == "smart":
-            queue.remove_pull(pull)
-
         if self.config["method"] != "rebase" or pull.g_pull.raw_data["rebaseable"]:
             method = self.config["method"]
         elif self.config["rebase_fallback"]:

--- a/mergify_engine/actions/merge/queue.py
+++ b/mergify_engine/actions/merge/queue.py
@@ -174,7 +174,7 @@ def smart_strict_workflow_periodic_task():
                 # NOTE(sileht): Pick up this pull request and rebase it again
                 # or update its status and remove it from the queue
                 LOG.debug(
-                    "pull request needs to be updated again or " "has been closed",
+                    "pull request needs to be updated again or has been closed",
                     pull_request=pull,
                 )
                 _handle_first_pull_in_queue(queue, pull)


### PR DESCRIPTION
If MergeAction._merge() is called at the same time as
smart_strict_workflow_periodic_task(), since we just remove the PR from
the queue but not yet merged it, the periodic task will update the next
one.

This changes cleanup the queue just after the merge to avoid this race.