### PR TITLE
refactor(auth): make auth repo-free

### DIFF
--- a/mergify_engine/clients/github.py
+++ b/mergify_engine/clients/github.py
@@ -148,9 +148,8 @@ class GithubAppInstallationAuth(httpx.Auth):
                     )
                 if installation_response.status_code == 404:
                     LOG.debug(
-                        "Mergify not installed or repository not found",
+                        "Mergify not installed",
                         gh_owner=self.owner,
-                        gh_repo=self.repo,
                         error_message=installation_response.json()["message"],
                     )
                     raise exceptions.MergifyNotInstalled()
@@ -178,7 +177,7 @@ class GithubAppInstallationAuth(httpx.Auth):
 
     def build_installation_request(self, url=None, force=False):
         if url is None:
-            url = f"{config.GITHUB_API_URL}/repos/{self.owner}/{self.repo}/installation"
+            url = f"{config.GITHUB_API_URL}/users/{self.owner}/installation"
         return self.build_github_app_request("GET", url, force=force)
 
     def build_access_token_request(self, force=False):

--- a/mergify_engine/tests/unit/test_clients.py
+++ b/mergify_engine/tests/unit/test_clients.py
@@ -31,7 +31,7 @@ def test_client_401_raise_ratelimit(httpserver):
     owner = "owner"
     repo = "repo"
 
-    httpserver.expect_request("/repos/owner/repo/installation").respond_with_json(
+    httpserver.expect_request("/users/owner/installation").respond_with_json(
         {
             "id": 12345,
             "target_type": "User",
@@ -163,7 +163,7 @@ def test_client_retry_429_retry_after_as_absolute_date(httpserver):
 
 @mock.patch.object(github.CachedToken, "STORAGE", {})
 def test_client_access_token_HTTP_500(httpserver):
-    httpserver.expect_request("/repos/owner/repo/installation").respond_with_json(
+    httpserver.expect_request("/users/owner/installation").respond_with_json(
         {
             "id": 12345,
             "target_type": "User",
@@ -204,7 +204,7 @@ def test_client_access_token_HTTP_500(httpserver):
 
 @mock.patch.object(github.CachedToken, "STORAGE", {})
 def test_client_installation_HTTP_500(httpserver):
-    httpserver.expect_request("/repos/owner/repo/installation").respond_with_data(
+    httpserver.expect_request("/users/owner/installation").respond_with_data(
         "This is an 5XX error", status=500
     )
     with mock.patch(
@@ -224,7 +224,7 @@ def test_client_installation_HTTP_500(httpserver):
     assert exc_info.value.status_code == 500
     assert exc_info.value.response.status_code == 500
     assert str(exc_info.value.request.url) == httpserver.url_for(
-        "/repos/owner/repo/installation"
+        "/users/owner/installation"
     )
 
     httpserver.check_assertions()
@@ -232,7 +232,7 @@ def test_client_installation_HTTP_500(httpserver):
 
 @mock.patch.object(github.CachedToken, "STORAGE", {})
 def test_client_installation_HTTP_404(httpserver):
-    httpserver.expect_request("/repos/owner/repo/installation").respond_with_json(
+    httpserver.expect_request("/users/owner/installation").respond_with_json(
         {"message": "Repository not found"}, status=404
     )
     with mock.patch(
@@ -252,7 +252,7 @@ def test_client_installation_HTTP_404(httpserver):
 
 @mock.patch.object(github.CachedToken, "STORAGE", {})
 def test_client_installation_HTTP_301(httpserver):
-    httpserver.expect_request("/repos/owner/repo/installation").respond_with_data(
+    httpserver.expect_request("/users/owner/installation").respond_with_data(
         status=301,
         headers={"Location": httpserver.url_for("/repositories/12345/installation")},
     )


### PR DESCRIPTION
This makes it possible to authenticate without specifying a repository.