### PR TITLE
Rework retry timeout

### DIFF
--- a/mergify_engine/tests/unit/test_prom_exporter.py
+++ b/mergify_engine/tests/unit/test_prom_exporter.py
@@ -20,4 +20,4 @@ def test_exception_wait_time():
     retry_state.outcome.exception.return_value = e = requests.exceptions.HTTPError()
     e.response = mock.Mock()
     e.response.status_code = 500
-    assert prom_exporter._wait_time_for_exception(retry_state) == 30
+    assert prom_exporter._wait_time_for_exception(retry_state) == 60

--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -67,8 +67,8 @@ def retry_task_on_exception(
         return
 
     LOG.warning("job %s: failed %d times - retrying", task_id, sender.request.retries)
-    # Exponential backoff
-    retry_in = 2 ** sender.request.retries * backoff
+    # Exponential ^3 backoff
+    retry_in = 3 ** sender.request.retries * backoff
     sender.retry(countdown=retry_in)
 
 


### PR DESCRIPTION
Github issue are never solved in a snap, so be less aggressive in
retrying.

This changes retries from 30, 60, 120 to 60, 180, 540
