### PR TITLE
chore: remove useless log message

### DIFF
--- a/mergify_engine/actions/merge/queue.py
+++ b/mergify_engine/actions/merge/queue.py
@@ -216,7 +216,6 @@ class Queue:
         LOG.info("smart strict workflow loop start")
         for queue_name in redis.keys("strict-merge-queues~*"):
             queue = cls.from_queue_name(redis, queue_name)
-            queue.log.info("handling queue")
             try:
                 queue.process()
             except exceptions.MergifyNotInstalled:


### PR DESCRIPTION
we log in a row:
* "handling queue"
* "2 pull queued"

Only the second one is useful