### PR TITLE
fix: backport error should return failure

### DIFF
--- a/mergify_engine/actions/copy.py
+++ b/mergify_engine/actions/copy.py
@@ -64,7 +64,7 @@ class CopyAction(actions.Action):
             if e.response.status_code >= 500:
                 state = check_api.Conclusion.PENDING
             else:
-                state = check_api.Conclusion.SUCCESS
+                state = check_api.Conclusion.FAILURE
                 detail += e.response.json()["message"]
             return state, detail
 


### PR DESCRIPTION
I discover this because related tests can't be record again.

With this record work again.