### PR TITLE
fix: uvloop py39 workaround

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ starlette==0.13.6
 tenacity==6.2.0
 urllib3==1.25.11
 uvicorn==0.12.2
-uvloop==0.14.0
+./uvloop-0.15.0.dev0-cp39-cp39-linux_x86_64.whl
 voluptuous==0.12.0
 watchgod==0.6
 websockets==8.1

--- a/tox.ini
+++ b/tox.ini
@@ -57,6 +57,7 @@ commands =
   pip uninstall --yes mergify-engine
   bash -c "pip freeze --exclude-editable >| requirements.txt"
   bash -c "echo '-e .' >> requirements.txt"
+  bash -c "sed -i -e 's,^uvloop.*,./uvloop-0.15.0.dev0-cp39-cp39-linux_x86_64.whl,g' requirements.txt"
 whitelist_externals =
     bash
 


### PR DESCRIPTION
until 0.15 is release we need this fix

Fixes MERGIFY-ENGINE-1WQ
