### PR TITLE
build: remove idna dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ install_requires =
     sentry-sdk
     tenacity
     pyparsing
-    idna
     gunicorn[setproctitle]
     honcho
     pyjwt


### PR DESCRIPTION
We don't use/import it directly.