### PR TITLE
fix: create a memory cache of temporary access token

### DIFF
--- a/mergify_engine/tests/functional/base.py
+++ b/mergify_engine/tests/functional/base.py
@@ -366,6 +366,8 @@ class FunctionalTestBase(unittest.TestCase):
                 },
             ).start()
 
+        github.CachedToken.STORAGE = {}
+
         github_app_client = github_app._Client()
 
         mock.patch.object(github_app, "get_client", lambda: github_app_client).start()


### PR DESCRIPTION
retrieving too many token cause Github to return 401 after a while.

This change creates a memory cache of them to avoid that.
