### PR TITLE
fix: add python-multipart dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ PyJWT==1.7.1
 pyparsing==2.4.7
 python-dotenv==0.13.0
 python-json-logger==0.1.11
+python-multipart==0.0.5
 pytz==2020.1
 PyYAML==5.3.1
 redis==3.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ install_requires =
     datadog
     python-dotenv
     fastapi
+    python-multipart  # fastapi extra
     uvicorn
     celery[redis,gevent]
     setproctitle


### PR DESCRIPTION
python-multipart is now optional dependency of fastapi.

Fixes MERGIFY-ENGINE-1KK