### PR TITLE
Pull request for httpx-testools-drop

### DIFF
--- a/mergify_engine/tests/functional/test_github_client.py
+++ b/mergify_engine/tests/functional/test_github_client.py
@@ -61,5 +61,7 @@ class TestGithubClient(base.FunctionalTestBase):
         pull = client.item("pulls/2")
         self.assertEqual(2, pull["number"])
 
-        e = self.assertRaises(httpx.HTTPError, client.item, "pulls/4")
-        self.assertEqual(404, e.response.status_code)
+        with self.assertRaises(httpx.HTTPError) as ctxt:
+            client.item("pulls/4")
+
+        self.assertEqual(404, ctxt.exception.response.status_code)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ celery==4.4.2
 certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
-Click==7.1.1
+click==7.1.1
 cryptography==2.8
 daiquiri==2.1.1
 datadog==0.35.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     cryptography
     pygithub>=1.43.8
     requests
-    redis
+    redis!=3.4.1!=3.4.0
     hiredis
     httpx
     pyyaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,9 +52,7 @@ test =
     pytest
     pytest-cov
     vcrpy>=1.12.0
-    fixture
     pifpaf
-    testtools
 docs =
     sphinx
 


### PR DESCRIPTION
## fix(tox): ensure genreqs don't update redis


## chore: drop unmaintained testtools and fixtures