### PR TITLE
fix(queue): always use queue logger on rate limit

### DIFF
--- a/mergify_engine/actions/merge/queue.py
+++ b/mergify_engine/actions/merge/queue.py
@@ -189,8 +189,7 @@ def process_queue(queue):
         try:
             ctxt = context.Context(client, data, subscription)
         except exceptions.RateLimited as e:
-            log = ctxt.log if ctxt else queue_log
-            log.debug("rate limited", remaining_seconds=e.countdown)
+            queue_log.debug("rate limited", remaining_seconds=e.countdown)
             return
         except exceptions.MergeableStateUnknown as e:  # pragma: no cover
             e.ctxt.log.warning(


### PR DESCRIPTION
If a RateLimited error is raised, `ctxt` is undefined so that code should fail.