### PR TITLE
Pull request for no-install-id

### DIFF
--- a/mergify_engine/actions/refresh.py
+++ b/mergify_engine/actions/refresh.py
@@ -29,7 +29,7 @@ class RefreshAction(actions.Action):
         data = {
             "action": "user",
             "repository": ctxt.pull["base"]["repo"],
-            "installation": {"id": ctxt.client.installation["id"]},
+            "installation": {"id": ctxt.client.auth.installation["id"]},
             "pull_request": ctxt.pull,
             "sender": {"login": "<internal>"},
         }

--- a/mergify_engine/actions/refresh.py
+++ b/mergify_engine/actions/refresh.py
@@ -29,7 +29,6 @@ class RefreshAction(actions.Action):
         data = {
             "action": "user",
             "repository": ctxt.pull["base"]["repo"],
-            "installation": {"id": ctxt.client.auth.installation["id"]},
             "pull_request": ctxt.pull,
             "sender": {"login": "<internal>"},
         }

--- a/mergify_engine/branch_updater.py
+++ b/mergify_engine/branch_updater.py
@@ -218,7 +218,7 @@ def update_with_api(ctxt):
 )
 def update_with_git(ctxt, method="merge"):
     subscription = asyncio.run(
-        sub_utils.get_subscription(ctxt.client.installation["id"])
+        sub_utils.get_subscription(ctxt.client.auth.installation["id"])
     )
 
     for login, token in subscription["tokens"].items():

--- a/mergify_engine/clients/github.py
+++ b/mergify_engine/clients/github.py
@@ -321,20 +321,6 @@ async def aget_installation_by_id(installation_id):
     return await client.get_installation_by_id(installation_id)
 
 
-async def aget_installation(owner, repo, installation_id=None):
-    client = github_app.aget_client()
-    installation = await client.get_installation(owner, repo)
-    if installation_id is not None and installation["id"] != installation_id:
-        LOG.error(
-            "installation id for repository diff from event installation id",
-            gh_owner=owner,
-            gh_repo=repo,
-            installation_id=installation["id"],
-            expected_installation_id=installation_id,
-        )
-    return installation
-
-
 class GithubInstallationClient(http.Client):
     def __init__(self, owner, repo):
         self.owner = owner
@@ -465,19 +451,3 @@ def get_installation_by_id(installation_id):
         }
     else:
         raise RuntimeError("Unexpected installation id")
-
-
-def get_installation(owner, repo, installation_id=None):
-    if config.GITHUB_APP:
-        installation = github_app.get_client().get_installation(owner, repo)
-        if installation_id is not None and installation["id"] != installation_id:
-            LOG.error(
-                "installation id for repository diff from event installation id",
-                gh_owner=owner,
-                gh_repo=repo,
-                installation_id=installation["id"],
-                expected_installation_id=installation_id,
-            )
-        return installation
-    else:
-        return get_github_action_installation()

--- a/mergify_engine/debug.py
+++ b/mergify_engine/debug.py
@@ -107,27 +107,25 @@ def report(url):
     slug = owner + "/" + repo
 
     try:
-        installation = github.get_installation(owner, repo)
+        client = github.get_client(owner, repo)
     except exceptions.MergifyNotInstalled:
         print("* Mergify is not installed there")
         return
 
-    client = github.get_client(owner, repo, installation)
-
-    print("* INSTALLATION ID: %s" % client.installation["id"])
+    print("* INSTALLATION ID: %s" % client.auth.installation["id"])
 
     cached_sub, db_sub = utils.async_run(
-        sub_utils.get_subscription(client.installation["id"]),
-        sub_utils._retrieve_subscription_from_db(client.installation["id"]),
+        sub_utils.get_subscription(client.auth.installation["id"]),
+        sub_utils._retrieve_subscription_from_db(client.auth.installation["id"]),
     )
     print(
         "* SUBSCRIBED (cache/db): %s / %s"
         % (cached_sub["subscription_active"], db_sub["subscription_active"])
     )
