### PR TITLE
ci: run check-obsolete-fixtures at end

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -90,10 +90,10 @@ deps = flake8
 whitelist_externals =
   bash
 commands =
-  bash tools/check-obsolete-fixtures.sh
   flake8
   isort -c .
   mypy
+  bash tools/check-obsolete-fixtures.sh
 
 [testenv:docs]
 extras = docs


### PR DESCRIPTION
check-obsolete-fixtures fails entirely if the code fails to load because e.g.
SyntaxError. But it does not report it correctly.

Running it last makes it easier to spot mistakes by having Python tools
reporting the error first.