### PR TITLE
ci(tox): specify basepython

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py39,pep8
 skipsdist = true
 
 [testenv]
+basepython = python3.9
 setenv =
    MERGIFYENGINE_TEST_SETTINGS=fake.env
 usedevelop = true
@@ -46,7 +47,6 @@ skip_install = true
 commands = pip check
 
 [testenv:genreqs]
-basepython = python3.9
 recreate = true
 skip_install = true
 deps =


### PR DESCRIPTION
Right now, for example, the `record` target takes whatever Python tox is
installed with.