### PR TITLE
feat(actions/copy): add ignore_conflicts option

### DIFF
--- a/doc/source/actions.rst
+++ b/doc/source/actions.rst
@@ -68,7 +68,14 @@ parameter:
    * - ``regexes``
      - array of string
      - ``[]``
-     - The list of regexes to find branches the pull request should be copied to.
+     - The list of regexes to find branches the pull request should be copied
+       to.
+   * - ``ignore_conflicts``
+     - Boolean
+     - ``False``
+     - Whether to create the pull requests even if they are conflicts when
+       cherry-picking the commits.
+
 
 Once the backporting pull request is closed or merged, Mergify will
 automatically delete the backport head branch that it created.
@@ -94,6 +101,11 @@ The ``copy`` action creates a copy of the pull request targetting other branches
      - array of string
      - ``[]``
      - The list of regexes to find branches the pull request should be copied to.
+   * - ``ignore_conflicts``
+     - Boolean
+     - ``False``
+     - Whether to create the pull requests even if they are conflicts when
+       cherry-picking the commits.
 
 
 .. _comment action:

--- a/mergify_engine/actions/copy.py
+++ b/mergify_engine/actions/copy.py
@@ -40,6 +40,7 @@ class CopyAction(actions.Action):
     validator = {
         voluptuous.Required("branches", default=[]): [str],
         voluptuous.Required("regexes", default=[]): [Regex],
+        voluptuous.Required("ignore_conflicts", default=False): bool,
     }
 
     def _copy(self, pull, branch_name):
@@ -66,7 +67,12 @@ class CopyAction(actions.Action):
 
         # No, then do it
         if not new_pull:
-            new_pull = duplicate_pull.duplicate(pull, branch, self.KIND)
+            try:
+                new_pull = duplicate_pull.duplicate(
+                    pull, branch, self.config["ignore_conflicts"], self.KIND,
+                )
+            except duplicate_pull.DuplicateFailed as e:
+                return ("failure", e.reason)
 
             # NOTE(sileht): We relook again in case of concurrent duplicate
             # are done because of two events received too closely

--- a/mergify_engine/tests/unit/test_command.py
+++ b/mergify_engine/tests/unit/test_command.py
@@ -48,4 +48,8 @@ def test_command_loader():
     assert command == "backport"
     assert args == "branch-3.1 branch-3.2"
     assert isinstance(action, BackportAction)
-    assert action.config == {"branches": ["branch-3.1", "branch-3.2"], "regexes": []}
+    assert action.config == {
+        "branches": ["branch-3.1", "branch-3.2"],
+        "regexes": [],
+        "ignore_conflicts": False,
+    }


### PR DESCRIPTION
This adds a new option ignore_conflicts which allows to create copy or
backports of pull requests even if git fails.

This was the default and is now false by default. User will have to specify
that they still want a PR created if it's impossible to do so automatically.