### PR TITLE
feat(worker): too many stream attempts should at least log an error

### DIFF
--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -58,6 +58,7 @@ LOG = daiquiri.getLogger(__name__)
 
 MAX_RETRIES = 3
 WORKER_PROCESSING_DELAY = 30
+STREAM_ATTEMPTS_LOGGING_THRESHOLD = 20
 
 
 class IgnoredException(Exception):
@@ -323,7 +324,12 @@ class StreamProcessor:
             LOG.info("unused stream, dropping it", gh_owner=owner, exc_info=True)
             await self.redis.delete(stream_name)
         except StreamRetry as e:
-            LOG.info(
+            log_method = (
+                LOG.error
+                if e.attempts >= STREAM_ATTEMPTS_LOGGING_THRESHOLD
+                else LOG.info
+            )
+            log_method(
                 "failed to process stream, retrying",
                 attempts=e.attempts,
                 retry_at=e.retry_at,


### PR DESCRIPTION
log error when the number of attempts for an installation is too high