-    report_sub(client.installation["id"], slug, cached_sub, "ENGINE-CACHE")
-    report_sub(client.installation["id"], slug, db_sub, "DASHBOARD")
+    report_sub(client.auth.installation["id"], slug, cached_sub, "ENGINE-CACHE")
+    report_sub(client.auth.installation["id"], slug, db_sub, "DASHBOARD")
 
-    utils.async_run(report_worker_status(installation))
+    utils.async_run(report_worker_status(client.auth.installation))
 
     pull_raw = client.item(f"pulls/{pull_number}")
     ctxt = context.Context(

--- a/mergify_engine/engine/__init__.py
+++ b/mergify_engine/engine/__init__.py
@@ -169,7 +169,7 @@ def run(client, pull, subscription, sources):
     if not ctxt.sources:
         return
 
-    if ctxt.client.installation["permissions_need_to_be_updated"]:
+    if ctxt.client.auth.installation["permissions_need_to_be_updated"]:
         check_api.set_check_run(
             ctxt,
             "Summary",

--- a/mergify_engine/github_events.py
+++ b/mergify_engine/github_events.py
@@ -212,8 +212,8 @@ async def _get_github_pulls_from_sha(client, sha):
         return [int(pull_number)]
 
 
-async def extract_pull_numbers_from_event(installation, owner, repo, event_type, data):
-    async with await github.aget_client(owner, repo, installation) as client:
+async def extract_pull_numbers_from_event(owner, repo, event_type, data):
+    async with await github.aget_client(owner, repo) as client:
         # NOTE(sileht): Don't fail if we received even on repo that doesn't exists anymore
         with contextlib.suppress(http.HTTPNotFound):
             if event_type == "refresh":

--- a/mergify_engine/github_events.py
+++ b/mergify_engine/github_events.py
@@ -30,10 +30,7 @@ LOG = logs.getLogger(__name__)
 
 
 def get_ignore_reason(event_type, data):
-    if "installation" not in data:
-        return "no installation found"
-
-    elif "repository" not in data:
+    if "repository" not in data:
         return "no repository found"
 
     elif event_type in ["installation", "installation_repositories"]:
@@ -145,11 +142,6 @@ async def job_filter_and_dispatch(redis, event_type, event_id, data):
     # TODO(sileht): is statsd async ?
     meter_event(event_type, data)
 
-    if "installation" in data:
-        installation_id = data["installation"]["id"]
-    else:
-        installation_id = "<unknown>"
-
     if "repository" in data:
         owner = data["repository"]["owner"]["login"]
         repo = data["repository"]["name"]
@@ -172,7 +164,7 @@ async def job_filter_and_dispatch(redis, event_type, event_id, data):
             pull_number = None
 
         await worker.push(
-            redis, installation_id, owner, repo, pull_number, event_type, source_data,
+            redis, owner, repo, pull_number, event_type, source_data,
         )
 
     LOG.info(
@@ -180,7 +172,6 @@ async def job_filter_and_dispatch(redis, event_type, event_id, data):
         msg_action,
         event_type=event_type,
         event_id=event_id,
-        install_id=installation_id,
         sender=data["sender"]["login"],
         gh_owner=owner,
         gh_repo=repo,

--- a/mergify_engine/tests/functional/test_engine.py
+++ b/mergify_engine/tests/functional/test_engine.py
@@ -796,8 +796,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
 
         p, commits = self.create_pr()
 
-        installation = {"id": config.INSTALLATION_ID}
-        client = github.get_client(p.base.user.login, p.base.repo.name, installation)
+        client = github.get_client(p.base.user.login, p.base.repo.name)
         pull = context.Context(client, p.raw_data, {})
 
         logins = pull.resolve_teams(
@@ -835,8 +834,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
 
         p, commits = self.create_pr()
 
-        installation = {"id": config.INSTALLATION_ID}
-        client = github.get_client(p.base.user.login, p.base.repo.name, installation)
+        client = github.get_client(p.base.user.login, p.base.repo.name)
         pull = context.Context(client, p.raw_data, {})
 
         logins = pull.resolve_teams(
@@ -1426,8 +1424,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
         }
         self.setup_repo(yaml.dump(rules))
         p, _ = self.create_pr()
-        installation = {"id": config.INSTALLATION_ID}
-        client = github.get_client(p.base.user.login, p.base.repo.name, installation)
+        client = github.get_client(p.base.user.login, p.base.repo.name)
         ctxt = context.Context(client, {"number": p.number}, {})
         assert p.number == ctxt.pull["number"]
         assert "open" == ctxt.pull["state"]

--- a/mergify_engine/tests/functional/test_github_async_client.py
+++ b/mergify_engine/tests/functional/test_github_async_client.py
@@ -42,11 +42,8 @@ class TestGithubClient(base.FunctionalTestBase):
         self.create_pr(base=other_branch)
 
         async def _test_github_async_client():
-            installation = await github.aget_installation(
-                self.o_integration.login, self.r_o_integration.name
-            )
             client = await github.aget_client(
-                self.o_integration.login, self.r_o_integration.name, installation
+                self.o_integration.login, self.r_o_integration.name
             )
 
             pulls = [p async for p in client.items("pulls")]

--- a/mergify_engine/tests/functional/test_github_client.py
+++ b/mergify_engine/tests/functional/test_github_client.py
@@ -39,12 +39,7 @@ class TestGithubClient(base.FunctionalTestBase):
         p2, _ = self.create_pr()
         self.create_pr(base=other_branch)
 
-        installation = github.get_installation(
-            self.o_integration.login, self.r_o_integration.name
-        )
-        client = github.get_client(
-            self.o_integration.login, self.r_o_integration.name, installation
-        )
+        client = github.get_client(self.o_integration.login, self.r_o_integration.name)
 
         pulls = list(client.items("pulls"))
         self.assertEqual(2, len(pulls))

--- a/mergify_engine/tests/unit/test_clients.py
+++ b/mergify_engine/tests/unit/test_clients.py
@@ -59,8 +59,7 @@ def test_client_401_raise_ratelimit(httpserver):
     with mock.patch(
         "mergify_engine.config.GITHUB_API_URL", httpserver.url_for("/"),
     ):
-        installation = github.get_installation(owner, repo, 12345)
-        client = github.get_client(owner, repo, installation)
+        client = github.get_client(owner, repo)
         with pytest.raises(exceptions.RateLimited):
             client.item("pull/1")
 

--- a/mergify_engine/tests/unit/test_event_to_pull.py
+++ b/mergify_engine/tests/unit/test_event_to_pull.py
@@ -40,19 +40,17 @@ async def _do_test_event_to_pull_check_run(filename, expected_pulls):
             "https://api.github.com/repos/CytopiaTeam/Cytopia/", allow_relative=False,
         ),
         name="foo",
+        auth=mock.Mock(installation={"id": installation_id}),
     )
     client.__aenter__ = mock.AsyncMock(return_value=client)
     client.__aexit__ = mock.AsyncMock()
     client.items.return_value = []
 
     with mock.patch.object(github, "aget_client", return_value=client):
-        with mock.patch.object(
-            github, "aget_installation", return_value={"id": installation_id},
-        ):
-            pulls = await github_events.extract_pull_numbers_from_event(
-                installation_id, owner, repo, event_type, data
-            )
-            assert pulls == expected_pulls
+        pulls = await github_events.extract_pull_numbers_from_event(
+            owner, repo, event_type, data
+        )
+        assert pulls == expected_pulls
 
 
 @pytest.mark.asyncio

--- a/mergify_engine/tests/unit/test_record_endpoints.py
+++ b/mergify_engine/tests/unit/test_record_endpoints.py
@@ -36,6 +36,7 @@ def test_app_event_testing():
         "Content-Type": "application/json",
     }
     with testclient.TestClient(web.app) as client:
+        client.delete("/events-testing", data=data, headers=headers)
         client.post("/events-testing", data=data, headers=headers)
         client.post("/events-testing", data=data, headers=headers)
         client.post("/events-testing", data=data, headers=headers)

--- a/mergify_engine/tests/unit/test_web.py
+++ b/mergify_engine/tests/unit/test_web.py
@@ -39,7 +39,7 @@ with open(
             {"sender": {"login": "JD",}, "event_type": "foobar",},
             None,
             200,
-            b"Event ignored: no installation found",
+            b"Event ignored: no repository found",
         ),
         (push_event, "push", 200, b"Event ignored: push on refs/tags/simple-tag",),
         (pull_request_event, "pull_request", 202, b"Event queued",),

--- a/mergify_engine/tests/unit/test_worker.py
+++ b/mergify_engine/tests/unit/test_worker.py
@@ -328,8 +328,8 @@ async def test_stream_processor_retrying_pull(
     assert 1 == (await redis.zcard("streams"))
     assert 1 == len(await redis.keys("stream~*"))
     assert {
-        b"pull~12345~owner~repo~42": b"1",
-        b"pull~12345~owner~repo~123": b"1",
+        b"pull~owner~repo~42": b"1",
+        b"pull~owner~repo~123": b"1",
     } == await redis.hgetall("attempts")
 
     await p.consume("stream~12345")
@@ -337,7 +337,7 @@ async def test_stream_processor_retrying_pull(
     assert 1 == len(await redis.keys("stream~*"))
     assert 1 == len(await redis.hgetall("attempts"))
     assert len(run_engine.mock_calls) == 4
-    assert {b"pull~12345~owner~repo~42": b"2"} == await redis.hgetall("attempts")
+    assert {b"pull~owner~repo~42": b"2"} == await redis.hgetall("attempts")
 
     await p.consume("stream~12345")
     assert len(run_engine.mock_calls) == 5

--- a/mergify_engine/web.py
+++ b/mergify_engine/web.py
@@ -144,13 +144,7 @@ app.mount("/validate", config_validator_app)
 
 async def _refresh(owner, repo, action="user", **extra_data):
     event_type = "refresh"
-    try:
-        installation = await github_app.aget_client().get_installation(owner, repo)
-    except exceptions.MergifyNotInstalled:
-        return responses.Response("Mergify not installed", status_code=404)
-
     data = {
-        "installation": installation,
         "action": action,
         "repository": {
             "name": repo,

--- a/mergify_engine/web.py
+++ b/mergify_engine/web.py
@@ -145,7 +145,7 @@ app.mount("/validate", config_validator_app)
 async def _refresh(owner, repo, action="user", **extra_data):
     event_type = "refresh"
     try:
-        installation = github.get_installation(owner, repo)
+        installation = await github_app.aget_client().get_installation(owner, repo)
     except exceptions.MergifyNotInstalled:
         return responses.Response("Mergify not installed", status_code=404)
 

--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -288,7 +288,7 @@ class StreamProcessor:
     async def _run_engine_and_translate_exception_to_retries(
         self, installation, owner, repo, pull_number, sources
     ):
-        attempts_key = f"pull~{installation['id']}~{owner}~{repo}~{pull_number}"
+        attempts_key = f"pull~{owner}~{repo}~{pull_number}"
         try:
             await self._thread.exec(
                 run_engine, installation, owner, repo, pull_number, sources,


### PR DESCRIPTION
## chore: reset event testing endpoint

testing redis may have data from other tests

## refactor(worker): don't use install_id in attempts key


## refactor: move installation to auth


## refactor: use installation from auth


## chore: remove github.get_installation()


## refactor: remove useless aget_installation


## chore: don't deduce install id from stream name


## feat(worker): use owner instead of install id
