### PR TITLE
fix(merge): do not start queue in UI on 0

### DIFF
--- a/mergify_engine/actions/merge.py
+++ b/mergify_engine/actions/merge.py
@@ -200,7 +200,7 @@ class MergeAction(actions.Action):
                 ctxt.log.error("expected queued pull request not found in queue")
                 title = "The pull request is queued to be merged"
             else:
-                ord = utils.to_ordinal_numeric(position)
+                ord = utils.to_ordinal_numeric(position + 1)
                 title = f"The pull request is the {ord} in the queue to be merged"
 
             if is_behind:


### PR DESCRIPTION
Right now if a PR is first in queue it says "0th".