### PR TITLE
chore: handle status pending

### DIFF
--- a/mergify_engine/github_events.py
+++ b/mergify_engine/github_events.py
@@ -45,9 +45,6 @@ def get_ignore_reason(event_type, data):
     elif event_type in ["push"] and not data["ref"].startswith("refs/heads/"):
         return f"push on {data['ref']}"
 
-    elif event_type == "status" and data["state"] == "pending":
-        return "state pending"
-
     elif event_type == "check_suite" and data["action"] != "rerequested":
         return f"check_suite/{data['action']}"
 


### PR DESCRIPTION
We was ignoring this state to reduce the load before we was batching
events.

Ignoring this status have a unwanted behavior. If CI fails and user
re-run it, the status goes back to pending from GitHub point of view,
but for us, it's stay failing until we receive success.

In real world, we often received events that make us looks at the status
and user didn't notice it was not updated on time.