### PR TITLE
Pull request for no-install-id

### DIFF
--- a/mergify_engine/actions/merge/queue.py
+++ b/mergify_engine/actions/merge/queue.py
@@ -235,9 +235,9 @@ class Queue:
 
         pull_number = pull_numbers[0]
 
-        subscription = asyncio.run(sub_utils.get_subscription(self.installation_id))
-
         with github.get_client(self.owner, self.repo) as client:
+            subscription = asyncio.run(sub_utils.get_subscription(client.auth.owner_id))
+
             data = client.item(f"pulls/{pull_number}")
 
             ctxt = None

--- a/mergify_engine/branch_updater.py
+++ b/mergify_engine/branch_updater.py
@@ -217,9 +217,7 @@ def update_with_api(ctxt):
     retry=tenacity.retry_if_exception_type(AuthentificationFailure),
 )
 def update_with_git(ctxt, method="merge"):
-    subscription = asyncio.run(
-        sub_utils.get_subscription(ctxt.client.auth.installation["id"])
-    )
+    subscription = asyncio.run(sub_utils.get_subscription(ctxt.client.auth.owner_id))
 
     for login, token in subscription["tokens"].items():
         try:

--- a/mergify_engine/clients/github.py
+++ b/mergify_engine/clients/github.py
@@ -64,10 +64,12 @@ class CachedToken:
 
 class GithubActionAccessTokenAuth(httpx.Auth):
     def __init__(self):
