### PR TITLE
fix: replace httpx mixing by inheritance

### DIFF
--- a/mergify_engine/clients/common.py
+++ b/mergify_engine/clients/common.py
@@ -50,27 +50,29 @@ httpx.HTTPNotFound = HTTPNotFound
 STATUS_CODE_TO_EXC = {404: HTTPNotFound}
 
 
-class HttpxHelpersMixin:
+class BaseClient(httpx.Client):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # httpx doesn't support retries yet, but the sync client uses urllib3 like request
         # https://github.com/encode/httpx/blob/master/httpx/_dispatch/urllib3.py#L105
 
-        real_url_open = self.dispatch.pool.url_open
+        real_urlopen = self.dispatch.pool.urlopen
 
-        def _mergify_patched_url_open(*args, **kwargs):
+        def _mergify_patched_urlopen(*args, **kwargs):
             kwargs["retries"] = RETRY
-            return real_url_open(*args, **kwargs)
+            return real_urlopen(*args, **kwargs)
 
-        self.dispatch.pool.url_open = _mergify_patched_url_open
+        self.dispatch.pool.urlopen = _mergify_patched_urlopen
 
     def request(self, *args, **kwargs):
         try:
-            return super().request(*args, **kwargs)
+            r = super().request(*args, **kwargs)
+            r.raise_for_status()
+            return r
         except httpx.HTTPError as e:
             if e.response and 400 <= e.response.status_code < 500:
                 exc_class = STATUS_CODE_TO_EXC.get(
-                    e.reponse.status_code, HTTPClientSideError
+                    e.response.status_code, HTTPClientSideError
                 )
-                raise exc_class(e.args, e.request, e.response) from e
+                raise exc_class(*e.args, request=e.request, response=e.response)
             raise

--- a/mergify_engine/clients/github.py
+++ b/mergify_engine/clients/github.py
@@ -47,7 +47,6 @@ class GithubInstallationAuth(httpx.Auth):
             r = github_app.get_client().post(
                 f"/app/installations/{self.installation_id}/access_tokens",
             )
-            r.raise_for_status()
             self._access_token = r.json()["token"]
             self._access_token_expiration = datetime.fromisoformat(
                 r.json()["expires_at"][:-1]
@@ -55,7 +54,7 @@ class GithubInstallationAuth(httpx.Auth):
         return self._access_token
 
 
-class GithubInstallationClient(httpx.Client, common.HttpxHelpersMixin):
+class GithubInstallationClient(common.BaseClient):
     def __init__(self, owner, repo, installation_id=None):
         self.owner = owner
         self.repo = repo
@@ -74,7 +73,6 @@ class GithubInstallationClient(httpx.Client, common.HttpxHelpersMixin):
             headers["Accept"] = f"application/vnd.github.{api_version}-preview+json"
 
         r = self.get(url, params=params, headers=headers)
-        r.raise_for_status()
         return r.json()
 
     def items(self, url, api_version=None, list_items=None, **params):
@@ -84,7 +82,6 @@ class GithubInstallationClient(httpx.Client, common.HttpxHelpersMixin):
 
         while True:
             r = self.get(url, params=params, headers=headers)
-            r.raise_for_status()
             items = r.json()
             if list_items:
                 items = items[list_items]

--- a/mergify_engine/clients/github_app.py
+++ b/mergify_engine/clients/github_app.py
@@ -55,7 +55,7 @@ class GithubBearerAuth(httpx.Auth):
             yield request
 
 
-class _Client(httpx.Client, common.HttpxHelpersMixin):
+class _Client(common.BaseClient):
     def __init__(self):
         super().__init__(
             base_url=f"https://api.{config.GITHUB_DOMAIN}",
@@ -76,7 +76,6 @@ class _Client(httpx.Client, common.HttpxHelpersMixin):
         response = self.get(url)
         if response.status_code == 200:
             return response.json()["id"]
-        response.raise_for_status()
 
 
 global _GITHUB_APP


### PR DESCRIPTION
The httpx mixin class was not working, this change also replace it by
classic inheritance.
