### PR TITLE
fix: remove intermediate schema

### DIFF
--- a/mergify_engine/rules/__init__.py
+++ b/mergify_engine/rules/__init__.py
@@ -44,23 +44,6 @@ def PullRequestRuleCondition(value):
         )
 
 
-PullRequestRulesSchema = voluptuous.Schema(
-    voluptuous.All(
-        [
-            {
-                voluptuous.Required("name"): str,
-                voluptuous.Required("hidden", default=False): bool,
-                voluptuous.Required("conditions"): [
-                    voluptuous.All(str, voluptuous.Coerce(PullRequestRuleCondition))
-                ],
-                voluptuous.Required("actions"): actions.get_action_schemas(),
-            }
-        ],
-        voluptuous.Length(min=1),
-    )
-)
-
-
 @dataclasses.dataclass
 class PullRequestRules:
     rules: typing.List
@@ -77,10 +60,6 @@ class PullRequestRules:
 
     def __iter__(self):
         return iter(self.rules)
-
-    @classmethod
-    def from_list(cls, lst):
-        return cls(PullRequestRulesSchema(lst))
 
     def as_dict(self):
         return {
@@ -197,14 +176,26 @@ def YAML(v):
     return v
 
 
+PullRequestRulesSchema = voluptuous.All(
+    [
+        {
+            voluptuous.Required("name"): str,
+            voluptuous.Required("hidden", default=False): bool,
+            voluptuous.Required("conditions"): [
+                voluptuous.All(str, voluptuous.Coerce(PullRequestRuleCondition))
+            ],
+            voluptuous.Required("actions"): actions.get_action_schemas(),
+        }
+    ],
+    voluptuous.Length(min=1),
+    voluptuous.Coerce(PullRequestRules),
+)
+
+
 UserConfigurationSchema = voluptuous.Schema(
     voluptuous.And(
         voluptuous.Coerce(YAML),
-        {
-            voluptuous.Required("pull_request_rules"): voluptuous.Coerce(
-                PullRequestRules.from_list
-            )
-        },
+        {voluptuous.Required("pull_request_rules"): PullRequestRulesSchema},
     )
 )
 

--- a/mergify_engine/tests/unit/rules/test_rules.py
+++ b/mergify_engine/tests/unit/rules/test_rules.py
@@ -22,6 +22,10 @@ from mergify_engine import context
 from mergify_engine import rules
 
 
+def pull_request_rule_from_list(lst):
+    return voluptuous.Schema(rules.PullRequestRulesSchema)(lst)
+
+
 def test_valid_condition():
     c = rules.PullRequestRuleCondition("head~=bar")
     assert str(c) == "head~=bar"
@@ -40,11 +44,11 @@ def test_invalid_condition_re():
     ),
 )
 def test_pull_request_rule(valid):
-    rules.PullRequestRules.from_list([valid])
+    pull_request_rule_from_list([valid])
 
 
 def test_same_names():
-    pull_request_rules = rules.PullRequestRules.from_list(
+    pull_request_rules = pull_request_rule_from_list(
         [
             {"name": "hello", "conditions": [], "actions": {}},
             {"name": "foobar", "conditions": [], "actions": {}},
@@ -230,7 +234,7 @@ pull_request_rules:
 )
 def test_pull_request_rule_schema_invalid(invalid, match):
     with pytest.raises(voluptuous.MultipleInvalid, match=match):
-        rules.PullRequestRules.from_list([invalid])
+        pull_request_rule_from_list([invalid])
 
 
 def test_get_pull_request_rule():
@@ -309,7 +313,7 @@ def test_get_pull_request_rule():
     for rule in match.rules:
         assert rule["actions"] == {}
 
-    pull_request_rules = rules.PullRequestRules.from_list(
+    pull_request_rules = pull_request_rule_from_list(
         [{"name": "hello", "conditions": ["base:master"], "actions": {}}]
     )
 
@@ -320,7 +324,7 @@ def test_get_pull_request_rule():
     for rule in match.rules:
         assert rule["actions"] == {}
 
-    pull_request_rules = rules.PullRequestRules.from_list(
+    pull_request_rules = pull_request_rule_from_list(
         [
             {"name": "hello", "conditions": ["base:master"], "actions": {}},
             {"name": "backport", "conditions": ["base:master"], "actions": {}},
@@ -334,7 +338,7 @@ def test_get_pull_request_rule():
     for rule in match.rules:
         assert rule["actions"] == {}
 
-    pull_request_rules = rules.PullRequestRules.from_list(
+    pull_request_rules = pull_request_rule_from_list(
         [
             {"name": "hello", "conditions": ["#files=3"], "actions": {}},
             {"name": "backport", "conditions": ["base:master"], "actions": {}},
@@ -347,7 +351,7 @@ def test_get_pull_request_rule():
     for rule in match.rules:
         assert rule["actions"] == {}
 
-    pull_request_rules = rules.PullRequestRules.from_list(
+    pull_request_rules = pull_request_rule_from_list(
         [
             {"name": "hello", "conditions": ["#files=2"], "actions": {}},
             {"name": "backport", "conditions": ["base:master"], "actions": {}},
@@ -362,7 +366,7 @@ def test_get_pull_request_rule():
         assert rule["actions"] == {}
 
     # No match
-    pull_request_rules = rules.PullRequestRules.from_list(
+    pull_request_rules = pull_request_rule_from_list(
         [
             {
                 "name": "merge",
@@ -380,7 +384,7 @@ def test_get_pull_request_rule():
     assert [r["name"] for r in match.rules] == ["merge"]
     assert [r["name"] for r, _ in match.matching_rules] == []
 
-    pull_request_rules = rules.PullRequestRules.from_list(
+    pull_request_rules = pull_request_rule_from_list(
         [
             {
                 "name": "merge",
@@ -401,7 +405,7 @@ def test_get_pull_request_rule():
     for rule in match.rules:
         assert rule["actions"] == {}
 
-    pull_request_rules = rules.PullRequestRules.from_list(
+    pull_request_rules = pull_request_rule_from_list(
         [
             {
                 "name": "merge",
@@ -476,7 +480,7 @@ def test_get_pull_request_rule():
     )
 
     # Team conditions with one review missing
-    pull_request_rules = rules.PullRequestRules.from_list(
+    pull_request_rules = pull_request_rule_from_list(
         [
             {
                 "name": "default",
@@ -509,7 +513,7 @@ def test_get_pull_request_rule():
     del ctxt.__dict__["consolidated_reviews"]
 
     # Team conditions with no review missing
-    pull_request_rules = rules.PullRequestRules.from_list(
+    pull_request_rules = pull_request_rule_from_list(
         [
             {
                 "name": "default",
@@ -530,7 +534,7 @@ def test_get_pull_request_rule():
     assert len(match.matching_rules[0][1]) == 0
 
     # Forbidden labels, when no label set
-    pull_request_rules = rules.PullRequestRules.from_list(
+    pull_request_rules = pull_request_rule_from_list(
         [
             {
                 "name": "default",
@@ -568,7 +572,7 @@ def test_get_pull_request_rule():
     assert len(match.matching_rules[0][1]) == 0
 
     # Test team expander
-    pull_request_rules = rules.PullRequestRules.from_list(
+    pull_request_rules = pull_request_rule_from_list(
         [
             {
                 "name": "default",


### PR DESCRIPTION
Some errors just end up to `expected from_list at ...`.

This change remove the intermediate schema, so a better error is
reported.

Fixes: MRGFY-49