### PR TITLE
ci(tox): remove implicit basepython declarations

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,12 +12,6 @@ deps = -r requirements.txt
 commands =
   pifpaf run -g MERGIFYENGINE_STORAGE_URL redis --port 6363 -- pifpaf run -g MERGIFYENGINE_CELERY_BROKER_URL redis --port 6364 -- pytest -v --pyargs mergify_engine {posargs}
 
-[testenv:py38]
-basepython = python3.8
-
-[testenv:py37]
-basepython = python3.7
-
 [testenv:cover]
 commands =
   pifpaf run -g MERGIFYENGINE_STORAGE_URL redis --port 6363 -- pifpaf run -g MERGIFYENGINE_CELERY_BROKER_URL redis --port 6364 -- pytest -v --pyargs mergify_engine --cov=mergify_engine --cov-config .coveragerc {posargs}


### PR DESCRIPTION
Those are standards in tox.