### PR TITLE
Pull request for revert

### DIFF
--- a/mergify_engine/tests/unit/actions/test_merge.py
+++ b/mergify_engine/tests/unit/actions/test_merge.py
@@ -21,7 +21,6 @@ import voluptuous
 from mergify_engine import context
 from mergify_engine import subscription
 from mergify_engine.actions import merge
-from mergify_engine.actions import merge_base
 
 
 PR = {
@@ -272,26 +271,3 @@ def test_queue_summary_subscription(active, summary):
     with mock.patch.object(merge.queue.Queue, "from_context", return_value=q):
         action = merge.MergeAction(voluptuous.Schema(merge.MergeAction.validator)({}))
         assert summary == action.get_queue_summary(ctxt, q)
-
-
-@pytest.mark.parametrize(
-    "test_input, expected",
-    [
-        (True, merge_base.StrictMergeParameter.true),
-        (False, merge_base.StrictMergeParameter.false),
-        ("smart", merge_base.StrictMergeParameter.ordered),
-        ("smart+ordered", merge_base.StrictMergeParameter.ordered),
-        ("smart+fasttrack", merge_base.StrictMergeParameter.fasttrack),
-        ("smart+fastpath", merge_base.StrictMergeParameter.fasttrack),
-    ],
-)
-def test_strict_merge_parameter_ok(test_input, expected):
-    assert merge_base.strict_merge_parameter(test_input) == expected
-
-
-def test_strict_merge_parameter_fail():
-    with pytest.raises(
-        ValueError,
-        match="toto is an unknown strict merge parameter",
-    ):
-        merge_base.strict_merge_parameter("toto")

--- a/mergify_engine/tests/unit/test_json.py
+++ b/mergify_engine/tests/unit/test_json.py
@@ -19,7 +19,7 @@ import json
 from mergify_engine import json as mergify_json
 
 
-class Color(enum.Enum):
+class Colour(enum.Enum):
     RED = 1
     GREEN = 2
     BLUE = 3
@@ -28,18 +28,18 @@ class Color(enum.Enum):
 with_enum = {
     "name": "hello",
     "conditions": [],
-    "actions": {"merge": {"strict": Color.BLUE}},
+    "actions": {"merge": {"strict": Colour.BLUE}},
 }
 
 with_enum_encode = {
     "name": "hello",
     "conditions": [],
     "actions": {
-        "merge": {"strict": {"__pytype__": "enum", "class": "Color", "name": "BLUE"}}
+        "merge": {"strict": {"__pytype__": "enum", "class": "Colour", "name": "BLUE"}}
     },
 }
 
-mergify_json.register_type(type(Color.BLUE))
+mergify_json.register_type(type(Colour.BLUE))
 
 
 def test_encode_enum():

--- a/mergify_engine/tests/unit/test_json.py
+++ b/mergify_engine/tests/unit/test_json.py
@@ -39,13 +39,13 @@ with_enum_encode = {
     },
 }
 
-mergify_json.register_type(type(Colour.BLUE))
-
 
 def test_encode_enum():
+    mergify_json.register_type(Colour)
     assert json.loads(mergify_json.dumps(with_enum)) == with_enum_encode
 
 
 def test_decode_enum():
+    mergify_json.register_type(Colour)
     json_file = mergify_json.dumps(with_enum)
     assert mergify_json.loads(json_file) == with_enum


### PR DESCRIPTION
Looks like the code have some bug that can be watched only by rerecording.

## Revert "chore: fix color typo"

This reverts commit 25585a01e6fcf0cc848d805bc0ce953ec4241239.

## Revert "refactor: use Enum for strict merge action config"

This reverts commit 6952f4f2be434a80b2f7a63b0116173216500e55.