### PR TITLE
fix: _ensure_mergeable_state()

### DIFF
--- a/mergify_engine/clients/github.py
+++ b/mergify_engine/clients/github.py
@@ -102,7 +102,7 @@ def get_client(*args, **kwargs):
     rate = client.item("/rate_limit")["resources"]
     if rate["core"]["remaining"] < RATE_LIMIT_THRESHOLD:
         reset = datetime.utcfromtimestamp(rate["core"]["reset"])
-        now = datetime.datetime.utcnow()
+        now = datetime.utcnow()
         delta = reset - now
         statsd.increment("engine.rate_limited")
         raise exceptions.RateLimited(delta.total_seconds(), rate)

--- a/mergify_engine/tests/functional/base.py
+++ b/mergify_engine/tests/functional/base.py
@@ -325,7 +325,7 @@ class FunctionalTestBase(testtools.TestCase):
             # NOTE(sileht): Don't wait exponentialy during replay
             self.useFixture(
                 fixtures.MockPatchObject(
-                    mergify_pull.MergifyPull._ensure_mergable_state.retry, "wait", None
+                    mergify_pull.MergifyPull._ensure_complete.retry, "wait", None
                 )
             )
 


### PR DESCRIPTION
## fix: _ensure_mergeable_state()

Looks like check-runs pull_requested payload don't even have "state"
attribute, just the number ...

Fixes MERGIFY-ENGINE-1B0

## fix: datetime usage in rate_limit check

Fixes MERGIFY-ENGINE-1B1
