### PR TITLE
feat(actions): validate GitHub login and team names

### DIFF
--- a/mergify_engine/actions/assign.py
+++ b/mergify_engine/actions/assign.py
@@ -23,7 +23,11 @@ from mergify_engine.rules import types
 
 
 class AssignAction(actions.Action):
-    validator = {voluptuous.Required("users", default=[]): [types.Jinja2]}
+    validator = {
+        voluptuous.Required("users", default=[]): [
+            voluptuous.Coerce(types.Jinja2, types.GitHubLogin)
+        ]
+    }
 
     silent_report = True
 

--- a/mergify_engine/actions/dismiss_reviews.py
+++ b/mergify_engine/actions/dismiss_reviews.py
@@ -27,10 +27,10 @@ from mergify_engine.rules import types
 class DismissReviewsAction(actions.Action):
     validator = {
         voluptuous.Required("approved", default=True): voluptuous.Any(
-            True, False, [str]
+            True, False, [types.GitHubLogin]
         ),
         voluptuous.Required("changes_requested", default=True): voluptuous.Any(
-            True, False, [str]
+            True, False, [types.GitHubLogin]
         ),
         voluptuous.Required(
             "message", default="Pull request has been modified."

--- a/mergify_engine/actions/request_reviews.py
+++ b/mergify_engine/actions/request_reviews.py
@@ -4,6 +4,7 @@ import voluptuous
 
 from mergify_engine import actions
 from mergify_engine.clients import http
+from mergify_engine.rules import types
 
 
 class RequestReviewsAction(actions.Action):
@@ -14,8 +15,8 @@ class RequestReviewsAction(actions.Action):
     GITHUB_MAXIMUM_REVIEW_REQUEST = 15
 
     validator = {
-        voluptuous.Required("users", default=[]): [str],
-        voluptuous.Required("teams", default=[]): [str],
+        voluptuous.Required("users", default=[]): [types.GitHubLogin],
+        voluptuous.Required("teams", default=[]): [types.GitHubTeam],
     }
 
     silent_report = True

--- a/mergify_engine/tests/unit/rules/test_types.py
+++ b/mergify_engine/tests/unit/rules/test_types.py
@@ -46,3 +46,65 @@ def test_jinja2_unknown_attr():
         types.Jinja2("{{foo}}")
     assert str(x.value) == "Template syntax error"
     assert str(x.value.error_message) == "Unknown pull request attribute: foo"
+
+
+@pytest.mark.parametrize(
+    "login", ("foobar", "foobaz", "foo-baz", "f123", "123foo"),
+)
+def test_github_login_ok(login):
+    types.GitHubLogin(login)
+
+
+@pytest.mark.parametrize(
+    "login,error",
+    (
+        ("-foobar", "GitHub login contains invalid characters"),
+        ("foobaz-", "GitHub login contains invalid characters"),
+        ("foo-béaz", "GitHub login contains invalid characters"),
+        ("🤣", "GitHub login contains invalid characters"),
+        ("O_o", "GitHub login contains invalid characters"),
+        ("", "A GitHub login cannot be an empty string"),
+    ),
+)
+def test_github_login_nok(login, error):
+    with pytest.raises(voluptuous.Invalid) as x:
+        types.GitHubLogin(login)
+    assert str(x.value) == error
+
+
+@pytest.mark.parametrize(
+    "login,result",
+    (
+        ("foobar", "foobar"),
+        ("foobaz", "foobaz"),
+        ("foo-baz", "foo-baz"),
+        ("f123", "f123"),
+        ("foo/bar", "bar"),
+        ("@foo/bar", "bar"),
+        ("@fo-o/bar", "bar"),
+        ("@fo-o/ba-r", "ba-r"),
+        ("@foo/ba-r", "ba-r"),
+    ),
+)
+def test_github_team_ok(login, result):
+    assert types.GitHubTeam(login) == result
+
+
+@pytest.mark.parametrize(
+    "login,error",
+    (
+        ("-foobar", "GitHub team contains invalid characters"),
+        ("/-foobar", "A GitHub organization cannot be an empty string"),
+        ("foo/-foobar", "GitHub team contains invalid characters"),
+        ("foo/-", "GitHub team contains invalid characters"),
+        ("foo//-", "GitHub team contains invalid characters"),
+        ("/foo//-", "A GitHub organization cannot be an empty string"),
+        ("@/foo//-", "A GitHub organization cannot be an empty string"),
+        ("@arf/", "A GitHub team cannot be an empty string"),
+        ("", "A GitHub team cannot be an empty string"),
+    ),
+)
+def test_github_team_nok(login, error):
+    with pytest.raises(voluptuous.Invalid) as x:
+        types.GitHubTeam(login)
+    assert str(x.value) == error


### PR DESCRIPTION
Make sure we validate GitHub login and team names when used in configuration.

For example, the current format name for teams is "@team" or "@org/team" in
conditions, but that does not work in the request reviews action. This makes
sure it now does.
