### PR TITLE
fix(github_types): repository is not on every GitHubEvent

### DIFF
--- a/mergify_engine/engine/commands_runner.py
+++ b/mergify_engine/engine/commands_runner.py
@@ -74,14 +74,14 @@ def load_action(
     return None
 
 
-async def on_each_event(
-    owner: str, repo: str, data: github_types.GitHubEventIssueComment
-) -> None:
-    action = load_action(data["comment"]["body"])
+async def on_each_event(event: github_types.GitHubEventIssueComment) -> None:
+    action = load_action(event["comment"]["body"])
     if action:
+        owner = event["repository"]["owner"]["login"]
+        repo = event["repository"]["name"]
         async with await github.aget_client(owner) as client:
             await client.post(
-                f"/repos/{owner}/{repo}/issues/comments/{data['comment']['id']}/reactions",
+                f"/repos/{owner}/{repo}/issues/comments/{event['comment']['id']}/reactions",
                 json={"content": "+1"},
                 api_version="squirrel-girl",
             )  # type: ignore[call-arg]

--- a/mergify_engine/github_types.py
+++ b/mergify_engine/github_types.py
@@ -134,7 +134,6 @@ GitHubEventType = typing.Literal[
 
 
 class GitHubEvent(typing.TypedDict):
-    repository: GitHubRepository
     organization: GitHubAccount
     installation: GitHubInstallation
     sender: GitHubAccount
@@ -148,6 +147,7 @@ GitHubEventRefreshActionType = typing.Literal[
 
 # This does not exist in GitHub, it's a Mergify made one
 class GitHubEventRefresh(GitHubEvent):
+    repository: GitHubRepository
     action: GitHubEventRefreshActionType
     ref: typing.Optional[GitHubRefType]
     pull_request: typing.Optional[GitHubPullRequest]
@@ -172,6 +172,7 @@ GitHubEventPullRequestActionType = typing.Literal[
 
 
 class GitHubEventPullRequest(GitHubEvent):
+    repository: GitHubRepository
     action: GitHubEventPullRequestActionType
     pull_request: GitHubPullRequest
 
@@ -184,6 +185,7 @@ GitHubEventPullRequestReviewCommentActionType = typing.Literal[
 
 
 class GitHubEventPullRequestReviewComment(GitHubEvent):
+    repository: GitHubRepository
     action: GitHubEventPullRequestReviewCommentActionType
     pull_request: GitHubPullRequest
 
@@ -196,6 +198,7 @@ GitHubEventPullRequestReviewActionType = typing.Literal[
 
 
 class GitHubEventPullRequestReview(GitHubEvent):
+    repository: GitHubRepository
     action: GitHubEventPullRequestReviewActionType
     pull_request: GitHubPullRequest
 
@@ -208,18 +211,21 @@ GitHubEventIssueCommentActionType = typing.Literal[
 
 
 class GitHubEventIssueComment(GitHubEvent):
+    repository: GitHubRepository
     action: GitHubEventIssueCommentActionType
     issue: GitHubIssue
     comment: GitHubComment
 
 
 class GitHubEventPush(GitHubEvent):
+    repository: GitHubRepository
     ref: GitHubRefType
     before: SHAType
     after: SHAType
 
 
 class GitHubEventStatus(GitHubEvent):
+    repository: GitHubRepository
     sha: str
 
 
@@ -276,6 +282,7 @@ GitHubCheckRunActionType = typing.Literal[
 
 
 class GitHubEventCheckRun(GitHubEvent):
+    repository: GitHubRepository
     action: GitHubCheckRunActionType
     check_run: GitHubCheckRun
 
@@ -289,5 +296,6 @@ GitHubCheckSuiteActionType = typing.Literal[
 
 
 class GitHubEventCheckSuite(GitHubEvent):
+    repository: GitHubRepository
     action: GitHubCheckSuiteActionType
     check_suite: GitHubCheckSuite

--- a/mergify_engine/tests/unit/test_web.py
+++ b/mergify_engine/tests/unit/test_web.py
@@ -19,6 +19,7 @@ import os
 import pytest
 from starlette import testclient
 
+from mergify_engine import github_types
 from mergify_engine import utils
 from mergify_engine import web
 
@@ -44,7 +45,7 @@ with open(
             },
             None,
             200,
-            b"Event ignored: no repository found",
+            b"Event ignored: unexpected event_type",
         ),
         (
             push_event,
@@ -60,7 +61,9 @@ with open(
         ),
     ),
 )
-def test_push_event(event, event_type, status_code, reason):
+def test_push_event(
+    event: github_types.GitHubEvent, event_type: str, status_code: int, reason: bytes
+) -> None:
     with testclient.TestClient(web.app) as client:
         charset = "utf-8"
         data = json.dumps(event).encode(charset)


### PR DESCRIPTION
Some GitHubEvent do not have the `repository` field, takes that into account.

That needs a big refactor of the `get_ignore_reason` function. Therefore, this
patch refactors GitHub event handling to cast them only once and handle them
entirely in a single function.

This makes it easier to read the code handling each event type and seeing how
they are processed or ignored.