### PR TITLE
fix(tests): don't use Test word in non-test class

### DIFF
--- a/mergify_engine/tests/unit/rules/test_filter.py
+++ b/mergify_engine/tests/unit/rules/test_filter.py
@@ -18,60 +18,60 @@ import pytest
 from mergify_engine.rules import filter
 
 
-class TestDict(dict):  # type: ignore[type-arg]
+class FakePR(dict):  # type: ignore[type-arg]
     def __getattr__(self, k):
         return self[k]
 
 
 def test_binary() -> None:
     f = filter.Filter({"=": ("foo", 1)})
-    assert f(TestDict({"foo": 1}))
-    assert not f(TestDict({"foo": 2}))
+    assert f(FakePR({"foo": 1}))
+    assert not f(FakePR({"foo": 2}))
 
 
 def test_string() -> None:
     f = filter.Filter({"=": ("foo", "bar")})
-    assert f(TestDict({"foo": "bar"}))
-    assert not f(TestDict({"foo": 2}))
+    assert f(FakePR({"foo": "bar"}))
+    assert not f(FakePR({"foo": 2}))
 
 
 def test_not() -> None:
     f = filter.Filter({"-": {"=": ("foo", 1)}})
-    assert not f(TestDict({"foo": 1}))
-    assert f(TestDict({"foo": 2}))
+    assert not f(FakePR({"foo": 1}))
+    assert f(FakePR({"foo": 2}))
 
 
 def test_len() -> None:
     f = filter.Filter({"=": ("#foo", 3)})
-    assert f(TestDict({"foo": "bar"}))
+    assert f(FakePR({"foo": "bar"}))
     with pytest.raises(filter.InvalidOperator):
-        f(TestDict({"foo": 2}))
-    assert not f(TestDict({"foo": "a"}))
-    assert not f(TestDict({"foo": "abcedf"}))
-    assert f(TestDict({"foo": [10, 20, 30]}))
-    assert not f(TestDict({"foo": [10, 20]}))
-    assert not f(TestDict({"foo": [10, 20, 40, 50]}))
+        f(FakePR({"foo": 2}))
+    assert not f(FakePR({"foo": "a"}))
+    assert not f(FakePR({"foo": "abcedf"}))
+    assert f(FakePR({"foo": [10, 20, 30]}))
+    assert not f(FakePR({"foo": [10, 20]}))
+    assert not f(FakePR({"foo": [10, 20, 40, 50]}))
     f = filter.Filter({">": ("#foo", 3)})
-    assert f(TestDict({"foo": "barz"}))
+    assert f(FakePR({"foo": "barz"}))
     with pytest.raises(filter.InvalidOperator):
-        f(TestDict({"foo": 2}))
-    assert not f(TestDict({"foo": "a"}))
-    assert f(TestDict({"foo": "abcedf"}))
-    assert f(TestDict({"foo": [10, "abc", 20, 30]}))
-    assert not f(TestDict({"foo": [10, 20]}))
-    assert not f(TestDict({"foo": []}))
+        f(FakePR({"foo": 2}))
+    assert not f(FakePR({"foo": "a"}))
+    assert f(FakePR({"foo": "abcedf"}))
+    assert f(FakePR({"foo": [10, "abc", 20, 30]}))
+    assert not f(FakePR({"foo": [10, 20]}))
+    assert not f(FakePR({"foo": []}))
 
 
 def test_regexp() -> None:
     f = filter.Filter({"~=": ("foo", "^f")})
-    assert f(TestDict({"foo": "foobar"}))
-    assert f(TestDict({"foo": "foobaz"}))
-    assert not f(TestDict({"foo": "x"}))
-    assert not f(TestDict({"foo": None}))
+    assert f(FakePR({"foo": "foobar"}))
+    assert f(FakePR({"foo": "foobaz"}))
+    assert not f(FakePR({"foo": "x"}))
+    assert not f(FakePR({"foo": None}))
 
     f = filter.Filter({"~=": ("foo", "^$")})
-    assert f(TestDict({"foo": ""}))
-    assert not f(TestDict({"foo": "x"}))
+    assert f(FakePR({"foo": ""}))
+    assert not f(FakePR({"foo": "x"}))
 
 
 def test_regexp_invalid() -> None:
@@ -84,47 +84,47 @@ def test_set_value_expanders() -> None:
         {"=": ("foo", "@bar")},
         value_expanders={"foo": lambda x: [x.replace("@", "foo")]},
     )
-    assert f(TestDict({"foo": "foobar"}))
-    assert not f(TestDict({"foo": "x"}))
+    assert f(FakePR({"foo": "foobar"}))
+    assert not f(FakePR({"foo": "x"}))
 
 
 def test_set_value_expanders_unset_at_init() -> None:
     f = filter.Filter({"=": ("foo", "@bar")})
     f.value_expanders = {"foo": lambda x: [x.replace("@", "foo")]}
-    assert f(TestDict({"foo": "foobar"}))
-    assert not f(TestDict({"foo": "x"}))
+    assert f(FakePR({"foo": "foobar"}))
+    assert not f(FakePR({"foo": "x"}))
 
 
 def test_does_not_contain() -> None:
     f = filter.Filter({"!=": ("foo", 1)})
-    assert f(TestDict({"foo": []}))
-    assert f(TestDict({"foo": [2, 3]}))
-    assert not f(TestDict({"foo": (1, 2)}))
+    assert f(FakePR({"foo": []}))
+    assert f(FakePR({"foo": [2, 3]}))
+    assert not f(FakePR({"foo": (1, 2)}))
 
 
 def test_set_value_expanders_does_not_contain() -> None:
     f = filter.Filter(
         {"!=": ("foo", "@bar")}, value_expanders={"foo": lambda x: ["foobaz", "foobar"]}
     )
-    assert not f(TestDict({"foo": "foobar"}))
-    assert not f(TestDict({"foo": "foobaz"}))
-    assert f(TestDict({"foo": "foobiz"}))
+    assert not f(FakePR({"foo": "foobar"}))
+    assert not f(FakePR({"foo": "foobaz"}))
+    assert f(FakePR({"foo": "foobiz"}))
 
 
 def test_contains() -> None:
     f = filter.Filter({"=": ("foo", 1)})
-    assert f(TestDict({"foo": [1, 2]}))
-    assert not f(TestDict({"foo": [2, 3]}))
-    assert f(TestDict({"foo": (1, 2)}))
+    assert f(FakePR({"foo": [1, 2]}))
+    assert not f(FakePR({"foo": [2, 3]}))
+    assert f(FakePR({"foo": (1, 2)}))
     f = filter.Filter({">": ("foo", 2)})
-    assert not f(TestDict({"foo": [1, 2]}))
-    assert f(TestDict({"foo": [2, 3]}))
+    assert not f(FakePR({"foo": [1, 2]}))
+    assert f(FakePR({"foo": [2, 3]}))
 
 
 def test_unknown_attribute() -> None:
     f = filter.Filter({"=": ("foo", 1)})
     with pytest.raises(filter.UnknownAttribute):
-        f(TestDict({"bar": 1}))
+        f(FakePR({"bar": 1}))
 
 
 def test_parse_error() -> None:


### PR DESCRIPTION
This avoids the pytest warning:

pytestCollectionWarning: cannot collect test class 'TestDict' because it has a __init__ constructor