### PR TITLE
feat(config): check the length of users/teams for request reviews

### DIFF
--- a/doc/source/actions.rst
+++ b/doc/source/actions.rst
@@ -482,7 +482,8 @@ Using the ``rebase`` method for the strict merge has many drawbacks:
 request_reviews
 ===============
 
-The ``request_reviews`` action requests reviews from users for the pull request.
+The ``request_reviews`` action requests reviews from users for the pull
+request.
 
 .. list-table::
   :header-rows: 1
@@ -500,6 +501,10 @@ The ``request_reviews`` action requests reviews from users for the pull request.
     - list of string
     -
     - The team name to request reviews from.
+
+.. note::
+
+   GitHub does not allow more to request more 15 users or teams for a review.
 
 .. _rebase action:
 

--- a/mergify_engine/actions/request_reviews.py
+++ b/mergify_engine/actions/request_reviews.py
@@ -1,3 +1,18 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright © 2019–2020 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
 import itertools
 
 import voluptuous
@@ -15,8 +30,14 @@ class RequestReviewsAction(actions.Action):
     GITHUB_MAXIMUM_REVIEW_REQUEST = 15
 
     validator = {
-        voluptuous.Required("users", default=[]): [types.GitHubLogin],
-        voluptuous.Required("teams", default=[]): [types.GitHubTeam],
+        voluptuous.Required("users", default=[]): voluptuous.All(
+            [types.GitHubLogin],
+            voluptuous.Length(max=GITHUB_MAXIMUM_REVIEW_REQUEST),
+        ),
+        voluptuous.Required("teams", default=[]): voluptuous.All(
+            [types.GitHubTeam],
+            voluptuous.Length(max=GITHUB_MAXIMUM_REVIEW_REQUEST),
+        ),
     }
 
     silent_report = True

--- a/mergify_engine/tests/unit/actions/test_request_reviews.py
+++ b/mergify_engine/tests/unit/actions/test_request_reviews.py
@@ -1,0 +1,64 @@
+# Copyright © 2020 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+import pytest
+import voluptuous
+
+from mergify_engine.actions import request_reviews
+
+
+@pytest.mark.parametrize(
+    "config",
+    (
+        {},
+        {
+            "users": ["hello"],
+        },
+        {
+            "teams": ["hello", "@foobar"],
+        },
+    ),
+)
+def test_config(config):
+    request_reviews.RequestReviewsAction.get_schema()(config)
+
+
+@pytest.mark.parametrize(
+    "config,error",
+    (
+        (
+            {
+                "users": ["hello"]
+                * (
+                    request_reviews.RequestReviewsAction.GITHUB_MAXIMUM_REVIEW_REQUEST
+                    + 1
+                ),
+            },
+            "length of value must be at most 15 for dictionary value @ data['users']",
+        ),
+        (
+            {
+                "teams": ["hello"]
+                * (
+                    request_reviews.RequestReviewsAction.GITHUB_MAXIMUM_REVIEW_REQUEST
+                    + 1
+                ),
+            },
+            "length of value must be at most 15 for dictionary value @ data['teams']",
+        ),
+    ),
+)
+def test_config_not_ok(config, error):
+    with pytest.raises(voluptuous.MultipleInvalid) as p:
+        request_reviews.RequestReviewsAction.get_schema()(config)
+    assert str(p.value) == error


### PR DESCRIPTION
Setting more than 15 users is not going to work, so let's try to validate this
a little in the configuration file.