### PR TITLE
ci: disable pre_commands for black/pep8 targets

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,7 @@ commands = bash -c "{posargs}"
 whitelist_externals = bash
 
 [testenv:black]
+pre_commands =
 skip_install = true
 deps =
   black
@@ -74,6 +75,7 @@ commands =
   black .
 
 [testenv:pep8]
+pre_commands =
 skip_install = true
 deps = flake8
        flake8-black


### PR DESCRIPTION
No need to install the requirements list.