### PR TITLE
chore: remove useless code

### DIFF
--- a/mergify_engine/github_events.py
+++ b/mergify_engine/github_events.py
@@ -283,10 +283,6 @@ async def _get_github_pulls_from_sha(client, repo, sha, pulls):
             if pull["head"]["sha"] == sha:
                 await redis.set(cache_key, pull["number"], ex=SHA_EXPIRATION)
                 return [pull["number"]]
-
-        await redis.set(cache_key, -1, ex=SHA_EXPIRATION)
-        return []
-    elif pull_number == -1:
         return []
     else:
         return [int(pull_number)]


### PR DESCRIPTION
We don't need to cache the fact that this sha is not attach to a pull
request since we don't do API call anymore in this method.