### PR TITLE
fix: decorate git error message with <pre>

### DIFF
--- a/mergify_engine/branch_updater.py
+++ b/mergify_engine/branch_updater.py
@@ -166,7 +166,10 @@ def _do_update(ctxt, token, method="merge"):
     except subprocess.CalledProcessError as in_exception:  # pragma: no cover
         for message, out_exception in GIT_MESSAGE_TO_EXCEPTION.items():
             if message in in_exception.output:
-                raise out_exception(in_exception.output.decode())
+                raise out_exception(
+                    "Git reported the following error:\n"
+                    f"```\n{in_exception.output.decode()}\n```\n"
+                )
         else:
             ctxt.log.error(
                 "update branch failed: %s",

--- a/mergify_engine/duplicate_pull.py
+++ b/mergify_engine/duplicate_pull.py
@@ -242,7 +242,10 @@ def duplicate(
                 if out_exception is None:
                     return
                 else:
-                    raise out_exception(in_exception.output.decode())
+                    raise out_exception(
+                        "Git reported the following error:\n"
+                        f"```\n{in_exception.output.decode()}\n```\n"
+                    )
         else:
             ctxt.log.error(
                 "duplicate failed: %s",


### PR DESCRIPTION
Git reported message can have some html tag coming from user code.

We must escape them with a `<pre>` tag so Github will not render them.

Close #1529
