### PR TITLE
feat(actions): do not log on error but store failed state in the PR

### DIFF
--- a/mergify_engine/actions/__init__.py
+++ b/mergify_engine/actions/__init__.py
@@ -61,6 +61,10 @@ class Action(abc.ABC):
     # If an action can't be twice in a rule this must be set to true
     only_once = False
 
+    # If set to True, does not post the report to the Check API
+    # Only keep it for internal tracking
+    silent_report = False
+
     @property
     @staticmethod
     @abc.abstractmethod

--- a/mergify_engine/actions/close.py
+++ b/mergify_engine/actions/close.py
@@ -33,22 +33,12 @@ class CloseAction(actions.Action):
         try:
             pull.g_pull.edit(state="close")
         except github.GithubException as e:  # pragma: no cover
-            pull.log.error(
-                "fail to close the pull request",
-                status=e.status,
-                error=e.data["message"],
-            )
-            return ("failure", "Pull request can't be closed", "")
+            return ("failure", "Pull request can't be closed", e.data["message"])
 
         try:
             pull.g_pull.create_issue_comment(self.config["message"])
         except github.GithubException as e:  # pragma: no cover
-            pull.log.error(
-                "fail to post comment on the pull request",
-                status=e.status,
-                error=e.data["message"],
-            )
-            return ("failure", "the close message can't be created", "")
+            return ("failure", "The close message can't be created", e.data["message"])
 
         return ("success", "The pull request has been closed", self.config["message"])
 

--- a/mergify_engine/actions/delete_head_branch.py
+++ b/mergify_engine/actions/delete_head_branch.py
@@ -56,12 +56,11 @@ class DeleteHeadBranchAction(actions.Action):
                 )
             except github.GithubException as e:
                 if e.status not in [422, 404]:
-                    pull.log.error(
-                        "Unable to delete head branch",
-                        status=e.status,
-                        error=e.data["message"],
+                    return (
+                        "failure",
+                        "Unable to delete the head branch",
+                        e.data["message"],
                     )
-                    return ("failure", "Unable to delete the head branch", "")
             return (
                 "success",
                 "Branch `%s` has been deleted" % pull.head_ref,

--- a/mergify_engine/actions/dismiss_reviews.py
+++ b/mergify_engine/actions/dismiss_reviews.py
@@ -35,6 +35,8 @@ class DismissReviewsAction(actions.Action):
 
     always_run = True
 
+    silent_report = True
+
     @staticmethod
     def _have_been_synchronized(sources):
         for source in sources:
@@ -71,9 +73,10 @@ class DismissReviewsAction(actions.Action):
                 headers={"Accept": "application/vnd.github.machine-man-preview+json"},
             )
         except github.GithubException as e:  # pragma: no cover
-            pull.log.error(
-                "failed to dismiss review",
-                status=e.status,
-                error_message=e.data["message"],
-                error=e.data.get("errors"),
+            server_message = e.data.get("message")
+            return (
+                None,
+                "Unable to dismiss review",
+                f"GitHub error: [{e.status_code}] `{server_message}`",
             )
+        return ("success", "Review dismissed", "")


### PR DESCRIPTION
When a post comment fails, rather than logging an error on our side, let's
store the failed state in the PR conclusion. That should allow the engine to
retry since the status will be "failure" rather than "sucesss".

We don't post the report to the check API because we don't want to have a
report for some actions like comment. To do that a new flag for Action is
added: "silent_report".

Fixes MERGIFY-ENGINE-ZB
FIxes MERGIFY-ENGINE-12Y
