### PR TITLE
fix(request_reviews): do not limit the number of user/teams

### DIFF
--- a/mergify_engine/actions/request_reviews.py
+++ b/mergify_engine/actions/request_reviews.py
@@ -37,19 +37,13 @@ class RequestReviewsAction(actions.Action):
 
     validator = {
         voluptuous.Required("users", default=[]): voluptuous.Any(
-            voluptuous.All(
-                [types.GitHubLogin],
-                voluptuous.Length(max=GITHUB_MAXIMUM_REVIEW_REQUEST),
-            ),
+            [types.GitHubLogin],
             {
                 types.GitHubLogin: _random_weight,
             },
         ),
         voluptuous.Required("teams", default=[]): voluptuous.Any(
-            voluptuous.All(
-                [types.GitHubTeam],
-                voluptuous.Length(max=GITHUB_MAXIMUM_REVIEW_REQUEST),
-            ),
+            [types.GitHubTeam],
             {
                 types.GitHubTeam: _random_weight,
             },

--- a/mergify_engine/tests/unit/actions/test_request_reviews.py
+++ b/mergify_engine/tests/unit/actions/test_request_reviews.py
@@ -38,37 +38,6 @@ def test_config(config):
     request_reviews.RequestReviewsAction.get_schema()(config)
 
 
-@pytest.mark.parametrize(
-    "config,error",
-    (
-        (
-            {
-                "users": ["hello"]
-                * (
-                    request_reviews.RequestReviewsAction.GITHUB_MAXIMUM_REVIEW_REQUEST
-                    + 1
-                ),
-            },
-            "length of value must be at most 15 for dictionary value @ data['users']",
-        ),
-        (
-            {
-                "teams": ["hello"]
-                * (
-                    request_reviews.RequestReviewsAction.GITHUB_MAXIMUM_REVIEW_REQUEST
-                    + 1
-                ),
-            },
-            "length of value must be at most 15 for dictionary value @ data['teams']",
-        ),
-    ),
-)
-def test_config_not_ok(config, error):
-    with pytest.raises(voluptuous.MultipleInvalid) as p:
-        request_reviews.RequestReviewsAction.get_schema()(config)
-    assert str(p.value) == error
-
-
 def test_random_reviewers():
     action = request_reviews.RequestReviewsAction.get_schema()(
         {


### PR DESCRIPTION
When `random_count` is being used, it should be possible to list more than 15
users/teams.

We still do the check at runtime.
