### PR TITLE
fix(github_types): only set action field where available

### DIFF
--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -460,12 +460,13 @@ class Context(object):
 
     def have_been_synchronized(self) -> bool:
         for source in self.sources:
-            if (
-                source["event_type"] == "pull_request"
-                and source["data"]["action"] == "synchronize"
-                and source["data"]["sender"]["id"] != config.BOT_USER_ID
-            ):
-                return True
+            if source["event_type"] == "pull_request":
+                event = typing.cast(github_types.GitHubEventPullRequest, source["data"])
+                if (
+                    event["action"] == "synchronize"
+                    and event["sender"]["id"] != config.BOT_USER_ID
+                ):
+                    return True
         return False
 
     def __str__(self) -> str:

--- a/mergify_engine/github_types.py
+++ b/mergify_engine/github_types.py
@@ -134,32 +134,81 @@ GitHubEventType = typing.Literal[
 
 
 class GitHubEvent(typing.TypedDict):
-    action: str
     repository: GitHubRepository
     organization: GitHubAccount
     installation: GitHubInstallation
     sender: GitHubAccount
 
 
+GitHubEventRefreshActionType = typing.Literal[
+    "user",
+    "forced",
+]
+
+
 # This does not exist in GitHub, it's a Mergify made one
 class GitHubEventRefresh(GitHubEvent):
+    action: GitHubEventRefreshActionType
     ref: typing.Optional[GitHubRefType]
     pull_request: typing.Optional[GitHubPullRequest]
 
 
+GitHubEventPullRequestActionType = typing.Literal[
+    "opened",
+    "edited",
+    "closed",
+    "assigned",
+    "unassigned",
+    "review_requested",
+    "review_request_removed",
+    "ready_for_review",
+    "labeled",
+    "unlabeled",
+    "synchronize",
+    "locked",
+    "unlocked",
+    "reopened",
+]
+
+
 class GitHubEventPullRequest(GitHubEvent):
+    action: GitHubEventPullRequestActionType
     pull_request: GitHubPullRequest
+
+
+GitHubEventPullRequestReviewCommentActionType = typing.Literal[
+    "created",
+    "edited",
+    "deleted",
+]
 
 
 class GitHubEventPullRequestReviewComment(GitHubEvent):
+    action: GitHubEventPullRequestReviewCommentActionType
     pull_request: GitHubPullRequest
+
+
+GitHubEventPullRequestReviewActionType = typing.Literal[
+    "submitted",
+    "edited",
+    "dismissed",
+]
 
 
 class GitHubEventPullRequestReview(GitHubEvent):
+    action: GitHubEventPullRequestReviewActionType
     pull_request: GitHubPullRequest
 
 
+GitHubEventIssueCommentActionType = typing.Literal[
+    "created",
+    "edited",
+    "deleted",
+]
+
+
 class GitHubEventIssueComment(GitHubEvent):
+    action: GitHubEventIssueCommentActionType
     issue: GitHubIssue
     comment: GitHubComment
 
@@ -218,9 +267,27 @@ class GitHubCheckSuite(typing.TypedDict):
     after: SHAType
 
 
+GitHubCheckRunActionType = typing.Literal[
+    "created",
+    "completed",
+    "rerequested",
+    "requested_action",
+]
+
+
 class GitHubEventCheckRun(GitHubEvent):
+    action: GitHubCheckRunActionType
     check_run: GitHubCheckRun
 
 
+GitHubCheckSuiteActionType = typing.Literal[
+    "created",
+    "completed",
+    "rerequested",
+    "requested_action",
+]
+
+
 class GitHubEventCheckSuite(GitHubEvent):
+    action: GitHubCheckSuiteActionType
     check_suite: GitHubCheckSuite

--- a/mergify_engine/web/__init__.py
+++ b/mergify_engine/web/__init__.py
@@ -81,7 +81,7 @@ async def http_post(*args, **kwargs):
 async def _refresh(
     owner: str,
     repo: str,
-    action: str = "user",
+    action: github_types.GitHubEventRefreshActionType = "user",
     ref: github_types.GitHubRefType = None,
     pull_request: github_types.GitHubPullRequest = None,
 ) -> responses.Response:
@@ -137,7 +137,10 @@ RefreshActionSchema = voluptuous.Schema(voluptuous.Any("user", "forced"))
     dependencies=[fastapi.Depends(auth.signature)],
 )
 async def refresh_pull(
-    owner: str, repo: str, pull: int, action: str = "user"
+    owner: str,
+    repo: str,
+    pull: int,
+    action: github_types.GitHubEventRefreshActionType = "user",
 ) -> responses.Response:
     action = RefreshActionSchema(action)
     return await _refresh(


### PR DESCRIPTION
Some GitHub events actually do not have the `action` attribute.
Declare those events and use Literal to handle valid values.