### PR TITLE
fix: add uvicorn extra

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ urllib3==1.25.10
 uvicorn==0.12.1
 uvloop==0.14.0
 voluptuous==0.12.0
+watchgod==0.6
 websockets==8.1
 Werkzeug==1.0.1
 -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     python-dotenv
     fastapi
     python-multipart  # fastapi extra
-    uvicorn
+    uvicorn[standard]
     cryptography
     aredis
     redis!=3.4.1,!=3.4.0
@@ -43,9 +43,6 @@ install_requires =
     msgpack
     jinja2
     werkzeug
-    uvloop
-    websockets
-    httptools
 
 [options.extras_require]
 test =


### PR DESCRIPTION
Since 0.12.0, many deps are optionnal, but we need them...

https://github.com/encode/uvicorn/commit/5fa99a11d6e07367cd559a4fc8694ce537796558

Dependabot never remove obsolete deps, so we didn't catch the issue
until I regenerate the requirements.txt from scratch.

But even with that we have no test to check this kind of bug.
The bug is only triggered when the Procfile is used.