### PR TITLE
chore: rename MergifyPull to MergifyContext

### DIFF
--- a/mergify_engine/actions/assign.py
+++ b/mergify_engine/actions/assign.py
@@ -25,13 +25,13 @@ class AssignAction(actions.Action):
 
     silent_report = True
 
-    def run(self, pull, sources, missing_conditions):
+    def run(self, ctxt, sources, missing_conditions):
         wanted = set(self.config["users"])
-        already = set((user["login"] for user in pull.data["assignees"]))
+        already = set((user["login"] for user in ctxt.pull["assignees"]))
         assignees = list(wanted - already)
         try:
-            pull.client.post(
-                f"issues/{pull.data['number']}/assignees",
+            ctxt.client.post(
+                f"issues/{ctxt.pull['number']}/assignees",
                 json={"assignees": assignees},
             )
         except httpx.HTTPClientSideError as e:  # pragma: no cover

--- a/mergify_engine/actions/backport.py
+++ b/mergify_engine/actions/backport.py
@@ -28,7 +28,7 @@ class BackportAction(copy.CopyAction):
     def command_to_config(string):
         return {"branches": string.split(" ")}
 
-    def run(self, pull, sources, missing_conditions):
-        if not pull.data["merged"]:
+    def run(self, ctxt, sources, missing_conditions):
+        if not ctxt.pull["merged"]:
             return None, "Waiting for the pull request to get merged", ""
-        return super().run(pull, sources, missing_conditions)
+        return super().run(ctxt, sources, missing_conditions)

--- a/mergify_engine/actions/close.py
+++ b/mergify_engine/actions/close.py
@@ -27,18 +27,18 @@ class CloseAction(actions.Action):
     only_once = True
     validator = {voluptuous.Required("message", default=MSG): str}
 
-    def run(self, pull, sources, missing_conditions):
-        if pull.data["state"] == "close":
+    def run(self, ctxt, sources, missing_conditions):
+        if ctxt.pull["state"] == "close":
             return ("success", "Pull request is already closed", "")
 
         try:
-            pull.client.patch(f"pulls/{pull.data['number']}", json={"state": "close"})
+            ctxt.client.patch(f"pulls/{ctxt.pull['number']}", json={"state": "close"})
         except httpx.HTTPClientSideError as e:  # pragma: no cover
             return ("failure", "Pull request can't be closed", e.message)
 
         try:
-            pull.client.post(
-                f"issues/{pull.data['number']}/comments",
+            ctxt.client.post(
+                f"issues/{ctxt.pull['number']}/comments",
                 json={"body": self.config["message"]},
             )
         except httpx.HTTPClientSideError as e:  # pragma: no cover

--- a/mergify_engine/actions/comment.py
+++ b/mergify_engine/actions/comment.py
@@ -26,9 +26,9 @@ class CommentAction(actions.Action):
 
     silent_report = True
 
-    def deprecated_double_comment_protection(self, pull):
+    def deprecated_double_comment_protection(self, ctxt):
         # TODO(sileht): drop this in 2 months (February 2020)
-        for comment in pull.client.items(f"issues/{pull.data['number']}/comments"):
+        for comment in ctxt.client.items(f"issues/{ctxt.pull['number']}/comments"):
             if (
                 comment["user"]["id"] == config.BOT_USER_ID
                 and comment["body"] == self.config["message"]
@@ -36,11 +36,11 @@ class CommentAction(actions.Action):
                 return True
         return False
 
-    def run(self, pull, sources, missing_conditions):
+    def run(self, ctxt, sources, missing_conditions):
         message = self.config["message"]
         try:
-            pull.client.post(
-                f"issues/{pull.data['number']}/comments", json={"body": message},
+            ctxt.client.post(
+                f"issues/{ctxt.pull['number']}/comments", json={"body": message},
             )
         except httpx.HTTPClientSideError as e:  # pragma: no cover
             return (

--- a/mergify_engine/actions/label.py
+++ b/mergify_engine/actions/label.py
@@ -32,32 +32,32 @@ class LabelAction(actions.Action):
 
     silent_report = True
 
-    def run(self, pull, sources, missing_conditions):
+    def run(self, ctxt, sources, missing_conditions):
         if self.config["add"]:
-            all_label = [l["name"] for l in pull.client.items("labels")]
+            all_label = [l["name"] for l in ctxt.client.items("labels")]
             for label in self.config["add"]:
                 if label not in all_label:
                     color = "%06x" % random.randrange(16 ** 6)
                     try:
-                        pull.client.post("labels", json={"name": label, "color": color})
+                        ctxt.client.post("labels", json={"name": label, "color": color})
                     except httpx.HTTPClientSideError:
                         continue
 
-            pull.client.post(
-                f"issues/{pull.data['number']}/labels",
+            ctxt.client.post(
+                f"issues/{ctxt.pull['number']}/labels",
                 json={"labels": self.config["add"]},
             )
 
         if self.config["remove_all"]:
-            pull.client.delete(f"issues/{pull.data['number']}/labels")
+            ctxt.client.delete(f"issues/{ctxt.pull['number']}/labels")
         elif self.config["remove"]:
-            pull_labels = [l["name"] for l in pull.data["labels"]]
+            pull_labels = [l["name"] for l in ctxt.pull["labels"]]
             for label in self.config["remove"]:
                 if label in pull_labels:
                     label_escaped = parse.quote(label, safe="")
                     try:
-                        pull.client.delete(
-                            f"issues/{pull.data['number']}/labels/{label_escaped}"
+                        ctxt.client.delete(
+                            f"issues/{ctxt.pull['number']}/labels/{label_escaped}"
                         )
                     except httpx.HTTPClientSideError:
                         continue

--- a/mergify_engine/actions/merge/helpers.py
+++ b/mergify_engine/actions/merge/helpers.py
@@ -16,9 +16,9 @@ from mergify_engine import branch_updater
 from mergify_engine.actions.merge import queue
 
 
-def merge_report(pull, strict):
-    if pull.data["merged"]:
-        if pull.data["merged_by"]["login"] in [
+def merge_report(ctxt, strict):
+    if ctxt.pull["merged"]:
+        if ctxt.pull["merged_by"]["login"] in [
             "mergify[bot]",
             "mergify-test[bot]",
         ]:
@@ -29,30 +29,30 @@ def merge_report(pull, strict):
         title = "The pull request has been merged %s" % mode
         summary = "The pull request has been merged %s at *%s*" % (
             mode,
-            pull.data["merge_commit_sha"],
+            ctxt.pull["merge_commit_sha"],
         )
-    elif pull.data["state"] == "closed":
+    elif ctxt.pull["state"] == "closed":
         conclusion = "cancelled"
         title = "The pull request has been closed manually"
         summary = ""
 
     # NOTE(sileht): Take care of all branch protection state
-    elif pull.data["mergeable_state"] == "dirty":
+    elif ctxt.pull["mergeable_state"] == "dirty":
         conclusion = "failure"
         title = "Merge conflict needs to be solved"
         summary = ""
-    elif pull.data["mergeable_state"] == "unknown":
+    elif ctxt.pull["mergeable_state"] == "unknown":
         conclusion = "failure"
         title = "Pull request state reported as `unknown` by GitHub"
         summary = ""
     # FIXME(sileht): We disable this check as github wrongly report
     # mergeable_state == blocked sometimes. The workaround is to try to merge
     # it and if that fail we checks for blocking state.
-    # elif pull.data["mergeable_state"] == "blocked":
+    # elif ctxt.pull["mergeable_state"] == "blocked":
     #     conclusion = "failure"
     #     title = "Branch protection settings are blocking automatic merging"
     #     summary = ""
-    elif pull.data["mergeable_state"] == "behind" and not strict:
+    elif ctxt.pull["mergeable_state"] == "behind" and not strict:
         # Strict mode has been enabled in branch protection but not in
         # mergify
         conclusion = "failure"

--- a/mergify_engine/actions/merge/queue.py
+++ b/mergify_engine/actions/merge/queue.py
@@ -16,7 +16,7 @@ import daiquiri
 
 from mergify_engine import check_api
 from mergify_engine import exceptions
-from mergify_engine import mergify_pull
+from mergify_engine import mergify_context
 from mergify_engine import utils
 from mergify_engine.actions.merge import helpers
 from mergify_engine.clients import github
@@ -33,59 +33,59 @@ def get_queue_logger(queue):
     )
 
 
-def _get_queue_cache_key(pull, base_ref=None):
+def _get_queue_cache_key(ctxt, base_ref=None):
     return "strict-merge-queues~%s~%s~%s~%s" % (
-        pull.installation_id,
-        pull.data["base"]["repo"]["owner"]["login"].lower(),
-        pull.data["base"]["repo"]["name"].lower(),
-        base_ref or pull.data["base"]["ref"],
+        ctxt.installation_id,
+        ctxt.pull["base"]["repo"]["owner"]["login"].lower(),
+        ctxt.pull["base"]["repo"]["name"].lower(),
+        base_ref or ctxt.pull["base"]["ref"],
     )
 
 
-def _get_update_method_cache_key(pull):
+def _get_update_method_cache_key(ctxt):
     return "strict-merge-method~%s~%s~%s~%s" % (
-        pull.installation_id,
-        pull.data["base"]["repo"]["owner"]["login"].lower(),
-        pull.data["base"]["repo"]["name"].lower(),
-        pull.data["number"],
+        ctxt.installation_id,
+        ctxt.pull["base"]["repo"]["owner"]["login"].lower(),
+        ctxt.pull["base"]["repo"]["name"].lower(),
+        ctxt.pull["number"],
     )
 
 
-def add_pull(pull, method):
-    queue = _get_queue_cache_key(pull)
+def add_pull(ctxt, method):
+    queue = _get_queue_cache_key(ctxt)
     redis = utils.get_redis_for_cache()
     score = utils.utcnow().timestamp()
-    redis.zadd(queue, {pull.data["number"]: score}, nx=True)
-    redis.set(_get_update_method_cache_key(pull), method)
-    pull.log.debug("pull request added to merge queue", queue=queue)
+    redis.zadd(queue, {ctxt.pull["number"]: score}, nx=True)
+    redis.set(_get_update_method_cache_key(ctxt), method)
+    ctxt.log.debug("pull request added to merge queue", queue=queue)
 
 
-def remove_pull(pull):
+def remove_pull(ctxt):
     redis = utils.get_redis_for_cache()
-    queue = _get_queue_cache_key(pull)
-    redis.zrem(queue, pull.data["number"])
-    redis.delete(_get_update_method_cache_key(pull))
-    pull.log.debug("pull request removed from merge queue", queue=queue)
+    queue = _get_queue_cache_key(ctxt)
+    redis.zrem(queue, ctxt.pull["number"])
+    redis.delete(_get_update_method_cache_key(ctxt))
+    ctxt.log.debug("pull request removed from merge queue", queue=queue)
 
 
-def _move_pull_at_end(pull):  # pragma: no cover
+def _move_pull_at_end(ctxt):  # pragma: no cover
     redis = utils.get_redis_for_cache()
-    queue = _get_queue_cache_key(pull)
+    queue = _get_queue_cache_key(ctxt)
     score = utils.utcnow().timestamp()
-    redis.zadd(queue, {pull.data["number"]: score}, xx=True)
-    pull.log.debug(
+    redis.zadd(queue, {ctxt.pull["number"]: score}, xx=True)
+    ctxt.log.debug(
         "pull request moved at the end of the merge queue", queue=queue,
     )
 
 
-def _move_pull_to_new_base_branch(pull, old_base_branch):
+def _move_pull_to_new_base_branch(ctxt, old_base_branch):
     redis = utils.get_redis_for_cache()
-    old_queue = _get_queue_cache_key(pull, old_base_branch)
-    new_queue = _get_queue_cache_key(pull)
-    redis.zrem(old_queue, pull.data["number"])
-    method = redis.get(_get_update_method_cache_key(pull)) or "merge"
-    add_pull(pull, method)
-    pull.log.debug("pull request moved from %s to %s", old_queue, new_queue)
+    old_queue = _get_queue_cache_key(ctxt, old_base_branch)
+    new_queue = _get_queue_cache_key(ctxt)
+    redis.zrem(old_queue, ctxt.pull["number"])
+    method = redis.get(_get_update_method_cache_key(ctxt)) or "merge"
+    add_pull(ctxt, method)
+    ctxt.log.debug("pull request moved from %s to %s", old_queue, new_queue)
 
 
 def _get_pulls(queue):
@@ -93,8 +93,8 @@ def _get_pulls(queue):
     return redis.zrange(queue, 0, -1)
 
 
-def get_pulls_from_queue(pull):
-    queue = _get_queue_cache_key(pull)
+def get_pulls_from_queue(ctxt):
+    queue = _get_queue_cache_key(ctxt)
     return _get_pulls(queue)
 
 
@@ -115,49 +115,49 @@ def _get_next_pull_request(queue, queue_log):
             _delete_queue(queue)
             return
         data = client.item(f"pulls/{pull_number}")
-        return mergify_pull.MergifyPull(client, data)
+        return mergify_context.MergifyContext(client, data)
 
 
-def _handle_first_pull_in_queue(queue, pull):
+def _handle_first_pull_in_queue(queue, ctxt):
     _, installation_id, owner, reponame, branch = queue.split("~")
     old_checks = [
         c
-        for c in check_api.get_checks(pull, mergify_only=True)
+        for c in check_api.get_checks(ctxt, mergify_only=True)
         if c["name"].endswith(" (merge)")
     ]
 
-    output = helpers.merge_report(pull, True)
+    output = helpers.merge_report(ctxt, True)
     if output:
         conclusion, title, summary = output
-        pull.log.debug(
+        ctxt.log.debug(
             "pull request closed in the meantime",
             conclusion=conclusion,
             title=title,
             summary=summary,
         )
-        remove_pull(pull)
+        remove_pull(ctxt)
     else:
-        pull.log.debug("updating base branch of pull request")
+        ctxt.log.debug("updating base branch of pull request")
         redis = utils.get_redis_for_cache()
-        method = redis.get(_get_update_method_cache_key(pull)) or "merge"
-        conclusion, title, summary = helpers.update_pull_base_branch(pull, method)
+        method = redis.get(_get_update_method_cache_key(ctxt)) or "merge"
+        conclusion, title, summary = helpers.update_pull_base_branch(ctxt, method)
 
-        if pull.data["state"] == "closed":
-            pull.log.debug(
+        if ctxt.pull["state"] == "closed":
+            ctxt.log.debug(
                 "pull request closed in the meantime",
                 conclusion=conclusion,
                 title=title,
                 summary=summary,
             )
-            remove_pull(pull)
+            remove_pull(ctxt)
         elif conclusion == "failure":
-            pull.log.debug("base branch update failed", title=title, summary=summary)
-            _move_pull_at_end(pull)
+            ctxt.log.debug("base branch update failed", title=title, summary=summary)
+            _move_pull_at_end(ctxt)
 
     status = "completed" if conclusion else "in_progress"
     for c in old_checks:
         check_api.set_check_run(
-            pull,
+            ctxt,
             c["name"],
             status,
             conclusion,
@@ -178,44 +178,44 @@ def smart_strict_workflow_periodic_task():
         queue_log = get_queue_logger(queue)
         queue_log.debug("handling queue: %s", queue)
 
-        pull = None
+        ctxt = None
         try:
-            pull = _get_next_pull_request(queue, queue_log)
-            if not pull:
+            ctxt = _get_next_pull_request(queue, queue_log)
+            if not ctxt:
                 queue_log.debug("no pull request for this queue")
-            elif pull.data["base"]["ref"] != queue_base_branch:
-                pull.log.debug(
+            elif ctxt.pull["base"]["ref"] != queue_base_branch:
+                ctxt.log.debug(
                     "pull request base branch have changed",
                     old_branch=queue_base_branch,
-                    new_branch=pull.data["base"]["ref"],
+                    new_branch=ctxt.pull["base"]["ref"],
                 )
-                _move_pull_to_new_base_branch(pull, queue_base_branch)
-            elif pull.data["state"] == "closed" or pull.is_behind:
+                _move_pull_to_new_base_branch(ctxt, queue_base_branch)
+            elif ctxt.pull["state"] == "closed" or ctxt.is_behind:
                 # NOTE(sileht): Pick up this pull request and rebase it again
                 # or update its status and remove it from the queue
-                pull.log.debug(
+                ctxt.log.debug(
                     "pull request needs to be updated again or has been closed",
                 )
-                _handle_first_pull_in_queue(queue, pull)
+                _handle_first_pull_in_queue(queue, ctxt)
             else:
                 # NOTE(sileht): Pull request has not been merged or cancelled
                 # yet wait next loop
-                pull.log.debug("pull request checks are still in progress")
+                ctxt.log.debug("pull request checks are still in progress")
 
         except exceptions.RateLimited as e:
-            log = pull.log if pull else queue_log
+            log = ctxt.log if ctxt else queue_log
             log.info("rate limited", remaining_seconds=e.countdown)
         except exceptions.MergeableStateUnknown as e:  # pragma: no cover
-            e.pull.log.warning(
+            e.ctxt.log.warning(
                 "pull request with mergeable_state unknown retrying later",
             )
-            _move_pull_at_end(e.pull)
+            _move_pull_at_end(e.ctxt)
         except Exception:  # pragma: no cover
-            log = pull.log if pull else queue_log
+            log = ctxt.log if ctxt else queue_log
             log.error(
                 "Fail to process merge queue", exc_info=True,
             )
-            if pull:
-                _move_pull_at_end(pull)
+            if ctxt:
+                _move_pull_at_end(ctxt)
 
     LOG.debug("smart strict workflow loop end")

--- a/mergify_engine/actions/refresh.py
+++ b/mergify_engine/actions/refresh.py
@@ -23,12 +23,12 @@ class RefreshAction(actions.Action):
     is_action = False
     validator = {}
 
-    def run(self, pull, sources, missing_conditions):
+    def run(self, ctxt, sources, missing_conditions):
         data = {
             "action": "user",
-            "repository": pull.data["base"]["repo"],
-            "installation": {"id": pull.client.installation_id},
-            "pull_request": pull.data,
+            "repository": ctxt.pull["base"]["repo"],
+            "installation": {"id": ctxt.client.installation_id},
+            "pull_request": ctxt.pull,
             "sender": {"login": "<internal>"},
         }
         github_events.job_filter_and_dispatch.s(

--- a/mergify_engine/actions/request_reviews.py
+++ b/mergify_engine/actions/request_reviews.py
@@ -14,10 +14,10 @@ class RequestReviewsAction(actions.Action):
 
     silent_report = True
 
-    def run(self, pull, sources, missing_conditions):
+    def run(self, ctxt, sources, missing_conditions):
 
         # Using consolidated data to avoid already done API lookup
-        data = pull.to_dict()
+        data = ctxt.to_dict()
         reviews_keys = (
             "approved-reviews-by",
             "dismissed-reviews-by",
@@ -29,7 +29,7 @@ class RequestReviewsAction(actions.Action):
         user_reviews_to_request = (
             set(self.config["users"])
             - existing_reviews
-            - set((pull.data["user"]["login"],))
+            - set((ctxt.pull["user"]["login"],))
         )
         team_reviews_to_request = set(self.config["teams"]).difference(
             # Team starts with @
@@ -37,8 +37,8 @@ class RequestReviewsAction(actions.Action):
         )
         if user_reviews_to_request or team_reviews_to_request:
             try:
-                pull.client.post(
-                    f"pulls/{pull.data['number']}/requested_reviewers",
+                ctxt.client.post(
+                    f"pulls/{ctxt.pull['number']}/requested_reviewers",
                     json={
                         "reviewers": list(user_reviews_to_request),
                         "team_reviewers": list(team_reviews_to_request),

--- a/mergify_engine/actions/review.py
+++ b/mergify_engine/actions/review.py
@@ -37,7 +37,7 @@ class ReviewAction(actions.Action):
 
     silent_report = True
 
-    def run(self, pull, sources, missing_conditions):
+    def run(self, ctxt, sources, missing_conditions):
         payload = {"event": self.config["type"]}
         body = self.config["message"]
         if not body and self.config["type"] != "APPROVE":
@@ -53,7 +53,7 @@ class ReviewAction(actions.Action):
         reviews = reversed(
             list(
                 filter(
-                    lambda r: r["user"]["id"] is not config.BOT_USER_ID, pull.reviews
+                    lambda r: r["user"]["id"] is not config.BOT_USER_ID, ctxt.reviews
                 )
             )
         )
@@ -77,6 +77,6 @@ class ReviewAction(actions.Action):
             ):
                 break
 
-        pull.client.post(f"pulls/{pull.data['number']}/reviews", json=payload)
+        ctxt.client.post(f"pulls/{ctxt.pull['number']}/reviews", json=payload)
 
         return ("success", "Review posted", "")

--- a/mergify_engine/exceptions.py
+++ b/mergify_engine/exceptions.py
@@ -26,8 +26,8 @@ class RateLimited(Exception):
 
 
 class MergeableStateUnknown(Exception):
-    def __init__(self, pull):
-        self.pull = pull
+    def __init__(self, ctxt):
+        self.ctxt = ctxt
 
 
 RATE_LIMIT_RETRY_MIN = 3

--- a/mergify_engine/rules/__init__.py
+++ b/mergify_engine/rules/__init__.py
@@ -208,13 +208,13 @@ class InvalidRules(Exception):
 MERGIFY_CONFIG_FILENAMES = (".mergify.yml", ".mergify/config.yml")
 
 
-def get_mergify_config_content(pull, ref=None):
+def get_mergify_config_content(ctxt, ref=None):
     kwargs = {}
     if ref:
         kwargs["ref"] = ref
     for filename in MERGIFY_CONFIG_FILENAMES:
         try:
-            content = pull.client.item(f"contents/{filename}", **kwargs)["content"]
+            content = ctxt.client.item(f"contents/{filename}", **kwargs)["content"]
             return base64.b64decode(bytearray(content, "utf-8"))
         except httpx.HTTPNotFound:
             continue

--- a/mergify_engine/tests/functional/base.py
+++ b/mergify_engine/tests/functional/base.py
@@ -37,7 +37,7 @@ import vcr
 from mergify_engine import branch_updater
 from mergify_engine import config
 from mergify_engine import duplicate_pull
-from mergify_engine import mergify_pull
+from mergify_engine import mergify_context
 from mergify_engine import sub_utils
 from mergify_engine import utils
 from mergify_engine import web
@@ -316,7 +316,7 @@ class FunctionalTestBase(unittest.TestCase):
         if not RECORD:
             # NOTE(sileht): Don't wait exponentialy during replay
             mock.patch.object(
-                mergify_pull.MergifyPull._ensure_complete.retry, "wait", None
+                mergify_context.MergifyContext._ensure_complete.retry, "wait", None
             ).start()
 
         # Web authentification always pass

--- a/mergify_engine/tests/functional/test_engine.py
+++ b/mergify_engine/tests/functional/test_engine.py
@@ -23,7 +23,7 @@ import yaml
 from mergify_engine import check_api
 from mergify_engine import config
 from mergify_engine import debug
-from mergify_engine import mergify_pull
+from mergify_engine import mergify_context
 from mergify_engine.clients import github
 from mergify_engine.tasks import engine
 from mergify_engine.tests.functional import base
@@ -73,7 +73,7 @@ class TestEngineV2Scenario(base.FunctionalTestBase):
         p.remove_from_labels("backport-3.1")
         self.wait_for("pull_request", {"action": "unlabeled"})
 
-        pull = mergify_pull.MergifyPull(self.cli_integration, p.raw_data)
+        pull = mergify_context.MergifyContext(self.cli_integration, p.raw_data)
         checks = list(
             check_api.get_checks(pull, check_name="Rule: backport (backport)")
         )
@@ -352,7 +352,7 @@ class TestEngineV2Scenario(base.FunctionalTestBase):
         self.assertEqual("WTF?", comments[-1].body)
 
         # Override Summary with the old format
-        pull = mergify_pull.MergifyPull(self.cli_integration, p.raw_data)
+        pull = mergify_context.MergifyContext(self.cli_integration, p.raw_data)
         check_api.set_check_run(
             pull,
             "Summary",
@@ -483,7 +483,7 @@ class TestEngineV2Scenario(base.FunctionalTestBase):
         self.add_label(p, "backport-#3.1")
         self.wait_for("pull_request", {"action": "closed"})
 
-        pull = mergify_pull.MergifyPull(self.cli_integration, p.raw_data)
+        pull = mergify_context.MergifyContext(self.cli_integration, p.raw_data)
         checks = list(
             check_api.get_checks(pull, check_name="Rule: Backport (backport)")
         )
@@ -531,7 +531,7 @@ class TestEngineV2Scenario(base.FunctionalTestBase):
         self.add_label(p, "backport-#3.1")
         self.wait_for("pull_request", {"action": "closed"})
 
-        pull = mergify_pull.MergifyPull(self.cli_integration, p.raw_data)
+        pull = mergify_context.MergifyContext(self.cli_integration, p.raw_data)
         return list(
             check_api.get_checks(
                 pull, check_name="Rule: Backport to stable/#3.1 (backport)"
@@ -624,7 +624,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
         bp_pull = pulls[0]
         assert bp_pull.title == "Pull request n1 from fork (bp #1)"
 
-        pull = mergify_pull.MergifyPull(self.cli_integration, p.raw_data)
+        pull = mergify_context.MergifyContext(self.cli_integration, p.raw_data)
         checks = list(
             check_api.get_checks(
                 pull, check_name="Rule: Backport to stable/#3.1 (backport)"
@@ -872,7 +872,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
             "Merge branch 'master' into fork/pr2", commits2[-1].commit.message
         )
 
-        pull = mergify_pull.MergifyPull(self.cli_integration, p2.raw_data)
+        pull = mergify_context.MergifyContext(self.cli_integration, p2.raw_data)
         checks = list(check_api.get_checks(pull))
         for check in checks:
             if check["name"] == "Rule: strict merge on master (merge)":
@@ -982,7 +982,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
         client = github.get_client(
             p.base.user.login, p.base.repo.name, config.INSTALLATION_ID
         )
-        pull = mergify_pull.MergifyPull(client, p.raw_data)
+        pull = mergify_context.MergifyContext(client, p.raw_data)
 
         logins = pull.resolve_teams(
             ["user", "@testing", "@unknown/team", "@invalid/team/break-here"]
@@ -1021,7 +1021,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
         client = github.get_client(
             p.base.user.login, p.base.repo.name, config.INSTALLATION_ID
         )
-        pull = mergify_pull.MergifyPull(client, p.raw_data)
+        pull = mergify_context.MergifyContext(client, p.raw_data)
 
         logins = pull.resolve_teams(
             [
@@ -1073,7 +1073,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
         commit = self.r_o_admin.get_commits()[0].commit
         self.assertEqual(msg, commit.message)
 
-        pull = mergify_pull.MergifyPull(self.cli_integration, p.raw_data)
+        pull = mergify_context.MergifyContext(self.cli_integration, p.raw_data)
         checks = list(check_api.get_checks(pull))
         assert len(checks) == 2
         for check in checks:
@@ -1193,7 +1193,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
             "check_run", {"check_run": {"conclusion": None, "status": "in_progress"}},
         )
 
-        pull = mergify_pull.MergifyPull(self.cli_integration, p.raw_data)
+        pull = mergify_context.MergifyContext(self.cli_integration, p.raw_data)
         checks = list(check_api.get_checks(pull, check_name="Rule: merge (merge)"))
         self.assertEqual(None, checks[0]["conclusion"])
         self.assertEqual("in_progress", checks[0]["status"])
@@ -1253,7 +1253,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
 
         self.wait_for("check_run", {"check_run": {"conclusion": "failure"}})
 
-        pull = mergify_pull.MergifyPull(self.cli_integration, p2.raw_data)
+        pull = mergify_context.MergifyContext(self.cli_integration, p2.raw_data)
         checks = list(check_api.get_checks(pull, check_name="Rule: merge (merge)"))
         self.assertEqual("failure", checks[0]["conclusion"])
         self.assertIn(
@@ -1326,7 +1326,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
         self.setup_repo(yaml.dump(rules))
         p, commits = self.create_pr()
 
-        pull = mergify_pull.MergifyPull(self.cli_integration, p.raw_data)
+        pull = mergify_context.MergifyContext(self.cli_integration, p.raw_data)
         check_api.set_check_run(
             pull,
             "Summary",
@@ -1388,7 +1388,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
             {"name": "foobar", "conditions": ["label!=wip"], "actions": {"merge": {}}}
         )
         p1, commits1 = self.create_pr(files={".mergify.yml": yaml.dump(rules)})
-        pull = mergify_pull.MergifyPull(self.cli_integration, p1.raw_data)
+        pull = mergify_context.MergifyContext(self.cli_integration, p1.raw_data)
         checks = list(check_api.get_checks(pull))
         assert len(checks) == 1
         assert checks[0]["name"] == "Summary"
@@ -1566,7 +1566,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
         }
         self.setup_repo(yaml.dump(rules))
         pr, commits = self.create_pr()
-        pull = mergify_pull.MergifyPull(self.cli_integration, pr.raw_data)
+        pull = mergify_context.MergifyContext(self.cli_integration, pr.raw_data)
         check = check_api.set_check_run(
             pull,
             "Test",
@@ -1585,7 +1585,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
         client = github.get_client(
             p.base.user.login, p.base.repo.name, config.INSTALLATION_ID
         )
-        pull = mergify_pull.MergifyPull(client, {"number": 1})
-        self.assertEqual(1, pull.data["number"])
-        self.assertEqual("open", pull.data["state"])
-        self.assertEqual("clean", pull.data["mergeable_state"])
+        ctxt = mergify_context.MergifyContext(client, {"number": 1})
+        self.assertEqual(1, ctxt.pull["number"])
+        self.assertEqual("open", ctxt.pull["state"])
+        self.assertEqual("clean", ctxt.pull["mergeable_state"])

--- a/mergify_engine/tests/unit/test_behind.py
+++ b/mergify_engine/tests/unit/test_behind.py
@@ -18,7 +18,7 @@ from unittest import mock
 
 import pytest
 
-from mergify_engine import mergify_pull
+from mergify_engine import mergify_context
 
 
 def create_commit(sha=None):
@@ -59,9 +59,9 @@ def test_pull_behind(commits_tree_generator):
     client.items.return_value = commits  # /pulls/X/commits
     client.item.return_value = {"commit": {"sha": "base"}}  # /branch/#foo
 
-    pull = mergify_pull.MergifyPull(
+    ctxt = mergify_context.MergifyContext(
         client,
-        data={
+        pull={
             "number": 1,
             "mergeable_state": "clean",
             "state": "open",
@@ -72,4 +72,4 @@ def test_pull_behind(commits_tree_generator):
         },
     )
 
-    assert expected == pull.is_behind
+    assert expected == ctxt.is_behind

--- a/mergify_engine/tests/unit/test_duplicate.py
+++ b/mergify_engine/tests/unit/test_duplicate.py
@@ -16,7 +16,7 @@
 from unittest import mock
 
 from mergify_engine import duplicate_pull
-from mergify_engine import mergify_pull
+from mergify_engine import mergify_context
 
 
 def fake_get_github_pulls_from_sha(url, api_version=None):
@@ -40,7 +40,8 @@ def fake_get_github_pulls_from_sha(url, api_version=None):
 
 
 @mock.patch(
-    "mergify_engine.mergify_pull.MergifyPull.commits", new_callable=mock.PropertyMock
+    "mergify_engine.mergify_context.MergifyContext.commits",
+    new_callable=mock.PropertyMock,
 )
 def test_get_commits_to_cherry_pick_rebase(commits):
     c1 = {"sha": "c1f", "parents": [], "commit": {"message": "foobar"}}
@@ -51,7 +52,7 @@ def test_get_commits_to_cherry_pick_rebase(commits):
     client.auth.get_access_token.return_value = "<token>"
     client.items.side_effect = fake_get_github_pulls_from_sha
 
-    pull = mergify_pull.MergifyPull(
+    ctxt = mergify_context.MergifyContext(
         client,
         {
             "number": 6,
@@ -77,14 +78,15 @@ def test_get_commits_to_cherry_pick_rebase(commits):
     rebased_c1 = {"sha": "rebased_c1", "parents": [base_branch]}
     rebased_c2 = {"sha": "rebased_c2", "parents": [rebased_c1]}
 
-    assert duplicate_pull._get_commits_to_cherrypick(pull, rebased_c2) == [
+    assert duplicate_pull._get_commits_to_cherrypick(ctxt, rebased_c2) == [
         rebased_c1,
         rebased_c2,
     ]
 
 
 @mock.patch(
-    "mergify_engine.mergify_pull.MergifyPull.commits", new_callable=mock.PropertyMock
+    "mergify_engine.mergify_context.MergifyContext.commits",
+    new_callable=mock.PropertyMock,
 )
 def test_get_commits_to_cherry_pick_merge(commits):
     c1 = {"sha": "c1f", "parents": [], "commit": {"message": "foobar"}}
@@ -94,7 +96,7 @@ def test_get_commits_to_cherry_pick_merge(commits):
     client = mock.Mock()
     client.auth.get_access_token.return_value = "<token>"
 
-    pull = mergify_pull.MergifyPull(
+    ctxt = mergify_context.MergifyContext(
         client,
         {
             "number": 6,
@@ -119,4 +121,4 @@ def test_get_commits_to_cherry_pick_merge(commits):
     base_branch = {"sha": "base_branch", "parents": []}
     merge_commit = {"sha": "merge_commit", "parents": [base_branch, c2]}
 
-    assert duplicate_pull._get_commits_to_cherrypick(pull, merge_commit) == [c1, c2]
+    assert duplicate_pull._get_commits_to_cherrypick(ctxt, merge_commit) == [c1, c2]


### PR DESCRIPTION
This avoid confusion between `pull["number"]` and sometimes
`pull.data["number"]`.

Now we have `pull["number"]` and `ctxt.pull["number"]`