### PR TITLE
fix(sub): remove spurious log line

### DIFF
--- a/mergify_engine/subscription.py
+++ b/mergify_engine/subscription.py
@@ -121,7 +121,6 @@ class Subscription:
 
     @classmethod
     async def _retrieve_subscription_from_db(cls, owner_id):
-        LOG.info("Subscription not cached, retrieving it...", gh_owner=owner_id)
         async with http.AsyncClient() as client:
             try:
                 resp = await client.get(


### PR DESCRIPTION
The log field for the owner is an id and not a login name, making it impossible
to find the log entry anyway. Just remove the log entirely.