### PR TITLE
chore: remove useless flake8 settings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -92,12 +92,10 @@ commands =
 [flake8]
 exclude = .tox,.eggs,doc
 show-source = true
-max-line-length = 80
 select = C,E,F,W,B,B950
 # E101,W191: Can't ignore tabs indent on multiline strings:
 #  https://gitlab.com/pycqa/flake8/issues/375
 ignore = E501,W503,E203,G200,G201,E101,W191
-application-import-names = mergify_engine
 enable-extensions = G
 
 [isort]


### PR DESCRIPTION
Line length is handled by black and application-import-names is not used by any
current flake8 plugin.
