### PR TITLE
fix(bridge): remove verify=False for http client

### DIFF
--- a/mergify_engine/tests/bridge.py
+++ b/mergify_engine/tests/bridge.py
@@ -82,7 +82,6 @@ def run():
                         "Content-type": "application/json",
                     },
                     data=data,
-                    verify=False,
                 )
         except Exception:
             LOG.error("event handling failure", exc_info=True)


### PR DESCRIPTION
This is not supported by httpx and not needed anymore.