### PR TITLE
merge: don't retrigger action on neutral conclusion

### DIFF
--- a/mergify_engine/actions/__init__.py
+++ b/mergify_engine/actions/__init__.py
@@ -54,7 +54,7 @@ class Action(abc.ABC):
     config = attr.ib()
     cancelled_check_report = (
         "neutral",
-        "The rule doesn't match anymore, this action " "has been cancelled",
+        "The rule doesn't match anymore, this action has been cancelled",
         "",
     )
 

--- a/mergify_engine/tasks/engine/actions_runner.py
+++ b/mergify_engine/tasks/engine/actions_runner.py
@@ -242,7 +242,7 @@ def run_actions(
                     )
                     continue
                 method_name = "cancel"
-                expected_conclusion = ["cancelled"]
+                expected_conclusion = ["cancelled", "neutral"]
             else:
                 method_name = "run"
                 expected_conclusion = ["success", "failure"]


### PR DESCRIPTION
We change merge action to return neutral when cancel