### PR TITLE
feat: don't return the engine, if mandatory perm are missing

### DIFF
--- a/mergify_engine/clients/github_app.py
+++ b/mergify_engine/clients/github_app.py
@@ -124,7 +124,8 @@ class _Client(http.Client):
                 installation["permissions_need_to_be_updated"] = True
                 # FIXME(sileht): Looks like ton of people have not all permissions
                 # Or this is buggy, so disable it for now.
-                # raise exceptions.MergifyNotInstalled()
+                if perm_name in ["checks", "pull_requests", "contents"]:
+                    raise exceptions.MergifyNotInstalled()
 
         return installation
 

--- a/mergify_engine/tests/unit/test_clients.py
+++ b/mergify_engine/tests/unit/test_clients.py
@@ -28,7 +28,15 @@ def test_client_401_raise_ratelimit(httpserver):
     repo = "repo"
 
     httpserver.expect_request("/repos/owner/repo/installation").respond_with_json(
-        {"id": 12345, "target_type": "User", "permissions": {}}
+        {
+            "id": 12345,
+            "target_type": "User",
+            "permissions": {
+                "checks": "write",
+                "contents": "write",
+                "pull_requests": "write",
+            },
+        }
     )
     httpserver.expect_request(
         "/app/installations/12345/access_tokens"


### PR DESCRIPTION
This permissions are mandatory to allow Mergify to report that other are
missing. So just do nothing in such case.
