### PR TITLE
chore(github_types): GitHubPullRequestNumber must be int

### DIFF
--- a/mergify_engine/github_events.py
+++ b/mergify_engine/github_events.py
@@ -168,9 +168,7 @@ async def filter_and_dispatch(
         owner_login = event["repository"]["owner"]["login"]
         owner_id = event["repository"]["owner"]["id"]
         repo_name = event["repository"]["name"]
-        pull_number = typing.cast(
-            github_types.GitHubPullRequestNumber, event["issue"]["number"]
-        )
+        pull_number = github_types.GitHubPullRequestNumber(event["issue"]["number"])
 
         if event["repository"]["archived"]:
             ignore_reason = "repository archived"
@@ -370,7 +368,7 @@ async def _get_github_pulls_from_sha(
                 return [pull["number"]]
         return []
     else:
-        return [typing.cast(github_types.GitHubPullRequestNumber, int(pull_number))]
+        return [github_types.GitHubPullRequestNumber(int(pull_number))]
 
 
 async def extract_pull_numbers_from_event(

--- a/mergify_engine/github_types.py
+++ b/mergify_engine/github_types.py
@@ -137,8 +137,8 @@ GitHubPullRequestMergeableState = typing.Literal[
     "has_hooks",
 ]
 
-GitHubPullRequestId = typing.NewType("GitHubPullRequestId", GitHubIssueId)
-GitHubPullRequestNumber = typing.NewType("GitHubPullRequestNumber", GitHubIssueNumber)
+GitHubPullRequestId = typing.NewType("GitHubPullRequestId", int)
+GitHubPullRequestNumber = typing.NewType("GitHubPullRequestNumber", int)
 
 
 ISODateTimeType = typing.NewType("ISODateTimeType", str)

--- a/mergify_engine/queue.py
+++ b/mergify_engine/queue.py
@@ -190,7 +190,7 @@ class Queue:
 
     def get_pulls(self) -> typing.List[github_types.GitHubPullRequestNumber]:
         return [
-            typing.cast(github_types.GitHubPullRequestNumber, int(pull))
+            github_types.GitHubPullRequestNumber(int(pull))
             for pull in self.redis.zrangebyscore(self._redis_queue_key, "-inf", "+inf")
         ]
 

--- a/mergify_engine/rules/types.py
+++ b/mergify_engine/rules/types.py
@@ -59,11 +59,9 @@ _DUMMY_PR = context.PullRequest(
         None,  # type: ignore
         github_types.GitHubPullRequest(
             {
-                "number": github_types.GitHubPullRequestNumber(
-                    github_types.GitHubIssueNumber(0)
-                ),
+                "number": github_types.GitHubPullRequestNumber(0),
                 "html_url": "",
-                "id": github_types.GitHubPullRequestId(github_types.GitHubIssueId(0)),
+                "id": github_types.GitHubPullRequestId(0),
                 "maintainer_can_modify": False,
                 "state": "open",
                 "merged": False,

--- a/mergify_engine/tests/unit/test_context.py
+++ b/mergify_engine/tests/unit/test_context.py
@@ -78,7 +78,7 @@ async def test_user_permission_cache() -> None:
     ) -> github_types.GitHubPullRequest:
         return github_types.GitHubPullRequest(
             {
-                "id": github_types.GitHubPullRequestId(github_types.GitHubIssueId(0)),
+                "id": github_types.GitHubPullRequestId(0),
                 "maintainer_can_modify": False,
                 "head": {
                     "user": owner,
@@ -88,9 +88,7 @@ async def test_user_permission_cache() -> None:
                     "repo": repo,
                 },
                 "user": owner,
-                "number": github_types.GitHubPullRequestNumber(
-                    github_types.GitHubIssueNumber(0)
-                ),
+                "number": github_types.GitHubPullRequestNumber(0),
                 "rebaseable": False,
                 "draft": False,
                 "merge_commit_sha": None,

--- a/mergify_engine/tests/unit/test_synchronize.py
+++ b/mergify_engine/tests/unit/test_synchronize.py
@@ -32,15 +32,13 @@ async def test_summary_synchronization_cache() -> None:
     ctxt = context.Context(
         client,
         {
-            "id": github_types.GitHubPullRequestId(github_types.GitHubIssueId(0)),
+            "id": github_types.GitHubPullRequestId(0),
             "maintainer_can_modify": False,
             "rebaseable": False,
             "draft": False,
             "merge_commit_sha": None,
             "labels": [],
-            "number": github_types.GitHubPullRequestNumber(
-                github_types.GitHubIssueNumber(6)
-            ),
+            "number": github_types.GitHubPullRequestNumber(6),
             "merged": True,
             "state": "closed",
             "html_url": "<html_url>",

--- a/mergify_engine/web/__init__.py
+++ b/mergify_engine/web/__init__.py
@@ -161,7 +161,7 @@ async def refresh_pull(
         pull_request=github_types.GitHubPullRequest(
             {
                 "number": pull_request_number,
-                "id": github_types.GitHubPullRequestId(github_types.GitHubIssueId(0)),
+                "id": github_types.GitHubPullRequestId(0),
                 "maintainer_can_modify": False,
                 "base": {
                     "label": "",


### PR DESCRIPTION
Using typing.cast(GitHubPullRequestNumber, "123") is valid for mypy as
it just trust us.

GitHubPullRequestNumber must be int, so we can use
GitHubPullRequestNumber("123") and got the expected:

Argument 1 to "GitHubPullRequestNumber" has incompatible type "str"; expected "int"

GitHubPullRequestNumber(GitHubIssueNumber(123)) will still works as
there are both int
