### PR TITLE
fix(github_events): also send initial summary on synchronize events

### DIFF
--- a/mergify_engine/github_events.py
+++ b/mergify_engine/github_events.py
@@ -132,7 +132,7 @@ async def filter_and_dispatch(
         if event["repository"]["archived"]:
             ignore_reason = "repository archived"
 
-        elif event["action"] == "opened":
+        elif event["action"] in ("opened", "synchronize"):
             try:
                 await engine.create_initial_summary(event)
             except Exception as e:


### PR DESCRIPTION
This should make sure the Mergify summary reappears as in progress as soon as
new commits are pushed.