### PR TITLE
fix(tasks): run even if no token are available

### DIFF
--- a/mergify_engine/tasks/github_events.py
+++ b/mergify_engine/tasks/github_events.py
@@ -88,9 +88,6 @@ def get_ignore_reason(installation, subscription, event_type, data):
     if not installation:
         return "ignored (no installation id)"
 
-    elif not subscription["tokens"]:
-        return "ignored (no token)"
-
     elif event_type in ["installation", "installation_repositories"]:
         return "ignored (action %s)" % data["action"]
 


### PR DESCRIPTION
Tokens are only needed in one corner case, worst thing, we can run without
them.