### PR TITLE
Pull request for datadog-tcp

### DIFF
--- a/mergify_engine/config.py
+++ b/mergify_engine/config.py
@@ -16,6 +16,7 @@
 
 import base64
 import distutils.util
+import logging
 import os
 import re
 
@@ -31,6 +32,13 @@ def CoercedBool(value):
     return bool(distutils.util.strtobool(str(value)))
 
 
+def CoercedLoggingLevel(value):
+    value = value.upper()
+    if value in ("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"):
+        return getattr(logging, value)
+    raise ValueError
+
+
 def CommaSeparatedStringList(value):
     return value.split(",")
 
@@ -41,6 +49,9 @@ Schema = voluptuous.Schema(
         voluptuous.Required("DEBUG", default=True): CoercedBool,
         voluptuous.Required("LOG_RATELIMIT", default=False): CoercedBool,
         voluptuous.Required("LOG_STDOUT", default=True): CoercedBool,
+        voluptuous.Required("LOG_STDOUT_LEVEL", default=None): voluptuous.Any(
+            None, CoercedLoggingLevel
+        ),
         voluptuous.Required("LOG_DATADOG", default=False): CoercedBool,
         voluptuous.Required("LOG_JSON_FILE", default=None): voluptuous.Any(None, str),
         voluptuous.Required("SENTRY_URL", default=None): voluptuous.Any(None, str),

--- a/mergify_engine/utils.py
+++ b/mergify_engine/utils.py
@@ -98,7 +98,9 @@ def setup_logging():
     if config.LOG_STDOUT:
         outputs.append(
             daiquiri.output.Stream(
-                sys.stdout, formatter=CustomFormatter(fmt=CELERY_EXTRAS_FORMAT)
+                sys.stdout,
+                formatter=CustomFormatter(fmt=CELERY_EXTRAS_FORMAT),
+                level=config.LOG_STDOUT_LEVEL,
             )
         )
 


### PR DESCRIPTION
## feat(logging): drop queues contents

This would help for debugging

## feat(logging): allow to config level of STDOUT

It's interesting, to keep error and critical in the console in
additional to external logger that receive everything.