### PR TITLE
Pull request for fix-monitoring-task

### DIFF
--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -634,13 +634,12 @@ class Worker:
                     "streams",
                     min=0,
                     max=now,
-                    start=self.worker_count,
                     withscores=True,
                 )
                 # NOTE(sileht): The latency may not be exact with the next StreamSelector
                 # based on hash+modulo
-                if streams:
-                    latency = now - streams[0][1]
+                if len(streams) > self.worker_count:
+                    latency = now - streams[self.worker_count][1]
                     statsd.timing("engine.streams.latency", latency)
                 else:
                     statsd.timing("engine.streams.latency", 0)

--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -652,7 +652,7 @@ class Worker:
                     "engine.workers-per-process.count", self.worker_per_process
                 )
             except Exception:
-                LOG.warning("monitoring task failed", exc_info=True)
+                LOG.error("monitoring task failed", exc_info=True)
 
             await self._sleep_or_stop(60)
 


### PR DESCRIPTION
## fix(worker): log an error when monitoring fails


## fix(worker): do not use start in zrangebyscore without num

This is the same result as previous, but now it works.