### PR TITLE
build: remove setproctitle dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ install_requires =
     fastapi
     python-multipart  # fastapi extra
     uvicorn
-    setproctitle
     cryptography
     aredis
     redis!=3.4.1,!=3.4.0


### PR DESCRIPTION
We don't use it directly and gunicorn pulls it from its own usage already.