### PR TITLE
Revert "worker: limit broker pool to 1"

### DIFF
--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -30,9 +30,6 @@ app = celery.Celery()
 
 app.conf.broker_url = config.CELERY_BROKER_URL
 
-# Limit the connection to Redis to 1 per worker
-app.conf.broker_pool_limit = 1
-
 # Configure number of worker via env var
 app.conf.worker_concurrency = int(os.environ.get("CELERYD_CONCURRENCY", 1))
 


### PR DESCRIPTION
This reverts commit c5f804f98ab3448690985e73810541add4bd4f80.

This should not be needed anymore.