### PR TITLE
fix(refresh): correct set summary conclusion

### DIFF
--- a/mergify_engine/tasks/engine/actions_runner.py
+++ b/mergify_engine/tasks/engine/actions_runner.py
@@ -281,8 +281,14 @@ def run_actions(
                 or previous_conclusion not in expected_conclusions
             )
 
+            # TODO(sileht): refactor it to store the whole report in the check summary,
+            # not just the conclusions
+
+            silent_report = action_obj.silent_report
+
             if not need_to_be_run:
-                report = None
+                silent_report = True
+                report = (previous_conclusion, "Already in expected state", "")
                 message = "ignored, already in expected state: %s/%s" % (
                     method_name,
                     previous_conclusion,
@@ -307,7 +313,7 @@ def run_actions(
             if report:
                 conclusion, title, summary = report
                 status = "completed" if conclusion else "in_progress"
-                if not action_obj.silent_report:
+                if not silent_report:
                     try:
                         check_api.set_check_run(
                             pull.g_pull,


### PR DESCRIPTION
When an action goes into an expected state and next event is receive
we set the conclusion to "success".

This makes refreshing not really working as expected.

This change fixes that.