### PR TITLE
fix(http-client): implement __aexit__/__exit__

### DIFF
--- a/mergify_engine/clients/github.py
+++ b/mergify_engine/clients/github.py
@@ -336,6 +336,13 @@ class AsyncGithubInstallationClient(http.AsyncClient):
 
     async def aclose(self):
         await super().aclose()
+        self._generate_metrics()
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await super().__aexit__(exc_type, exc_value, traceback)
+        self._generate_metrics()
+
+    def _generate_metrics(self):
         nb_requests = len(self._requests)
         statsd.histogram(
             "http.client.session",
@@ -459,6 +466,13 @@ class GithubInstallationClient(http.Client):
 
     def close(self):
         super().close()
+        self._generate_metrics()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._generate_metrics()
+
+    def _generate_metrics(self):
         nb_requests = len(self._requests)
         statsd.histogram(
             "http.client.session",


### PR DESCRIPTION
Since httpx 0.14.3, `aclose` is no more called by `__aexit__()`.
So we have to implement it too.