### PR TITLE
filter: make value expanded data honor iterable operator

### DIFF
--- a/mergify_engine/rules/filter.py
+++ b/mergify_engine/rules/filter.py
@@ -120,9 +120,9 @@ class Filter:
     LENGTH_OPERATOR = "#"
     ATTR_SEPARATOR = "."
 
-    def _get_value_comparator(self, op, name, values):
+    def _get_value_comparator(self, op, iterable_op, name, values):
         if op != len and name in self._value_expanders:
-            return lambda x: any(
+            return lambda x: iterable_op(
                 map(lambda y: op(x, y), self._value_expanders[name](values))
             )
         else:
@@ -170,7 +170,7 @@ class Filter:
 
             def _op(values):
                 values = self._resolve_name(values, nodes[0])
-                cmp = self._get_value_comparator(op, nodes[0], nodes[1])
+                cmp = self._get_value_comparator(op, iterable_op, nodes[0], nodes[1])
 
                 if isinstance(values, (list, tuple)) and op != len:
                     return iterable_op(map(cmp, values))

--- a/mergify_engine/tests/unit/rules/test_filter.py
+++ b/mergify_engine/tests/unit/rules/test_filter.py
@@ -88,6 +88,14 @@ def test_does_not_contain():
     assert not f(foo=(1, 2))
 
 
+def test_set_value_expanders_does_not_contain():
+    f = filter.Filter({"!=": ("foo", "@bar")})
+    f.set_value_expanders("foo", lambda x: ["foobaz", "foobar"])
+    assert not f(foo="foobar")
+    assert not f(foo="foobaz")
+    assert f(foo="foobiz")
+
+
 def test_contains():
     f = filter.Filter({"=": ("foo", 1)})
     assert f(foo=[1, 2])


### PR DESCRIPTION
Using `any` when expanding an array is wrong and the `iterable_op` should be
honored.

This fixes the use case of `author!=@myteam` not working as intended.

It used to match as soon as the author was different of one member, which is
always true (unless your team has only one member which is the author itself).

Now this will check for every member of `myteam` to be different than the
author.