### PR TITLE
fix(merge): improve error reporting for strict mode and not modifiable branches

### DIFF
--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -2,21 +2,6 @@
 FAQ
 ===
 
-How do I fix the *"Pull request can't be updated with latest base branch changes, owner doesn't allow modification"* error?
----------------------------------------------------------------------------------------------------------------------------
-
-When :ref:`strict merge` is enabled, pull requests must be updated with the
-latest content from the target branch before being merged. To do that, Mergify
-needs the permission to update the source branch of the pull request.
-
-In certain cases, the pull request creator might not have authorized the
-repository owners to modify its source branch, which will block Mergify with
-this error. The solution is for the author of the pull request to either update
-manually its branch to the target branch (via a ``git merge`` or a ``git
-rebase``) or to give permission for Mergify to do it as described in `the
-GitHub documentation
-<https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/>`_.
-
 Mergify is unable to merge my pull request due to my branch protection settings
 -------------------------------------------------------------------------------
 

--- a/mergify_engine/actions/merge/action.py
+++ b/mergify_engine/actions/merge/action.py
@@ -171,17 +171,33 @@ class MergeAction(actions.Action):
         return False
 
     def _sync_with_base_branch(self, ctxt):
+        # If PR from a public fork but cannot be edited
         if (
             ctxt.pull_from_fork
             and not ctxt.pull["base"]["repo"]["private"]
-            and not ctxt.pull_base_is_modifiable
+            and not ctxt.pull["maintainer_can_modify"]
         ):
             return (
                 "failure",
-                "Pull request can't be updated with latest "
-                "base branch changes, owner doesn't allow "
-                "modification",
-                "",
+                "Pull request can't be updated with latest base branch changes",
+                "Mergify needs the permission to update the base branch of the pull request.\n"
+                f"{ctxt.pull['base']['repo']['owner']['login']} needs to "
+                "[authorize modification on its base branch]"
+                "(https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/).",
+            )
+        # If PR from a private fork but cannot be edited:
+        # NOTE(jd): GitHub removed the ability to configure `maintainer_can_modify` on private fork we which make strict mode broken
+        elif (
+            ctxt.pull_from_fork
+            and ctxt.pull["base"]["repo"]["private"]
+            and not ctxt.pull["maintainer_can_modify"]
+        ):
+            return (
+                "failure",
+                "Pull request can't be updated with latest base branch changes",
+                "Mergify needs the permission to update the base branch of the pull request.\n"
+                "GitHub does not allow a GitHub App to modify base branch for a private fork.\n"
+                "You cannot use strict mode with a pull request from a private fork.",
             )
         elif self.config["strict"] in ("smart+fasttrack", "smart+ordered"):
             queue.Queue.from_context(ctxt).add_pull(ctxt, self.config)

--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -386,10 +386,6 @@ class Context(object):
     def pull_from_fork(self):
         return self.pull["head"]["repo"]["id"] != self.pull["base"]["repo"]["id"]
 
-    @property
-    def pull_base_is_modifiable(self):
-        return self.pull["maintainer_can_modify"] or not self.pull_from_fork
-
 
 @dataclasses.dataclass
 class RenderTemplateFailure(Exception):


### PR DESCRIPTION
This improves the error message with a proper link to the documentation.
It also covers the recent GitHub changes that makes it impossible to modify a
private fork from our app.