### PR TITLE
fix(commands): only report command name without args

### DIFF
--- a/mergify_engine/tests/unit/test_command.py
+++ b/mergify_engine/tests/unit/test_command.py
@@ -38,11 +38,14 @@ def test_command_loader():
         "@mergifyio rebase foobar",
         "@mergifyio rebase foobar\nsecondline\n",
     ]:
-        command, action = load_action(message)
-        assert command.startswith("rebase")
+        command, args, action = load_action(message)
+        assert command == "rebase"
         assert isinstance(action, RebaseAction)
 
-    command, action = load_action("@mergifyio backport branch-3.1 branch-3.2\nfoobar\n")
-    assert command == "backport branch-3.1 branch-3.2"
+    command, args, action = load_action(
+        "@mergifyio backport branch-3.1 branch-3.2\nfoobar\n"
+    )
+    assert command == "backport"
+    assert args == "branch-3.1 branch-3.2"
     assert isinstance(action, BackportAction)
     assert action.config == {"branches": ["branch-3.1", "branch-3.2"], "regexes": []}


### PR DESCRIPTION
This fixes the statsd tagging which included arguments rather than just the
command name.
