### PR TITLE
fix: don't shallow unexpected jinja issue

### DIFF
--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -408,7 +408,6 @@ class PullRequest:
     ATTRIBUTES = {
         "assignee",
         "label",
-        "review-requested",
         "author",
         "merged-by",
         "merged",
@@ -422,6 +421,10 @@ class PullRequest:
         "title",
         "body",
         "files",
+    }
+
+    LIST_ATTRIBUTES = {
+        "review-requested",
         "approved-reviews-by",
         "dismissed-reviews-by",
         "changes-requested-reviews-by",
@@ -435,7 +438,7 @@ class PullRequest:
         return self.context._get_consolidated_data(name.replace("_", "-"))
 
     def __iter__(self):
-        return iter(self.ATTRIBUTES)
+        return iter(self.ATTRIBUTES | self.LIST_ATTRIBUTES)
 
     def items(self):
         for k in self:

--- a/mergify_engine/rules/__init__.py
+++ b/mergify_engine/rules/__init__.py
@@ -44,20 +44,18 @@ def PullRequestRuleCondition(value):
         )
 
 
-PullRequestRulesSchema = voluptuous.Schema(
-    voluptuous.All(
-        [
-            {
-                voluptuous.Required("name"): str,
-                voluptuous.Required("hidden", default=False): bool,
-                voluptuous.Required("conditions"): [
-                    voluptuous.All(str, voluptuous.Coerce(PullRequestRuleCondition))
-                ],
-                voluptuous.Required("actions"): actions.get_action_schemas(),
-            }
-        ],
-        voluptuous.Length(min=1),
-    )
+PullRequestRulesSchema = voluptuous.All(
+    [
+        {
+            voluptuous.Required("name"): str,
+            voluptuous.Required("hidden", default=False): bool,
+            voluptuous.Required("conditions"): [
+                voluptuous.All(str, voluptuous.Coerce(PullRequestRuleCondition))
+            ],
+            voluptuous.Required("actions"): actions.get_action_schemas(),
+        }
+    ],
+    voluptuous.Length(min=1),
 )
 
 
@@ -200,8 +198,8 @@ UserConfigurationSchema = voluptuous.Schema(
     voluptuous.And(
         voluptuous.Coerce(YAML),
         {
-            voluptuous.Required("pull_request_rules"): voluptuous.Coerce(
-                PullRequestRules.from_list
+            voluptuous.Required("pull_request_rules"): voluptuous.And(
+                PullRequestRulesSchema, voluptuous.Coerce(PullRequestRules),
             )
         },
     )

--- a/mergify_engine/rules/types.py
+++ b/mergify_engine/rules/types.py
@@ -41,7 +41,11 @@ class DummyContext(context.Context):
     # This is only used to check Jinja2 syntax validity
     @staticmethod
     def _get_consolidated_data(key):
-        if key not in context.PullRequest.ATTRIBUTES:
+        if key in context.PullRequest.ATTRIBUTES:
+            return None
+        elif key in context.PullRequest.LIST_ATTRIBUTES:
+            return []
+        else:
             raise context.PullRequestAttributeError(key)
 
     @staticmethod
@@ -49,7 +53,7 @@ class DummyContext(context.Context):
         pass
 
 
-_DUMMY_PR = context.PullRequest(DummyContext(None, {}, {}))
+_DUMMY_PR = context.PullRequest(DummyContext(None, {}, {}, [],))
 
 
 def Jinja2(value):

--- a/mergify_engine/tests/functional/test_attributes.py
+++ b/mergify_engine/tests/functional/test_attributes.py
@@ -60,7 +60,9 @@ class TestAttributes(base.FunctionalTestBase):
             assert ctxt.pull_request.foobar
 
         # Test items
-        assert list(ctxt.pull_request) == list(context.PullRequest.ATTRIBUTES)
+        assert list(ctxt.pull_request) == list(
+            context.PullRequest.ATTRIBUTES | context.PullRequest.LIST_ATTRIBUTES
+        )
         assert dict(ctxt.pull_request.items()) == {
             "number": pr.number,
             "closed": False,

--- a/mergify_engine/tests/unit/rules/test_rules.py
+++ b/mergify_engine/tests/unit/rules/test_rules.py
@@ -58,6 +58,30 @@ def test_same_names():
     ]
 
 
+@pytest.mark.skip(reason="the dummy context is not yet perfect")
+def test_jinja_with_list_attribute():
+    pull_request_rules = rules.UserConfigurationSchema(
+        """
+pull_request_rules:
+  - name: ahah
+    conditions:
+    - base=master
+    actions:
+      comment:
+        message: |
+          This pull request has been approved by:
+          {% for name in approved_reviews_by %}
+          @{{name}}
+          {% endfor %}
+          Thank you @{{author}} for your contributions!
+
+"""
+    )["pull_request_rules"]
+    assert [rule["name"] for rule in pull_request_rules] == [
+        "ahah",
+    ]
+
+
 def test_user_configuration_schema():
     with pytest.raises(voluptuous.Invalid) as exc_info:
         rules.UserConfigurationSchema("- no\n* way")

--- a/mergify_engine/tests/unit/rules/test_rules.py
+++ b/mergify_engine/tests/unit/rules/test_rules.py
@@ -58,7 +58,6 @@ def test_same_names():
     ]
 
 
-@pytest.mark.skip(reason="the dummy context is not yet perfect")
 def test_jinja_with_list_attribute():
     pull_request_rules = rules.UserConfigurationSchema(
         """


### PR DESCRIPTION
## fix: don't shallow unexpected jinja issue

Jinja issue was reported as:

`expected from_list @ dictionary d["pull_request_rules"]`

Now the correct unexpected error is reported.

The added test now raises:

...
mergify_engine/rules/types.py:61: in Jinja2
    _DUMMY_PR.render_template(value)
mergify_engine/context.py:454: in render_template
    return self.jinja2_env.from_string(template).render()
.tox/py38/lib/python3.8/site-packages/jinja2/environment.py:1090: in render
    self.environment.handle_exception()
.tox/py38/lib/python3.8/site-packages/jinja2/environment.py:832: in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
.tox/py38/lib/python3.8/site-packages/jinja2/_compat.py:28: in reraise
    raise value.with_traceback(tb)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
>   ???
E   TypeError: 'NoneType' object is not iterable
<template>:2: TypeError

## fix(templating): return fake list for list attributes
