### PR TITLE
fix: allow retry of merge when branch is dirty

### DIFF
--- a/mergify_engine/actions/merge/helpers.py
+++ b/mergify_engine/actions/merge/helpers.py
@@ -51,7 +51,7 @@ def merge_report(ctxt, strict):
 
     # NOTE(sileht): Take care of all branch protection state
     elif ctxt.pull["mergeable_state"] == "dirty":
-        conclusion = "failure"
+        conclusion = "cancelled"
         title = "Merge conflict needs to be solved"
         summary = ""
     elif ctxt.pull["mergeable_state"] == "unknown":


### PR DESCRIPTION
Currently, we stop processing the PR until a conditions change.
While in such case we should retry.

To do, so we return cancelled instead of failure.
So next synchronize will retry to merge the PR if all conditions still
match.