-        self._installation = {
+        self.installation = {
             "id": config.ACTION_ID,
             "permissions_need_to_be_updated": False,
         }
+        # TODO(sileht): To be defined when we handle subscription for GitHub Action
+        self.owner_id = 0
 
     def auth_flow(self, request):
         request.headers["Authorization"] = f"token {config.GITHUB_TOKEN}"
@@ -81,6 +83,7 @@ class GithubAppInstallationAuth(httpx.Auth):
 
         self._cached_token = None
         self.installation = None
+        self.owner_id = None
 
     @contextlib.contextmanager
     def response_body_read(self):
@@ -153,6 +156,7 @@ class GithubAppInstallationAuth(httpx.Auth):
         self.installation = github_app.validate_installation(
             installation_response.json()
         )
+        self.owner_id = self.installation["account"]["id"]
         self._cached_token = CachedToken.get(self.installation["id"])
 
     def _set_access_token(self, data):

--- a/mergify_engine/config.py
+++ b/mergify_engine/config.py
@@ -83,7 +83,7 @@ Schema = voluptuous.Schema(
         voluptuous.Required("GITHUB_API_URL", default="https://api.github.com"): str,
         # Mergify website for subscription
         voluptuous.Required(
-            "SUBSCRIPTION_URL", default="http://localhost:5000/engine/installation/%s"
+            "SUBSCRIPTION_BASE_URL", default="http://localhost:5000"
         ): str,
         voluptuous.Required("WEBHOOK_APP_FORWARD_URL", default=None): voluptuous.Any(
             None, str
@@ -108,6 +108,9 @@ Schema = voluptuous.Schema(
         ): voluptuous.Coerce(int),
         # For test suite only (eg: tox -erecord)
         voluptuous.Required("INSTALLATION_ID", default=499592): voluptuous.Coerce(int),
+        voluptuous.Required(
+            "TESTING_ORGANIZATION_ID", default=40527191
+        ): voluptuous.Coerce(int),
         voluptuous.Required("TESTING_ORGANIZATION", default="mergifyio-testing"): str,
         voluptuous.Required(
             "ORG_ADMIN_PERSONAL_TOKEN", default="<ORG_ADMIN_PERSONAL_TOKEN>",

--- a/mergify_engine/debug.py
+++ b/mergify_engine/debug.py
@@ -115,8 +115,8 @@ def report(url):
     print("* INSTALLATION ID: %s" % client.auth.installation["id"])
 
     cached_sub, db_sub = utils.async_run(
-        sub_utils.get_subscription(client.auth.installation["id"]),
-        sub_utils._retrieve_subscription_from_db(client.auth.installation["id"]),
+        sub_utils.get_subscription(client.auth.owner_id),
+        sub_utils._retrieve_subscription_from_db(client.auth.owner_id),
     )
     print(
         "* SUBSCRIBED (cache/db): %s / %s"

--- a/mergify_engine/debug.py
+++ b/mergify_engine/debug.py
@@ -81,8 +81,8 @@ def report_sub(install_id, slug, sub, title):
         print(f"* {title} SUB: MERGIFY DOESN'T HAVE ANY VALID OAUTH TOKENS")
 
 
-async def report_worker_status(installation):
-    stream_name = f"stream~{installation['id']}".encode()
+async def report_worker_status(owner):
+    stream_name = f"stream~{owner}".encode()
     r = await utils.create_aredis_for_stream()
     streams = await r.zrangebyscore("streams", min=0, max="+inf")
     try:
@@ -125,7 +125,7 @@ def report(url):
     report_sub(client.auth.installation["id"], slug, cached_sub, "ENGINE-CACHE")
     report_sub(client.auth.installation["id"], slug, db_sub, "DASHBOARD")
 
-    utils.async_run(report_worker_status(client.auth.installation))
+    utils.async_run(report_worker_status(client.owner))
 
     pull_raw = client.item(f"pulls/{pull_number}")
     ctxt = context.Context(

--- a/mergify_engine/tests/functional/base.py
+++ b/mergify_engine/tests/functional/base.py
@@ -364,6 +364,7 @@ class FunctionalTestBase(unittest.TestCase):
                     "id": config.INSTALLATION_ID,
                     "permissions_need_to_be_updated": False,
                 }
+                client.auth.owner_id = config.TESTING_ORGANIZATION_ID
                 return client
 
             def github_client(*args, **kwargs):
@@ -372,6 +373,7 @@ class FunctionalTestBase(unittest.TestCase):
                     "id": config.INSTALLATION_ID,
                     "permissions_need_to_be_updated": False,
                 }
+                client.auth.owner_id = config.TESTING_ORGANIZATION_ID
                 return client
 
             mock.patch.object(github, "get_client", github_client).start()
@@ -474,8 +476,8 @@ class FunctionalTestBase(unittest.TestCase):
 
         real_get_subscription = sub_utils.get_subscription
 
-        async def fake_retrieve_subscription_from_db(install_id):
-            if int(install_id) == config.INSTALLATION_ID:
+        async def fake_retrieve_subscription_from_db(owner_id):
+            if owner_id == config.TESTING_ORGANIZATION_ID:
                 return self.subscription
             else:
                 return {
@@ -484,9 +486,9 @@ class FunctionalTestBase(unittest.TestCase):
                     "subscription_reason": "We're just testing",
                 }
 
-        async def fake_subscription(install_id):
-            if int(install_id) == config.INSTALLATION_ID:
-                return await real_get_subscription(install_id)
+        async def fake_subscription(owner_id):
+            if owner_id == config.TESTING_ORGANIZATION_ID:
+                return await real_get_subscription(owner_id)
             else:
                 return {
                     "tokens": {},

--- a/mergify_engine/tests/unit/test_clients.py
+++ b/mergify_engine/tests/unit/test_clients.py
@@ -40,7 +40,7 @@ def test_client_401_raise_ratelimit(httpserver):
                 "contents": "write",
                 "pull_requests": "write",
             },
-            "account": {"login": "testing"},
+            "account": {"login": "testing", "id": 12345},
         }
     )
     httpserver.expect_request(
@@ -171,7 +171,7 @@ def test_client_access_token_HTTP_500(httpserver):
                 "contents": "write",
                 "pull_requests": "write",
             },
-            "account": {"login": "testing"},
+            "account": {"login": "testing", "id": 12345},
         }
     )
     httpserver.expect_request(

--- a/mergify_engine/web.py
+++ b/mergify_engine/web.py
@@ -227,9 +227,7 @@ def PullRequestUrl(v):
             except http.HTTPNotFound:
                 raise PullRequestUrlInvalid(message=("Pull request '%s' not found" % v))
 
-            subscription = asyncio.run(
-                sub_utils.get_subscription(client.auth.installation["id"])
-            )
+            subscription = asyncio.run(sub_utils.get_subscription(client.auth.owner_id))
 
             return context.Context(
                 client,

--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -331,17 +331,14 @@ class StreamProcessor:
             pulls = await self._extract_pulls_from_stream(stream_name)
             await self._consume_pulls(stream_name, pulls)
         except StreamUnused:
-            # TODO(sileht): put back gh_owner when stream name have owner instead of
-            # install id
-            LOG.info("unused stream, dropping it", exc_info=True)
+            LOG.info("unused stream, dropping it", gh_owner=owner, exc_info=True)
             await self.redis.delete(stream_name)
         except StreamRetry as e:
-            # TODO(sileht): put back gh_owner when stream name have owner instead of
-            # install id
             LOG.info(
                 "failed to process stream, retrying",
                 attempts=e.attempts,
                 retry_at=e.retry_at,
+                gh_owner=owner,
                 exc_info=True,
             )
             return
@@ -355,9 +352,7 @@ class StreamProcessor:
 
         except Exception:
             # Ignore it, it will retried later
-            # TODO(sileht): put back gh_owner when stream name have owner instead of
-            # install id
-            LOG.error("failed to process stream", exc_info=True)
+            LOG.error("failed to process stream", gh_owner=owner, exc_info=True)
 
         LOG.debug("cleanup stream start", stream_name=stream_name)
         await self.redis.eval(

--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -132,7 +132,7 @@ async def get_pull_for_engine(owner, repo, pull_number, logger):
             logger.debug("pull request doesn't exists, skipping it")
             return
 
-        subscription = await sub_utils.get_subscription(client.auth.installation["id"])
+        subscription = await sub_utils.get_subscription(client.auth.owner_id)
 
         if pull["base"]["repo"]["private"] and not subscription["subscription_active"]:
             logger.debug(


### PR DESCRIPTION
## feat: use owner instead of install id for streams


## feat: use owner id for subscription

The subscription endpoint config name have changed to help
to migrate to the new endpoint.

The new config is already set everywhere.
