### PR TITLE
fix(httpx): exception handling have changed

### DIFF
--- a/mergify_engine/actions/assign.py
+++ b/mergify_engine/actions/assign.py
@@ -14,11 +14,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import httpx
 import voluptuous
 
 from mergify_engine import actions
 from mergify_engine import context
+from mergify_engine.clients import http
 from mergify_engine.rules import types
 
 
@@ -46,7 +46,7 @@ class AssignAction(actions.Action):
                     f"issues/{ctxt.pull['number']}/assignees",
                     json={"assignees": assignees},
                 )
-            except httpx.HTTPClientSideError as e:  # pragma: no cover
+            except http.HTTPClientSideError as e:  # pragma: no cover
                 return (
                     None,
                     "Unable to add assignees",

--- a/mergify_engine/actions/close.py
+++ b/mergify_engine/actions/close.py
@@ -14,11 +14,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import httpx
 import voluptuous
 
 from mergify_engine import actions
 from mergify_engine import context
+from mergify_engine.clients import http
 from mergify_engine.rules import types
 
 
@@ -35,7 +35,7 @@ class CloseAction(actions.Action):
 
         try:
             ctxt.client.patch(f"pulls/{ctxt.pull['number']}", json={"state": "close"})
-        except httpx.HTTPClientSideError as e:  # pragma: no cover
+        except http.HTTPClientSideError as e:  # pragma: no cover
             return ("failure", "Pull request can't be closed", e.message)
 
         try:
@@ -51,7 +51,7 @@ class CloseAction(actions.Action):
             ctxt.client.post(
                 f"issues/{ctxt.pull['number']}/comments", json={"body": message},
             )
-        except httpx.HTTPClientSideError as e:  # pragma: no cover
+        except http.HTTPClientSideError as e:  # pragma: no cover
             return ("failure", "The close message can't be created", e.message)
 
         return ("success", "The pull request has been closed", message)

--- a/mergify_engine/actions/comment.py
+++ b/mergify_engine/actions/comment.py
@@ -14,11 +14,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import httpx
 import voluptuous
 
 from mergify_engine import actions
 from mergify_engine import context
+from mergify_engine.clients import http
 from mergify_engine.rules import types
 
 
@@ -41,7 +41,7 @@ class CommentAction(actions.Action):
             ctxt.client.post(
                 f"issues/{ctxt.pull['number']}/comments", json={"body": message},
             )
-        except httpx.HTTPClientSideError as e:  # pragma: no cover
+        except http.HTTPClientSideError as e:  # pragma: no cover
             return (
                 None,
                 "Unable to post comment",

--- a/mergify_engine/actions/copy.py
+++ b/mergify_engine/actions/copy.py
@@ -17,11 +17,11 @@
 import re
 from urllib import parse
 
-import httpx
 import voluptuous
 
 from mergify_engine import actions
 from mergify_engine import duplicate_pull
+from mergify_engine.clients import http
 
 
 def Regex(value):
@@ -54,7 +54,7 @@ class CopyAction(actions.Action):
         escaped_branch_name = parse.quote(branch_name, safe="")
         try:
             ctxt.client.item(f"branches/{escaped_branch_name}")
-        except httpx.HTTPError as e:
+        except http.HTTPError as e:
             if not e.response:
                 raise
             detail = "%s to branch `%s` failed: " % (

--- a/mergify_engine/actions/delete_head_branch.py
+++ b/mergify_engine/actions/delete_head_branch.py
@@ -16,10 +16,10 @@
 
 from urllib import parse
 
-import httpx
 import voluptuous
 
 from mergify_engine import actions
+from mergify_engine.clients import http
 
 
 class DeleteHeadBranchAction(actions.Action):
@@ -53,7 +53,7 @@ class DeleteHeadBranchAction(actions.Action):
             ref_to_delete = parse.quote(ctxt.pull["head"]["ref"], safe="")
             try:
                 ctxt.client.delete(f"git/refs/heads/{ref_to_delete}")
-            except httpx.HTTPClientSideError as e:
+            except http.HTTPClientSideError as e:
                 if e.status_code not in [422, 404]:
                     return (
                         "failure",

--- a/mergify_engine/actions/dismiss_reviews.py
+++ b/mergify_engine/actions/dismiss_reviews.py
@@ -14,13 +14,13 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import httpx
 import voluptuous
 
 from mergify_engine import actions
 from mergify_engine import config
 from mergify_engine import context
 from mergify_engine import utils
+from mergify_engine.clients import http
 from mergify_engine.rules import types
 
 
@@ -81,7 +81,7 @@ class DismissReviewsAction(actions.Action):
                             f"pulls/{ctxt.pull['number']}/reviews/{review['id']}/dismissals",
                             json={"message": message},
                         )
-                    except httpx.HTTPClientSideError as e:  # pragma: no cover
+                    except http.HTTPClientSideError as e:  # pragma: no cover
                         errors.add(f"GitHub error: [{e.status_code}] `{e.message}`")
 
             if errors:

--- a/mergify_engine/actions/label.py
+++ b/mergify_engine/actions/label.py
@@ -17,10 +17,10 @@
 import random
 from urllib import parse
 
-import httpx
 import voluptuous
 
 from mergify_engine import actions
+from mergify_engine.clients import http
 
 
 class LabelAction(actions.Action):
@@ -40,7 +40,7 @@ class LabelAction(actions.Action):
                     color = "%06x" % random.randrange(16 ** 6)
                     try:
                         ctxt.client.post("labels", json={"name": label, "color": color})
-                    except httpx.HTTPClientSideError:
+                    except http.HTTPClientSideError:
                         continue
 
             ctxt.client.post(
@@ -59,7 +59,7 @@ class LabelAction(actions.Action):
                         ctxt.client.delete(
                             f"issues/{ctxt.pull['number']}/labels/{label_escaped}"
                         )
-                    except httpx.HTTPClientSideError:
+                    except http.HTTPClientSideError:
                         continue
 
         return ("success", "Labels added/removed", "")

--- a/mergify_engine/actions/merge/action.py
+++ b/mergify_engine/actions/merge/action.py
@@ -18,13 +18,13 @@ import itertools
 import re
 
 import daiquiri
-import httpx
 import voluptuous
 
 from mergify_engine import actions
 from mergify_engine import context
 from mergify_engine.actions.merge import helpers
 from mergify_engine.actions.merge import queue
+from mergify_engine.clients import http
 
 
 LOG = daiquiri.getLogger(__name__)
@@ -240,7 +240,7 @@ class MergeAction(actions.Action):
 
         try:
             ctxt.client.put(f"pulls/{ctxt.pull['number']}/merge", json=data)
-        except httpx.HTTPClientSideError as e:  # pragma: no cover
+        except http.HTTPClientSideError as e:  # pragma: no cover
             ctxt.update()
             if ctxt.pull["merged"]:
                 ctxt.log.info("merged in the meantime")

--- a/mergify_engine/actions/request_reviews.py
+++ b/mergify_engine/actions/request_reviews.py
@@ -1,9 +1,9 @@
 import itertools
 
-import httpx
 import voluptuous
 
 from mergify_engine import actions
+from mergify_engine.clients import http
 
 
 class RequestReviewsAction(actions.Action):
@@ -47,7 +47,7 @@ class RequestReviewsAction(actions.Action):
                         "team_reviewers": list(team_reviews_to_request),
                     },
                 )
-            except httpx.HTTPClientSideError as e:  # pragma: no cover
+            except http.HTTPClientSideError as e:  # pragma: no cover
                 return (
                     None,
                     "Unable to create review request",

--- a/mergify_engine/branch_updater.py
+++ b/mergify_engine/branch_updater.py
@@ -18,12 +18,12 @@
 import subprocess
 import uuid
 
-import httpx
 import tenacity
 
 from mergify_engine import config
 from mergify_engine import sub_utils
 from mergify_engine import utils
+from mergify_engine.clients import http
 
 
 UNRECOVERABLE_ERROR = ["head repository does not exist"]
@@ -186,7 +186,7 @@ def update_with_api(ctxt):
             api_version="lydian",
             json={"expected_head_sha": ctxt.pull["head"]["sha"]},
         )
-    except httpx.HTTPClientSideError as e:
+    except http.HTTPClientSideError as e:
         if e.status_code == 422 and e.message not in UNRECOVERABLE_ERROR:
             ctxt.log.info(
                 "branch updated in the meantime", status=e.status_code, error=e.message,
@@ -197,7 +197,7 @@ def update_with_api(ctxt):
                 "update branch failed", status=e.status_code, error=e.message,
             )
             raise BranchUpdateFailure(e.message)
-    except httpx.HTTPError as e:
+    except http.HTTPError as e:
         ctxt.log.info(
             "update branch failed",
             status=(e.response.status_code if e.response else None),

--- a/mergify_engine/clients/github.py
+++ b/mergify_engine/clients/github.py
@@ -160,7 +160,7 @@ class GithubInstallationClient(http.Client):
         reply = None
         try:
             reply = super().request(method, url, *args, **kwargs)
-        except httpx.HTTPClientSideError as e:
+        except http.HTTPClientSideError as e:
             if e.status_code == 403:
                 # TODO(sileht): Maybe we could look at header to avoid a request:
                 # they should be according the doc:

--- a/mergify_engine/clients/github_app.py
+++ b/mergify_engine/clients/github_app.py
@@ -95,7 +95,7 @@ class _Client(http.Client):
     def get_installation_by_id(self, installation_id):
         try:
             return self._get_installation(f"/app/installations/{installation_id}")
-        except httpx.HTTPNotFound as e:
+        except http.HTTPNotFound as e:
             LOG.debug(
                 "mergify not installed",
                 installation_id=installation_id,
@@ -115,7 +115,7 @@ class _Client(http.Client):
 
         try:
             return self._get_installation(url)
-        except httpx.HTTPNotFound as e:
+        except http.HTTPNotFound as e:
             LOG.debug(
                 "mergify not installed",
                 gh_owner=owner,

--- a/mergify_engine/clients/http.py
+++ b/mergify_engine/clients/http.py
@@ -15,6 +15,9 @@
 # under the License.
 
 
+import json
+
+import httpcore
 import httpx
 import urllib3
 
@@ -51,6 +54,29 @@ DEFAULT_CLIENT_OPTIONS = {
     "trust_env": False,
 }
 
+HTTPError = httpx.HTTPError
+
+# WARNING(sileht): httpx completly mess up exception handling of version 0.13.1, most
+# of them doesn't inherit anymore from HTTPError, they are aware of that and plan to
+# change/break it again before the 1.0 release
+# cf: https://github.com/encode/httpx/issues/949
+ConnectionErrors = (
+    httpcore.TimeoutException,
+    httpcore.NetworkError,
+    httpcore.ProtocolError,
+    httpcore.ProxyError,
+)
+
+
+class HTTPServerSideError(httpx.HTTPError):
+    @property
+    def message(self):
+        return self.response.text
+
+    @property
+    def status_code(self):
+        return self.response.status_code
+
 
 class HTTPClientSideError(httpx.HTTPError):
     @property
@@ -68,13 +94,33 @@ class HTTPNotFound(HTTPClientSideError):
     pass
 
 
-httpx.HTTPClientSideError = HTTPClientSideError
-httpx.HTTPNotFound = HTTPNotFound
-
 STATUS_CODE_TO_EXC = {404: HTTPNotFound}
 
 
-class Client(httpx.Client):
+class ClientMixin:
+    @staticmethod
+    def raise_for_status(resp):
+        message = "{0.status_code} {error_type}: {0.reason_phrase} for url: {0.url}"
+        if httpx.StatusCode.is_client_error(resp.status_code):
+            message = message.format(resp, error_type="Client Error")
+            try:
+                gh_message = resp.json().get("message")
+            except json.JSONDecodeError:
+                gh_message = None
+            if gh_message:
+                message += f"\nGitHub details: {gh_message}"
+            elif resp.text:
+                message += f"\nDetails: {resp.text}"
+            exc_class = STATUS_CODE_TO_EXC.get(resp.status_code, HTTPClientSideError)
+            raise exc_class(message, response=resp)
+        elif httpx.StatusCode.is_server_error(resp.status_code):
+            message = message.format(resp, error_type="Server Error")
+            if resp.text:
+                message += f"\nDetails: {resp.text}"
+            raise HTTPServerSideError(message, response=resp)
+
+
+class Client(httpx.Client, ClientMixin):
     def __init__(self, *args, **kwargs):
         # TODO(sileht): Due to our retries config, we have to use URLLIB3 transport
         # instead of the httpx default. It doesn't looks like httpx/httpcore will ever
@@ -100,48 +146,18 @@ class Client(httpx.Client):
 
     def request(self, method, url, *args, **kwargs):
         LOG.debug("http request start", method=method, url=url)
-        try:
-            r = super().request(method, url, *args, **kwargs)
-            r.raise_for_status()
-            return r
-        except httpx.HTTPError as e:
-            if e.response and 400 <= e.response.status_code < 500:
-                exc_class = STATUS_CODE_TO_EXC.get(
-                    e.response.status_code, HTTPClientSideError
-                )
-                message = e.args[0]
-                gh_message = e.response.json().get("message")
-                if gh_message:
-                    message = f"{message}\nGitHub details: {gh_message}"
-                raise exc_class(
-                    message, *e.args[1:], request=e.request, response=e.response,
-                )
-            raise
-        finally:
-            LOG.debug("http request end", method=method, url=url)
+        resp = super().request(method, url, *args, **kwargs)
+        LOG.debug("http request end", method=method, url=url)
+        self.raise_for_status(resp)
+        return resp
 
 
-class AsyncClient(httpx.AsyncClient):
+class AsyncClient(httpx.AsyncClient, ClientMixin):
     # TODO(sileht): Handle retries like we do with urllib3
 
     async def request(self, method, url, *args, **kwargs):
         LOG.debug("http request start", method=method, url=url)
-        try:
-            r = await super().request(method, url, *args, **kwargs)
-            r.raise_for_status()
-            return r
-        except httpx.HTTPError as e:
-            if e.response and 400 <= e.response.status_code < 500:
-                exc_class = STATUS_CODE_TO_EXC.get(
-                    e.response.status_code, HTTPClientSideError
-                )
-                message = e.args[0]
-                gh_message = e.response.json().get("message")
-                if gh_message:
-                    message = f"{message}\nGitHub details: {gh_message}"
-                raise exc_class(
-                    message, *e.args[1:], request=e.request, response=e.response,
-                )
-            raise
-        finally:
-            LOG.debug("http request end", method=method, url=url)
+        resp = await super().request(method, url, *args, **kwargs)
+        LOG.debug("http request end", method=method, url=url)
+        self.raise_for_status(resp)
+        return resp

--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -21,7 +21,6 @@ from typing import List
 from urllib import parse
 
 import cachetools
-import httpx
 import jinja2.exceptions
 import jinja2.runtime
 import jinja2.sandbox
@@ -272,7 +271,7 @@ class Context(object):
                     f"/orgs/{organization}/teams/{team_slug}/members"
                 )
             ]
-        except httpx.HTTPClientSideError as e:
+        except http.HTTPClientSideError as e:
             self.log.warning(
                 "fail to get the organization, team or members",
                 team=name,

--- a/mergify_engine/debug.py
+++ b/mergify_engine/debug.py
@@ -15,8 +15,6 @@
 import argparse
 import pprint
 
-import httpx
-
 from mergify_engine import config
 from mergify_engine import context
 from mergify_engine import engine
@@ -61,17 +59,14 @@ def report_sub(install_id, slug, sub, title):
     for login, token in sub["tokens"].items():
         try:
             repos = get_repositories_setuped(token, install_id)
-        except httpx.HTTPError as e:
-            if not e.response or e.response.status_code >= 500:
-                raise
-            if e.response.status_code == 404:
-                print(f"* {title} SUB: MERGIFY SEEMS NOT INSTALLED")
-                return
-            else:
-                print(
-                    f"* {title} SUB: token for {login} is invalid "
-                    f"({e.response.status_code}: {e.response.json()['message']})"
-                )
+        except http.HTTPNotFound:
+            print(f"* {title} SUB: MERGIFY SEEMS NOT INSTALLED")
+            return
+        except http.HTTPClientSideError as e:
+            print(
+                f"* {title} SUB: token for {login} is invalid "
+                f"({e.status_code}: {e.message})"
+            )
         else:
             if any((r["full_name"] == slug) for r in repos):
                 print(

--- a/mergify_engine/duplicate_pull.py
+++ b/mergify_engine/duplicate_pull.py
@@ -16,12 +16,12 @@ import dataclasses
 import functools
 import subprocess
 
-import httpx
 import tenacity
 
 from mergify_engine import config
 from mergify_engine import doc
 from mergify_engine import utils
+from mergify_engine.clients import http
 
 
 class DuplicateNeedRetry(Exception):
@@ -279,7 +279,7 @@ def duplicate(
                 "head": bp_branch,
             },
         ).json()
-    except httpx.HTTPClientSideError as e:
+    except http.HTTPClientSideError as e:
         if e.status_code == 422 and "No commits between" in e.message:
             return
         raise

--- a/mergify_engine/engine/__init__.py
+++ b/mergify_engine/engine/__init__.py
@@ -11,7 +11,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import httpx
 import pkg_resources
 import yaml
 
@@ -22,6 +21,7 @@ from mergify_engine import logs
 from mergify_engine import rules
 from mergify_engine import sub_utils
 from mergify_engine import utils
+from mergify_engine.clients import http
 from mergify_engine.engine import actions_runner
 from mergify_engine.engine import commands_runner
 
@@ -49,7 +49,7 @@ def get_github_pull_from_event(client, event_type, data):
     elif event_type == "issue_comment":
         try:
             return client.item(f"pulls/{data['issue']['number']}")
-        except httpx.HTTPNotFound:  # pragma: no cover
+        except http.HTTPNotFound:  # pragma: no cover
             return
 
     elif event_type == "status":

--- a/mergify_engine/engine/commands_runner.py
+++ b/mergify_engine/engine/commands_runner.py
@@ -15,12 +15,12 @@
 import re
 
 from datadog import statsd
-import httpx
 import voluptuous
 
 from mergify_engine import actions
 from mergify_engine import config
 from mergify_engine import logs
+from mergify_engine.clients import http
 
 
 LOG = logs.getLogger(__name__)
@@ -110,7 +110,7 @@ def handle(ctxt, comment, user, rerun=False):
         ctxt.client.post(
             f"issues/{ctxt.pull['number']}/comments", json={"body": result}
         )
-    except httpx.HTTPClientSideError as e:  # pragma: no cover
+    except http.HTTPClientSideError as e:  # pragma: no cover
         ctxt.log.error(
             "fail to post comment on the pull request",
             status=e.status_code,

--- a/mergify_engine/rules/__init__.py
+++ b/mergify_engine/rules/__init__.py
@@ -21,12 +21,12 @@ import itertools
 import operator
 import typing
 
-import httpx
 import voluptuous
 import yaml
 
 from mergify_engine import actions
 from mergify_engine import context
+from mergify_engine.clients import http
 from mergify_engine.rules import filter
 from mergify_engine.rules import types
 
@@ -264,7 +264,7 @@ def get_mergify_config_content(ctxt, ref=None):
     for filename in MERGIFY_CONFIG_FILENAMES:
         try:
             content = ctxt.client.item(f"contents/{filename}", **kwargs)["content"]
-        except httpx.HTTPNotFound:
+        except http.HTTPNotFound:
             continue
         return filename, base64.b64decode(bytearray(content, "utf-8"))
     raise NoRules()

--- a/mergify_engine/sub_utils.py
+++ b/mergify_engine/sub_utils.py
@@ -21,7 +21,6 @@ import cryptography
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import ciphers
 from cryptography.hazmat.primitives import hashes
-import httpx
 
 from mergify_engine import config
 from mergify_engine import logs
@@ -101,12 +100,11 @@ def _retrieve_subscription_from_db(installation_id):
                 config.SUBSCRIPTION_URL % installation_id,
                 auth=(config.OAUTH_CLIENT_ID, config.OAUTH_CLIENT_SECRET),
             )
-        except httpx.HTTPNotFound as e:
-            reason = e.response.json().get("message")
+        except http.HTTPNotFound as e:
             sub = {
                 "tokens": {},
                 "subscription_active": False,
-                "subscription_reason": reason,
+                "subscription_reason": e.message,
             }
         else:
             sub = resp.json()

--- a/mergify_engine/tests/functional/test_github_client.py
+++ b/mergify_engine/tests/functional/test_github_client.py
@@ -15,10 +15,10 @@
 # under the License.
 
 
-import httpx
 import yaml
 
 from mergify_engine.clients import github
+from mergify_engine.clients import http
 from mergify_engine.tests.functional import base
 
 
@@ -67,7 +67,7 @@ class TestGithubClient(base.FunctionalTestBase):
         pull = client.item(f"pulls/{p2.number}")
         self.assertEqual(p2.number, pull["number"])
 
-        with self.assertRaises(httpx.HTTPError) as ctxt:
+        with self.assertRaises(http.HTTPError) as ctxt:
             client.item("pulls/10000000000")
 
         self.assertEqual(404, ctxt.exception.response.status_code)

--- a/mergify_engine/tests/unit/test_forwards.py
+++ b/mergify_engine/tests/unit/test_forwards.py
@@ -43,17 +43,19 @@ tasks.app.conf.task_eager_propagates = True
 )
 def test_app_event_forward(_, __, httpserver):
 
-    with open(os.path.dirname(__file__) + "/push_event.json", "rb") as f:
+    with open(os.path.dirname(__file__) + "/push_event.json", "r") as f:
         data = f.read()
 
     headers = {
         "X-GitHub-Delivery": str(uuid.uuid4()),
         "X-GitHub-Event": "push",
-        "X-Hub-Signature": "sha1=%s" % utils.compute_hmac(data),
+        "X-Hub-Signature": "sha1=%s" % utils.compute_hmac(data.encode()),
         "User-Agent": "GitHub-Hookshot/044aadd",
         "Content-Type": "application/json",
     }
-    httpserver.expect_request("/", method="POST", data=data, headers=headers)
+    httpserver.expect_request(
+        "/", method="POST", data=data, headers=headers
+    ).respond_with_data("")
 
     with mock.patch(
         "mergify_engine.config.WEBHOOK_APP_FORWARD_URL", httpserver.url_for("/"),
@@ -71,17 +73,19 @@ def test_app_event_forward(_, __, httpserver):
 )
 def test_market_event_forward(_, __, httpserver):
 
-    with open(os.path.dirname(__file__) + "/market_event.json", "rb") as f:
+    with open(os.path.dirname(__file__) + "/market_event.json", "r") as f:
         data = f.read()
 
     headers = {
         "X-GitHub-Delivery": str(uuid.uuid4()),
         "X-GitHub-Event": "purchased",
-        "X-Hub-Signature": "sha1=%s" % utils.compute_hmac(data),
+        "X-Hub-Signature": "sha1=%s" % utils.compute_hmac(data.encode()),
         "User-Agent": "GitHub-Hookshot/044aadd",
         "Content-Type": "application/json",
     }
-    httpserver.expect_request("/", method="POST", data=data, headers=headers)
+    httpserver.expect_request(
+        "/", method="POST", data=data, headers=headers
+    ).respond_with_data("")
 
     with mock.patch(
         "mergify_engine.config.WEBHOOK_MARKETPLACE_FORWARD_URL",

--- a/mergify_engine/tests/unit/test_worker.py
+++ b/mergify_engine/tests/unit/test_worker.py
@@ -18,13 +18,13 @@ import time
 from unittest import mock
 
 from freezegun import freeze_time
-import httpx
 import pytest
 
 from mergify_engine import exceptions
 from mergify_engine import logs
 from mergify_engine import utils
 from mergify_engine import worker
+from mergify_engine.clients import http
 
 
 if sys.version_info < (3, 8):
@@ -372,7 +372,7 @@ async def test_stream_processor_retrying_stream_recovered(
     response = mock.Mock()
     response.json.return_value = {"message": "boom"}
     response.status_code = 401
-    run_engine.side_effect = httpx.HTTPClientSideError(response=response)
+    run_engine.side_effect = http.HTTPClientSideError(response=response)
 
     await worker.push(
         redis, 12345, "owner", "repo", 123, "pull_request", {"payload": "whatever"},
@@ -434,7 +434,7 @@ async def test_stream_processor_retrying_stream_failure(
     response = mock.Mock()
     response.json.return_value = {"message": "boom"}
     response.status_code = 401
-    run_engine.side_effect = httpx.HTTPClientSideError(response=response)
+    run_engine.side_effect = http.HTTPClientSideError(response=response)
 
     await worker.push(
         redis, 12345, "owner", "repo", 123, "pull_request", {"payload": "whatever"},

--- a/mergify_engine/web.py
+++ b/mergify_engine/web.py
@@ -25,7 +25,6 @@ import uuid
 
 import daiquiri
 import fastapi
-import httpx
 from starlette import requests
 from starlette import responses
 from starlette.middleware import cors
@@ -40,6 +39,7 @@ from mergify_engine import sub_utils
 from mergify_engine import utils
 from mergify_engine.clients import github
 from mergify_engine.clients import github_app
+from mergify_engine.clients import http
 from mergify_engine.engine import actions_runner
 
 
@@ -82,7 +82,7 @@ async def authentification(request: requests.Request):
 
 
 async def http_post(*args, **kwargs):
-    async with httpx.AsyncClient() as client:
+    async with http.AsyncClient() as client:
         await client.post(*args, **kwargs)
 
 
@@ -233,7 +233,7 @@ def PullRequestUrl(v):
     with github.get_client(owner, repo, installation) as client:
         try:
             data = client.item(f"pulls/{pull_number}")
-        except httpx.HTTPNotFound:
+        except http.HTTPNotFound:
             raise PullRequestUrlInvalid(message=("Pull request '%s' not found" % v))
 
         return context.Context(

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     aredis
     redis!=3.4.1,!=3.4.0
     hiredis
-    httpx
+    httpx>=0.13.1
     pyyaml
     voluptuous
     sentry-sdk[celery]


### PR DESCRIPTION
httpx exceptions does not inherit from HTTPError anymore.

This may break again in the future...
https://github.com/encode/httpx/issues/949

So this change:
* removes the httpx monkeypatching
* put all http related error in clients/http.py
* adds catch HTTP Connection related Exception again

The rest of the code does not import httpx for caching exception anymore.

Fixes MERGIFY-ENGINE-1KZ MERGIFY-ENGINE-1KY
