### PR TITLE
chore(sentry): increase log message size

### DIFF
--- a/mergify_engine/__init__.py
+++ b/mergify_engine/__init__.py
@@ -27,3 +27,4 @@ if config.SENTRY_URL:  # pragma: no cover
         environment=config.SENTRY_ENVIRONMENT,
         integrations=[RedisIntegration()],
     )
+    sentry_sdk.utils.MAX_STRING_LENGTH = 2048


### PR DESCRIPTION
We have many sentry with truncated exc_info, eg:

Traceback (most recent call last):
  File "/app/.heroku/python/bin/mergify-engine-worker", line 33, in <module>
    sys.exit(load_entry_point('mergify-engine', 'console_scripts', 'mergify-engine-worker')())
  File "/app/mergify_engine/worker.py", line 797, in main
    return asyncio.run(run_forever())
  File "/app/.heroku/python/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/app/.heroku/python/lib/python3.9/asyncio/base_events.py", line 640, in run_un...

This should help to debug them.