### PR TITLE
fix: take more times before refreshing all PRs

### DIFF
--- a/mergify_engine/tasks/github_events.py
+++ b/mergify_engine/tasks/github_events.py
@@ -183,7 +183,7 @@ def job_filter_and_dispatch(event_type, event_id, data):
         branch = data["ref"][11:]
         msg_action = "run refresh branch %s" % branch
         mergify_events.job_refresh.s(owner, repo, "branch", branch).apply_async(
-            countdown=10
+            countdown=60
         )
     else:
         engine.run.s(event_type, data).apply_async()


### PR DESCRIPTION
When something is merged in a branch, all `mergeable_state` of all opened
PRs of this branch become `unknown` it takes some times for Github to
reevalute them.

This changes the delay before refreshing all opened PRs on our sides.
To avoid many retry due to all mergeable_state being "unknown", just
after a "push" events.