### PR TITLE
refactor(rules): pass object to Filter.__call__ rather than dict

### DIFF
--- a/mergify_engine/actions/merge.py
+++ b/mergify_engine/actions/merge.py
@@ -32,6 +32,11 @@ if typing.TYPE_CHECKING:
 LOG = daiquiri.getLogger(__name__)
 
 
+class FakePR:
+    def __init__(self, key: str, value: typing.Any):
+        setattr(self, key, value)
+
+
 class MergeAction(merge_base.MergeBaseAction):
 
     validator = {
@@ -134,7 +139,7 @@ class MergeAction(merge_base.MergeBaseAction):
                 state
                 for name, state in ctxt.checks.items()
                 for cond in need_look_at_checks
-                if cond({cond.attribute_name: name})
+                if cond(FakePR(cond.attribute_name, name))
             ]
             if not states:
                 return False

--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -524,7 +524,7 @@ class RenderTemplateFailure(Exception):
 class PullRequest:
     """A high level pull request object.
 
-    This object is used for e.g. templates.
+    This object is used for templates and rule evaluations.
     """
 
     context: Context

--- a/mergify_engine/rules/__init__.py
+++ b/mergify_engine/rules/__init__.py
@@ -143,14 +143,9 @@ class RulesEvaluator:
             next_conditions_to_validate = []
             for condition in rule.conditions:
                 for attrib in self.TEAM_ATTRIBUTES:
-                    condition.set_value_expanders(
-                        attrib,
-                        self.context.resolve_teams,
-                    )
+                    condition.value_expanders[attrib] = self.context.resolve_teams
 
-                name = condition.get_attribute_name()
-                value = getattr(self.context.pull_request, name)
-                if not condition({name: value}):
+                if not condition(self.context.pull_request):
                     next_conditions_to_validate.append(condition)
                     if condition.attribute_name in self.BASE_ATTRIBUTES:
                         ignore_rules = True


### PR DESCRIPTION
This allows to pass context.PullRequest object directly rather than building an
intermediary dict.
