### PR TITLE
fix: don't reuse aredis client yet

### DIFF
--- a/mergify_engine/debug.py
+++ b/mergify_engine/debug.py
@@ -97,6 +97,14 @@ def report_sub(
         print(f"* {title} SUB: MERGIFY DOESN'T HAVE ANY VALID OAUTH TOKENS")
 
 
+async def get_mergify_config_content(
+    client: github.GithubInstallationClient,
+    repo_info: github_types.GitHubRepository,
+) -> typing.Tuple[str, bytes]:
+    async with utils.aredis_for_cache() as redis:
+        return await rules.get_mergify_config_content(redis, client, repo_info)
+
+
 async def report_worker_status(owner: github_types.GitHubLogin) -> None:
     stream_name = f"stream~{owner}".encode()
     r = await utils.create_aredis_for_stream()
@@ -189,7 +197,7 @@ def report(
         mergify_config = None
         try:
             filename, mergify_config_content = asyncio.run(
-                rules.get_mergify_config_content(client, repo_info)
+                get_mergify_config_content(client, repo_info)
             )
         except rules.NoRules:  # pragma: no cover
             print(".mergify.yml is missing")

--- a/mergify_engine/tests/unit/rules/test_rules.py
+++ b/mergify_engine/tests/unit/rules/test_rules.py
@@ -22,6 +22,7 @@ import voluptuous
 from mergify_engine import context
 from mergify_engine import github_types
 from mergify_engine import rules
+from mergify_engine import utils
 from mergify_engine.clients import http
 from mergify_engine.rules import InvalidRules
 from mergify_engine.rules import get_mergify_config
@@ -226,10 +227,12 @@ async def test_get_mergify_config_location_from_cache() -> None:
         http.HTTPNotFound("Not Found", request=mock.Mock(), response=mock.Mock()),
         {"content": encodebytes("whatever".encode()).decode()},
     ]
-    filename, content = await rules.get_mergify_config_content(
-        client,
-        repo,
-    )
+    async with utils.aredis_for_cache() as redis:
+        filename, content = await rules.get_mergify_config_content(
+            redis,
+            client,
+            repo,
+        )
     assert client.item.call_count == 3
     client.item.assert_has_calls(
         [
@@ -243,10 +246,12 @@ async def test_get_mergify_config_location_from_cache() -> None:
     client.item.side_effect = [
         {"content": encodebytes("whatever".encode()).decode()},
     ]
-    filename, content = await rules.get_mergify_config_content(
-        client,
-        repo,
-    )
+    async with utils.aredis_for_cache() as redis:
+        filename, content = await rules.get_mergify_config_content(
+            redis,
+            client,
+            repo,
+        )
     assert client.item.call_count == 1
     client.item.assert_has_calls(
         [


### PR DESCRIPTION
Everything that run in the engine thread must not share httpx and aredis
client.

They open tcp connection binded to an asyncio loop. loop can't be shared
between async.run() run.
Luckily httpx client reraise the asyncio RuntimeError exception, but
aredis doesn't and assume connection have been reset by the peer.
Which is wrong, the connection stay establish from OS point of view
until OS TCP idle timeout is reach.

This changes opens one connection per loop until we remove the engine
thread and have only one loop forever.

Related to https://github.com/NoneGG/aredis/issues/149

Fixes MERGIFY-ENGINE-1ZT
Fixes MERGIFY-ENGINE-1ZQ
Fixes MERGIFY-ENGINE-1ZW
