### PR TITLE
chore: we only need rerequested check_suite

### DIFF
--- a/mergify_engine/tasks/github_events.py
+++ b/mergify_engine/tasks/github_events.py
@@ -108,6 +108,9 @@ def get_ignore_reason(subscription, event_type, data):
     elif event_type == "status" and data["state"] == "pending":
         return "ignored (state pending)"
 
+    elif event_type == "check_suite" and data["action"] != "rerequested":
+        return "ignored (check_suite/%s)" % data["action"]
+
     elif (
         event_type in ["check_run", "check_suite"]
         and data[event_type]["app"]["id"] == config.INTEGRATION_ID


### PR DESCRIPTION
We now receive all check-runs since a while, no need to continue to
handle them.