### PR TITLE
fix(ci): allow merge commit

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,1 +1,2 @@
 commitsOnly: true
+allowMergeCommits: true


### PR DESCRIPTION
When Mergify update the PR before merging, it adds merge commit
that not allow by semantic pull requests by default