### PR TITLE
fix(action): ignore conflicts by default

### DIFF
--- a/doc/source/actions.rst
+++ b/doc/source/actions.rst
@@ -76,7 +76,7 @@ parameter:
        to.
    * - ``ignore_conflicts``
      - Boolean
-     - ``False``
+     - ``True``
      - Whether to create the pull requests even if they are conflicts when
        cherry-picking the commits.
    * - ``label_conflicts``
@@ -121,7 +121,7 @@ The ``copy`` action creates a copy of the pull request targetting other branches
      - The list of regexes to find branches the pull request should be copied to.
    * - ``ignore_conflicts``
      - Boolean
-     - ``False``
+     - ``True``
      - Whether to create the pull requests even if they are conflicts when
        cherry-picking the commits.
    * - ``label_conflicts``

--- a/mergify_engine/actions/copy.py
+++ b/mergify_engine/actions/copy.py
@@ -41,7 +41,7 @@ class CopyAction(actions.Action):
     validator = {
         voluptuous.Required("branches", default=[]): [str],
         voluptuous.Required("regexes", default=[]): [Regex],
-        voluptuous.Required("ignore_conflicts", default=False): bool,
+        voluptuous.Required("ignore_conflicts", default=True): bool,
         voluptuous.Required("label_conflicts", default="conflicts"): str,
     }
 

--- a/mergify_engine/tests/unit/test_command.py
+++ b/mergify_engine/tests/unit/test_command.py
@@ -51,6 +51,6 @@ def test_command_loader():
     assert action.config == {
         "branches": ["branch-3.1", "branch-3.2"],
         "regexes": [],
-        "ignore_conflicts": False,
+        "ignore_conflicts": True,
         "label_conflicts": "conflicts",
     }


### PR DESCRIPTION
This restores the previous behaviour of creating conflicting backport by
default. This is what people seems to be using.

It also fixes a limitation: since commands can't have options, it's impossible
to do a backport via the command in comment when there's a conflict.
This makes it possible and up to the user to close the conflicting backport if
needed.