### PR TITLE
refactor(clients): do not check /rate_limit each time

### DIFF
--- a/mergify_engine/exceptions.py
+++ b/mergify_engine/exceptions.py
@@ -11,7 +11,8 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-
+import dataclasses
+import datetime
 import typing
 
 from mergify_engine.clients import http
@@ -21,10 +22,10 @@ class MergifyNotInstalled(Exception):
     pass
 
 
+@dataclasses.dataclass
 class RateLimited(Exception):
-    def __init__(self, countdown, raw_data):
-        self.countdown = countdown
-        self.raw_data = raw_data
+    countdown: datetime.timedelta
+    remaining: int
 
 
 class MergeableStateUnknown(Exception):

--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -267,7 +267,7 @@ class StreamProcessor:
             raise IgnoredException() from e
 
         if isinstance(e, exceptions.RateLimited):
-            retry_at = utils.utcnow() + datetime.timedelta(seconds=e.countdown)
+            retry_at = utils.utcnow() + e.countdown
             score = retry_at.timestamp()
             if attempts_key:
                 await self.redis.hdel("attempts", attempts_key)


### PR DESCRIPTION
We only check the value returned by GitHub API when a 403 is returned, without
making another request.