### PR TITLE
refactor: use asyncio.run once by engine run

### DIFF
--- a/mergify_engine/actions/__init__.py
+++ b/mergify_engine/actions/__init__.py
@@ -95,12 +95,12 @@ class Action(abc.ABC):
         """Convert string to dict config"""
         return {}
 
-    def run(
+    async def run(
         self, ctxt: context.Context, rule: "rules.EvaluatedRule"
     ) -> check_api.Result:  # pragma: no cover
         pass
 
-    def cancel(
+    async def cancel(
         self, ctxt: context.Context, rule: "rules.EvaluatedRule"
     ) -> check_api.Result:  # pragma: no cover
         return self.cancelled_check_report

--- a/mergify_engine/actions/assign.py
+++ b/mergify_engine/actions/assign.py
@@ -36,16 +36,18 @@ class AssignAction(actions.Action):
 
     silent_report = True
 
-    def run(self, ctxt: context.Context, rule: rules.EvaluatedRule) -> check_api.Result:
+    async def run(
+        self, ctxt: context.Context, rule: rules.EvaluatedRule
+    ) -> check_api.Result:
         # NOTE: "users" is deprecated, but kept as legacy code for old config
         if self.config["users"]:
-            self._add_assignees(ctxt, self.config["users"])
+            await self._add_assignees(ctxt, self.config["users"])
 
         if self.config["add_users"]:
-            self._add_assignees(ctxt, self.config["add_users"])
+            await self._add_assignees(ctxt, self.config["add_users"])
 
         if self.config["remove_users"]:
-            self._remove_assignees(ctxt, self.config["remove_users"])
+            await self._remove_assignees(ctxt, self.config["remove_users"])
 
         return check_api.Result(
             check_api.Conclusion.SUCCESS,
@@ -53,10 +55,10 @@ class AssignAction(actions.Action):
             "",
         )
 
-    def _add_assignees(
+    async def _add_assignees(
         self, ctxt: context.Context, users_to_add: typing.List[str]
     ) -> check_api.Result:
-        assignees = self._wanted_users(ctxt, users_to_add)
+        assignees = await self._wanted_users(ctxt, users_to_add)
 
         if assignees:
             try:
@@ -82,10 +84,10 @@ class AssignAction(actions.Action):
             "No user added to assignees",
         )
 
-    def _remove_assignees(
+    async def _remove_assignees(
         self, ctxt: context.Context, users_to_remove: typing.List[str]
     ) -> check_api.Result:
-        assignees = self._wanted_users(ctxt, users_to_remove)
+        assignees = await self._wanted_users(ctxt, users_to_remove)
 
         if assignees:
             try:
@@ -112,13 +114,13 @@ class AssignAction(actions.Action):
             "No user removed from assignees",
         )
 
-    def _wanted_users(
+    async def _wanted_users(
         self, ctxt: context.Context, users: typing.List[str]
     ) -> typing.List[str]:
         wanted = set()
         for user in set(users):
             try:
-                user = ctxt.pull_request.render_template(user)
+                user = await ctxt.pull_request.render_template(user)
             except context.RenderTemplateFailure:
                 # NOTE: this should never happen since
                 # the template is validated when parsing the config 🤷

--- a/mergify_engine/actions/backport.py
+++ b/mergify_engine/actions/backport.py
@@ -32,7 +32,9 @@ class BackportAction(copy.CopyAction):
     def command_to_config(string):
         return {"branches": string.split(" ")}
 
-    def run(self, ctxt: context.Context, rule: rules.EvaluatedRule) -> check_api.Result:
+    async def run(
+        self, ctxt: context.Context, rule: rules.EvaluatedRule
+    ) -> check_api.Result:
         if not config.GITHUB_APP:
             return check_api.Result(
                 check_api.Conclusion.FAILURE,
@@ -47,4 +49,4 @@ class BackportAction(copy.CopyAction):
                 "Waiting for the pull request to get merged",
                 "",
             )
-        return super().run(ctxt, rule)
+        return await super().run(ctxt, rule)

--- a/mergify_engine/actions/close.py
+++ b/mergify_engine/actions/close.py
@@ -31,7 +31,9 @@ class CloseAction(actions.Action):
     only_once = True
     validator = {voluptuous.Required("message", default=MSG): types.Jinja2}
 
-    def run(self, ctxt: context.Context, rule: rules.EvaluatedRule) -> check_api.Result:
+    async def run(
+        self, ctxt: context.Context, rule: rules.EvaluatedRule
+    ) -> check_api.Result:
         if ctxt.pull["state"] == "closed":
             return check_api.Result(
                 check_api.Conclusion.SUCCESS, "Pull request is already closed", ""
@@ -47,7 +49,7 @@ class CloseAction(actions.Action):
             )
 
         try:
-            message = ctxt.pull_request.render_template(self.config["message"])
+            message = await ctxt.pull_request.render_template(self.config["message"])
         except context.RenderTemplateFailure as rmf:
             return check_api.Result(
                 check_api.Conclusion.FAILURE,

--- a/mergify_engine/actions/comment.py
+++ b/mergify_engine/actions/comment.py
@@ -35,7 +35,10 @@ class CommentAction(actions.Action):
 
     silent_report = True
 
-    def run(self, ctxt: context.Context, rule: rules.EvaluatedRule) -> check_api.Result:
+    async def run(
+        self, ctxt: context.Context, rule: rules.EvaluatedRule
+    ) -> check_api.Result:
+
         if self.config["bot_account"] and not ctxt.subscription.has_feature(
             subscription.Features.BOT_ACCOUNT
         ):
@@ -48,7 +51,7 @@ class CommentAction(actions.Action):
             )
 
         try:
-            message = ctxt.pull_request.render_template(self.config["message"])
+            message = await ctxt.pull_request.render_template(self.config["message"])
         except context.RenderTemplateFailure as rmf:
             return check_api.Result(
                 check_api.Conclusion.FAILURE,

--- a/mergify_engine/actions/copy.py
+++ b/mergify_engine/actions/copy.py
@@ -107,7 +107,9 @@ class CopyAction(actions.Action):
             f"{self.KIND.capitalize()} to branch `{branch_name}` failed",
         )
 
-    def run(self, ctxt: context.Context, rule: rules.EvaluatedRule) -> check_api.Result:
+    async def run(
+        self, ctxt: context.Context, rule: rules.EvaluatedRule
+    ) -> check_api.Result:
         if not config.GITHUB_APP:
             return check_api.Result(
                 check_api.Conclusion.FAILURE,

--- a/mergify_engine/actions/delete_head_branch.py
+++ b/mergify_engine/actions/delete_head_branch.py
@@ -31,7 +31,9 @@ class DeleteHeadBranchAction(actions.Action):
         {voluptuous.Optional("force", default=False): bool}, None
     )
 
-    def run(self, ctxt: context.Context, rule: rules.EvaluatedRule) -> check_api.Result:
+    async def run(
+        self, ctxt: context.Context, rule: rules.EvaluatedRule
+    ) -> check_api.Result:
         if ctxt.pull_from_fork:
             return check_api.Result(
                 check_api.Conclusion.SUCCESS, "Pull request come from fork", ""

--- a/mergify_engine/actions/label.py
+++ b/mergify_engine/actions/label.py
@@ -35,7 +35,9 @@ class LabelAction(actions.Action):
 
     silent_report = True
 
-    def run(self, ctxt: context.Context, rule: rules.EvaluatedRule) -> check_api.Result:
+    async def run(
+        self, ctxt: context.Context, rule: rules.EvaluatedRule
+    ) -> check_api.Result:
         if self.config["add"]:
             all_label = [
                 label["name"] for label in ctxt.client.items(f"{ctxt.base_url}/labels")

--- a/mergify_engine/actions/merge.py
+++ b/mergify_engine/actions/merge.py
@@ -107,7 +107,7 @@ class MergeAction(merge_base.MergeBaseAction):
         else:
             raise RuntimeError("Unexpected strict")
 
-    def _should_be_cancel(
+    async def _should_be_cancel(
         self, ctxt: context.Context, rule: "rules.EvaluatedRule"
     ) -> bool:
         # It's closed, it's not going to change
@@ -137,7 +137,7 @@ class MergeAction(merge_base.MergeBaseAction):
                 state
                 for name, state in ctxt.checks.items()
                 for cond in need_look_at_checks
-                if cond(FakePR(cond.attribute_name, name))
+                if await cond(FakePR(cond.attribute_name, name))
             ]
             if not states:
                 return False

--- a/mergify_engine/actions/post_check.py
+++ b/mergify_engine/actions/post_check.py
@@ -49,7 +49,7 @@ class PostCheckAction(actions.Action):
     always_run = True
     allow_retrigger_mergify = True
 
-    def _post(
+    async def _post(
         self, ctxt: context.Context, rule: rules.EvaluatedRule
     ) -> check_api.Result:
         # TODO(sileht): Don't run it if conditions contains the rule itself, as it can
@@ -76,7 +76,7 @@ class PostCheckAction(actions.Action):
             "check_conditions": check_conditions,
         }
         try:
-            title = ctxt.pull_request.render_template(
+            title = await ctxt.pull_request.render_template(
                 self.config["title"],
                 extra_variables,
             )
@@ -88,7 +88,7 @@ class PostCheckAction(actions.Action):
             )
 
         try:
-            summary = ctxt.pull_request.render_template(
+            summary = await ctxt.pull_request.render_template(
                 self.config["summary"], extra_variables
             )
         except context.RenderTemplateFailure as rmf:

--- a/mergify_engine/actions/rebase.py
+++ b/mergify_engine/actions/rebase.py
@@ -13,7 +13,6 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-import asyncio
 
 import voluptuous
 
@@ -39,7 +38,9 @@ class RebaseAction(actions.Action):
         ),
     }
 
-    def run(self, ctxt: context.Context, rule: rules.EvaluatedRule) -> check_api.Result:
+    async def run(
+        self, ctxt: context.Context, rule: rules.EvaluatedRule
+    ) -> check_api.Result:
         if not config.GITHUB_APP:
             return check_api.Result(
                 check_api.Conclusion.FAILURE,
@@ -61,9 +62,7 @@ class RebaseAction(actions.Action):
                 return output
 
             try:
-                asyncio.run(
-                    branch_updater.rebase_with_git(ctxt, self.config["bot_account"])
-                )
+                await branch_updater.rebase_with_git(ctxt, self.config["bot_account"])
                 return check_api.Result(
                     check_api.Conclusion.SUCCESS,
                     "Branch has been successfully rebased",

--- a/mergify_engine/actions/refresh.py
+++ b/mergify_engine/actions/refresh.py
@@ -11,7 +11,6 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-import asyncio
 import typing
 
 from mergify_engine import actions
@@ -26,8 +25,10 @@ class RefreshAction(actions.Action):
     is_action = False
     validator: typing.ClassVar[typing.Dict[typing.Any, typing.Any]] = {}
 
-    def run(self, ctxt: context.Context, rule: rules.EvaluatedRule) -> check_api.Result:
-        asyncio.run(github_events.send_refresh(ctxt.pull))
+    async def run(
+        self, ctxt: context.Context, rule: rules.EvaluatedRule
+    ) -> check_api.Result:
+        await github_events.send_refresh(ctxt.pull)
         return check_api.Result(
             check_api.Conclusion.SUCCESS, title="Pull request refreshed", summary=""
         )

--- a/mergify_engine/actions/request_reviews.py
+++ b/mergify_engine/actions/request_reviews.py
@@ -117,7 +117,9 @@ class RequestReviewsAction(actions.Action):
 
         return user_reviews_to_request, team_reviews_to_request
 
-    def run(self, ctxt: context.Context, rule: rules.EvaluatedRule) -> check_api.Result:
+    async def run(
+        self, ctxt: context.Context, rule: rules.EvaluatedRule
+    ) -> check_api.Result:
         if "random_count" in self.config and not ctxt.subscription.has_feature(
             subscription.Features.RANDOM_REQUEST_REVIEWS
         ):
@@ -138,7 +140,9 @@ class RequestReviewsAction(actions.Action):
             "review-requested",
         )
         existing_reviews = set(
-            itertools.chain(*[getattr(ctxt.pull_request, key) for key in reviews_keys])
+            itertools.chain(
+                *[await getattr(ctxt.pull_request, key) for key in reviews_keys]
+            )
         )
 
         user_reviews_to_request, team_reviews_to_request = self._get_reviewers(
@@ -148,7 +152,7 @@ class RequestReviewsAction(actions.Action):
         )
 
         if user_reviews_to_request or team_reviews_to_request:
-            requested_reviews_nb = len(ctxt.pull_request.review_requested)
+            requested_reviews_nb = len(await ctxt.pull_request.review_requested)
 
             already_at_max = requested_reviews_nb == self.GITHUB_MAXIMUM_REVIEW_REQUEST
             will_exceed_max = (

--- a/mergify_engine/actions/review.py
+++ b/mergify_engine/actions/review.py
@@ -47,7 +47,9 @@ class ReviewAction(actions.Action):
 
     silent_report = True
 
-    def run(self, ctxt: context.Context, rule: rules.EvaluatedRule) -> check_api.Result:
+    async def run(
+        self, ctxt: context.Context, rule: rules.EvaluatedRule
+    ) -> check_api.Result:
         payload = {"event": self.config["type"]}
 
         if self.config["bot_account"] and not ctxt.subscription.has_feature(
@@ -63,7 +65,7 @@ class ReviewAction(actions.Action):
 
         if self.config["message"]:
             try:
-                body = ctxt.pull_request.render_template(self.config["message"])
+                body = await ctxt.pull_request.render_template(self.config["message"])
             except context.RenderTemplateFailure as rmf:
                 return check_api.Result(
                     check_api.Conclusion.FAILURE, "Invalid review message", str(rmf)

--- a/mergify_engine/actions/update.py
+++ b/mergify_engine/actions/update.py
@@ -32,7 +32,7 @@ class UpdateAction(actions.Action):
     validator: typing.ClassVar[typing.Dict[typing.Any, typing.Any]] = {}
 
     @staticmethod
-    def run(ctxt: context.Context, rule: rules.EvaluatedRule) -> check_api.Result:
+    async def run(ctxt: context.Context, rule: rules.EvaluatedRule) -> check_api.Result:
         if ctxt.is_behind:
             try:
                 branch_updater.update_with_api(ctxt)

--- a/mergify_engine/tests/functional/test_attributes.py
+++ b/mergify_engine/tests/functional/test_attributes.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 #
-# Copyright © 2020 Mehdi Abaakouk <sileht@mergify.io>
+# Copyright © 2020–2021 Mergify SAS
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -13,6 +13,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+import asyncio
 import logging
 
 import pytest
@@ -40,7 +41,7 @@ class TestAttributes(base.FunctionalTestBase):
 
         pr, _ = self.create_pr()
         ctxt = context.Context(self.cli_integration, pr.raw_data, {})
-        assert not ctxt.pull_request.draft
+        assert not asyncio.run(ctxt.pull_request.draft)
 
         pr, _ = self.create_pr(draft=True)
 
@@ -67,16 +68,16 @@ class TestAttributes(base.FunctionalTestBase):
         self.assertEqual("draft pr", comments[-1].body)
 
         # Test underscore/dash attributes
-        assert ctxt.pull_request.review_requested == []
+        assert asyncio.run(ctxt.pull_request.review_requested) == []
 
         with pytest.raises(AttributeError):
-            assert ctxt.pull_request.foobar
+            assert asyncio.run(ctxt.pull_request.foobar)
 
         # Test items
         assert list(ctxt.pull_request) == list(
             context.PullRequest.ATTRIBUTES | context.PullRequest.LIST_ATTRIBUTES
         )
-        assert dict(ctxt.pull_request.items()) == {
+        assert asyncio.run(ctxt.pull_request.items()) == {
             "number": pr.number,
             "closed": False,
             "locked": False,

--- a/mergify_engine/tests/functional/test_debug.py
+++ b/mergify_engine/tests/functional/test_debug.py
@@ -1,3 +1,20 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright © 2018—2021 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import asyncio
 from concurrent import futures
 from unittest import mock
 
@@ -31,19 +48,23 @@ class TestDebugger(base.FunctionalTestBase):
         # NOTE(sileht): Run is a thread to not mess with the main asyncio loop
         with mock.patch("sys.stdout") as stdout:
             with futures.ThreadPoolExecutor(max_workers=1) as executor:
-                executor.submit(debug.report, p.html_url).result()
+                executor.submit(asyncio.run, debug.report(p.html_url)).result()
 
             s1 = "".join(call.args[0] for call in stdout.write.mock_calls)
 
         with mock.patch("sys.stdout") as stdout:
             with futures.ThreadPoolExecutor(max_workers=1) as executor:
-                executor.submit(debug.report, p.base.repo.html_url).result()
+                executor.submit(
+                    asyncio.run, debug.report(p.base.repo.html_url)
+                ).result()
 
             s2 = "".join(call.args[0] for call in stdout.write.mock_calls)
 
         with mock.patch("sys.stdout") as stdout:
             with futures.ThreadPoolExecutor(max_workers=1) as executor:
-                executor.submit(debug.report, p.base.user.html_url).result()
+                executor.submit(
+                    asyncio.run, debug.report(p.base.user.html_url)
+                ).result()
 
             s3 = "".join(call.args[0] for call in stdout.write.mock_calls)
 

--- a/mergify_engine/tests/unit/actions/test_merge.py
+++ b/mergify_engine/tests/unit/actions/test_merge.py
@@ -142,14 +142,18 @@ my title
         ("Here's my message", "My PR title (#43)", "Here's my message", "title+body"),
     ],
 )
-def test_merge_commit_message(body, title, message, mode):
+@pytest.mark.asyncio
+async def test_merge_commit_message(body, title, message, mode):
     pull = PR.copy()
     pull["body"] = body
     client = mock.MagicMock()
     ctxt = context.Context(client=client, pull=pull, subscription={})
     ctxt.checks = {"my CI": "success"}
     pr = ctxt.pull_request
-    assert merge.MergeAction._get_commit_message(pr, mode=mode) == (title, message)
+    assert await merge.MergeAction._get_commit_message(pr, mode=mode) == (
+        title,
+        message,
+    )
 
 
 @pytest.mark.parametrize(
@@ -175,14 +179,15 @@ on two lines"""
         ),
     ],
 )
-def test_merge_commit_message_undefined(body):
+@pytest.mark.asyncio
+async def test_merge_commit_message_undefined(body):
     pull = PR.copy()
     pull["body"] = body
     pr = context.Context(
         client=mock.MagicMock(), pull=pull, subscription={}
     ).pull_request
     with pytest.raises(context.RenderTemplateFailure) as x:
-        merge.MergeAction._get_commit_message(pr)
+        await merge.MergeAction._get_commit_message(pr)
         assert str(x) == "foobar"
 
 
@@ -201,14 +206,15 @@ here is my message {{ and broken template
         ),
     ],
 )
-def test_merge_commit_message_syntax_error(body, error):
+@pytest.mark.asyncio
+async def test_merge_commit_message_syntax_error(body, error):
     pull = PR.copy()
     pull["body"] = body
     pr = context.Context(
         client=mock.MagicMock(), pull=pull, subscription={}
     ).pull_request
     with pytest.raises(context.RenderTemplateFailure) as rmf:
-        merge.MergeAction._get_commit_message(pr)
+        await merge.MergeAction._get_commit_message(pr)
         assert str(rmf) == error
 
 

--- a/mergify_engine/tests/unit/actions/test_request_reviews.py
+++ b/mergify_engine/tests/unit/actions/test_request_reviews.py
@@ -150,7 +150,8 @@ def test_get_reviewers():
     assert reviewers == ({"jd"}, {"foobar"})
 
 
-def test_disabled():
+@pytest.mark.asyncio
+async def test_disabled():
     action = request_reviews.RequestReviewsAction.get_schema()(
         {
             "random_count": 2,
@@ -201,7 +202,7 @@ def test_disabled():
         },
         sub,
     )
-    result = action.run(ctxt, None)
+    result = await action.run(ctxt, None)
     assert result.conclusion == check_api.Conclusion.ACTION_REQUIRED
     assert result.title == "Random request reviews are disabled"
     assert result.summary == (

--- a/mergify_engine/tests/unit/rules/test_filter.py
+++ b/mergify_engine/tests/unit/rules/test_filter.py
@@ -18,131 +18,134 @@ import pytest
 from mergify_engine.rules import filter
 
 
+pytestmark = pytest.mark.asyncio
+
+
 class FakePR(dict):  # type: ignore[type-arg]
     def __getattr__(self, k):
         return self[k]
 
 
-def test_binary() -> None:
+async def test_binary() -> None:
     f = filter.Filter({"=": ("foo", 1)})
-    assert f(FakePR({"foo": 1}))
-    assert not f(FakePR({"foo": 2}))
+    assert await f(FakePR({"foo": 1}))
+    assert not await f(FakePR({"foo": 2}))
 
 
-def test_string() -> None:
+async def test_string() -> None:
     f = filter.Filter({"=": ("foo", "bar")})
-    assert f(FakePR({"foo": "bar"}))
-    assert not f(FakePR({"foo": 2}))
+    assert await f(FakePR({"foo": "bar"}))
+    assert not await f(FakePR({"foo": 2}))
 
 
-def test_not() -> None:
+async def test_not() -> None:
     f = filter.Filter({"-": {"=": ("foo", 1)}})
-    assert not f(FakePR({"foo": 1}))
-    assert f(FakePR({"foo": 2}))
+    assert not await f(FakePR({"foo": 1}))
+    assert await f(FakePR({"foo": 2}))
 
 
-def test_len() -> None:
+async def test_len() -> None:
     f = filter.Filter({"=": ("#foo", 3)})
-    assert f(FakePR({"foo": "bar"}))
+    assert await f(FakePR({"foo": "bar"}))
     with pytest.raises(filter.InvalidOperator):
-        f(FakePR({"foo": 2}))
-    assert not f(FakePR({"foo": "a"}))
-    assert not f(FakePR({"foo": "abcedf"}))
-    assert f(FakePR({"foo": [10, 20, 30]}))
-    assert not f(FakePR({"foo": [10, 20]}))
-    assert not f(FakePR({"foo": [10, 20, 40, 50]}))
+        await f(FakePR({"foo": 2}))
+    assert not await f(FakePR({"foo": "a"}))
+    assert not await f(FakePR({"foo": "abcedf"}))
+    assert await f(FakePR({"foo": [10, 20, 30]}))
+    assert not await f(FakePR({"foo": [10, 20]}))
+    assert not await f(FakePR({"foo": [10, 20, 40, 50]}))
     f = filter.Filter({">": ("#foo", 3)})
-    assert f(FakePR({"foo": "barz"}))
+    assert await f(FakePR({"foo": "barz"}))
     with pytest.raises(filter.InvalidOperator):
-        f(FakePR({"foo": 2}))
-    assert not f(FakePR({"foo": "a"}))
-    assert f(FakePR({"foo": "abcedf"}))
-    assert f(FakePR({"foo": [10, "abc", 20, 30]}))
-    assert not f(FakePR({"foo": [10, 20]}))
-    assert not f(FakePR({"foo": []}))
+        await f(FakePR({"foo": 2}))
+    assert not await f(FakePR({"foo": "a"}))
+    assert await f(FakePR({"foo": "abcedf"}))
+    assert await f(FakePR({"foo": [10, "abc", 20, 30]}))
+    assert not await f(FakePR({"foo": [10, 20]}))
+    assert not await f(FakePR({"foo": []}))
 
 
-def test_regexp() -> None:
+async def test_regexp() -> None:
     f = filter.Filter({"~=": ("foo", "^f")})
-    assert f(FakePR({"foo": "foobar"}))
-    assert f(FakePR({"foo": "foobaz"}))
-    assert not f(FakePR({"foo": "x"}))
-    assert not f(FakePR({"foo": None}))
+    assert await f(FakePR({"foo": "foobar"}))
+    assert await f(FakePR({"foo": "foobaz"}))
+    assert not await f(FakePR({"foo": "x"}))
+    assert not await f(FakePR({"foo": None}))
 
     f = filter.Filter({"~=": ("foo", "^$")})
-    assert f(FakePR({"foo": ""}))
-    assert not f(FakePR({"foo": "x"}))
+    assert await f(FakePR({"foo": ""}))
+    assert not await f(FakePR({"foo": "x"}))
 
 
-def test_regexp_invalid() -> None:
+async def test_regexp_invalid() -> None:
     with pytest.raises(filter.InvalidArguments):
         filter.Filter({"~=": ("foo", r"([^\s\w])(\s*\1+")})
 
 
-def test_set_value_expanders() -> None:
+async def test_set_value_expanders() -> None:
     f = filter.Filter(
         {"=": ("foo", "@bar")},
         value_expanders={"foo": lambda x: [x.replace("@", "foo")]},
     )
-    assert f(FakePR({"foo": "foobar"}))
-    assert not f(FakePR({"foo": "x"}))
+    assert await f(FakePR({"foo": "foobar"}))
+    assert not await f(FakePR({"foo": "x"}))
 
 
-def test_set_value_expanders_unset_at_init() -> None:
+async def test_set_value_expanders_unset_at_init() -> None:
     f = filter.Filter({"=": ("foo", "@bar")})
     f.value_expanders = {"foo": lambda x: [x.replace("@", "foo")]}
-    assert f(FakePR({"foo": "foobar"}))
-    assert not f(FakePR({"foo": "x"}))
+    assert await f(FakePR({"foo": "foobar"}))
+    assert not await f(FakePR({"foo": "x"}))
 
 
-def test_does_not_contain() -> None:
+async def test_does_not_contain() -> None:
     f = filter.Filter({"!=": ("foo", 1)})
-    assert f(FakePR({"foo": []}))
-    assert f(FakePR({"foo": [2, 3]}))
-    assert not f(FakePR({"foo": (1, 2)}))
+    assert await f(FakePR({"foo": []}))
+    assert await f(FakePR({"foo": [2, 3]}))
+    assert not await f(FakePR({"foo": (1, 2)}))
 
 
-def test_set_value_expanders_does_not_contain() -> None:
+async def test_set_value_expanders_does_not_contain() -> None:
     f = filter.Filter(
         {"!=": ("foo", "@bar")}, value_expanders={"foo": lambda x: ["foobaz", "foobar"]}
     )
-    assert not f(FakePR({"foo": "foobar"}))
-    assert not f(FakePR({"foo": "foobaz"}))
-    assert f(FakePR({"foo": "foobiz"}))
+    assert not await f(FakePR({"foo": "foobar"}))
+    assert not await f(FakePR({"foo": "foobaz"}))
+    assert await f(FakePR({"foo": "foobiz"}))
 
 
-def test_contains() -> None:
+async def test_contains() -> None:
     f = filter.Filter({"=": ("foo", 1)})
-    assert f(FakePR({"foo": [1, 2]}))
-    assert not f(FakePR({"foo": [2, 3]}))
-    assert f(FakePR({"foo": (1, 2)}))
+    assert await f(FakePR({"foo": [1, 2]}))
+    assert not await f(FakePR({"foo": [2, 3]}))
+    assert await f(FakePR({"foo": (1, 2)}))
     f = filter.Filter({">": ("foo", 2)})
-    assert not f(FakePR({"foo": [1, 2]}))
-    assert f(FakePR({"foo": [2, 3]}))
+    assert not await f(FakePR({"foo": [1, 2]}))
+    assert await f(FakePR({"foo": [2, 3]}))
 
 
-def test_unknown_attribute() -> None:
+async def test_unknown_attribute() -> None:
     f = filter.Filter({"=": ("foo", 1)})
     with pytest.raises(filter.UnknownAttribute):
-        f(FakePR({"bar": 1}))
+        await f(FakePR({"bar": 1}))
 
 
-def test_parse_error() -> None:
+async def test_parse_error() -> None:
     with pytest.raises(filter.ParseError):
         filter.Filter({})
 
 
-def test_unknown_operator() -> None:
+async def test_unknown_operator() -> None:
     with pytest.raises(filter.UnknownOperator):
         filter.Filter({"oops": (1, 2)})  # type: ignore[typeddict-item]
 
 
-def test_invalid_arguments() -> None:
+async def test_invalid_arguments() -> None:
     with pytest.raises(filter.InvalidArguments):
         filter.Filter({"=": (1, 2, 3)})  # type: ignore[typeddict-item]
 
 
-def test_str() -> None:
+async def test_str() -> None:
     assert "foo~=^f" == str(filter.Filter({"~=": ("foo", "^f")}))
     assert "-foo=1" == str(filter.Filter({"-": {"=": ("foo", 1)}}))
     assert "foo" == str(filter.Filter({"=": ("foo", True)}))
@@ -151,6 +154,6 @@ def test_str() -> None:
         str(filter.Filter({">=": ("bar", False)}))
 
 
-def test_parser() -> None:
+async def test_parser() -> None:
     for string in ("head=foobar", "-base=master", "#files>3"):
         assert string == str(filter.Filter.parse(string))

--- a/mergify_engine/tests/unit/rules/test_rules.py
+++ b/mergify_engine/tests/unit/rules/test_rules.py
@@ -509,7 +509,8 @@ def test_pull_request_rule_schema_invalid(invalid, match):
         pull_request_rule_from_list([invalid])
 
 
-def test_get_pull_request_rule():
+@pytest.mark.asyncio
+async def test_get_pull_request_rule():
 
     client = mock.Mock()
 
@@ -579,7 +580,7 @@ def test_get_pull_request_rule():
         [rules.Rule(name="default", conditions=[], actions={})]
     )
 
-    match = pull_request_rules.get_pull_request_rule(ctxt)
+    match = await pull_request_rules.get_pull_request_rule(ctxt)
     assert [r.name for r in match.rules] == ["default"]
     assert [r.name for r in match.matching_rules] == ["default"]
     assert [
@@ -592,7 +593,7 @@ def test_get_pull_request_rule():
         [{"name": "hello", "conditions": ["base:master"], "actions": {}}]
     )
 
-    match = pull_request_rules.get_pull_request_rule(ctxt)
+    match = await pull_request_rules.get_pull_request_rule(ctxt)
     assert [r.name for r in match.rules] == ["hello"]
     assert [r.name for r in match.matching_rules] == ["hello"]
     assert [
@@ -608,7 +609,7 @@ def test_get_pull_request_rule():
         ]
     )
 
-    match = pull_request_rules.get_pull_request_rule(ctxt)
+    match = await pull_request_rules.get_pull_request_rule(ctxt)
     assert [r.name for r in match.rules] == ["hello", "backport"]
     assert [r.name for r in match.matching_rules] == ["hello", "backport"]
     assert [
@@ -624,7 +625,7 @@ def test_get_pull_request_rule():
         ]
     )
 
-    match = pull_request_rules.get_pull_request_rule(ctxt)
+    match = await pull_request_rules.get_pull_request_rule(ctxt)
     assert [r.name for r in match.rules] == ["hello", "backport"]
     assert [r.name for r in match.matching_rules] == ["backport"]
     for rule in match.rules:
@@ -637,7 +638,7 @@ def test_get_pull_request_rule():
         ]
     )
 
-    match = pull_request_rules.get_pull_request_rule(ctxt)
+    match = await pull_request_rules.get_pull_request_rule(ctxt)
     assert [r.name for r in match.rules] == ["hello", "backport"]
     assert [r.name for r in match.matching_rules] == ["hello", "backport"]
     assert [
@@ -661,7 +662,7 @@ def test_get_pull_request_rule():
         ]
     )
 
-    match = pull_request_rules.get_pull_request_rule(ctxt)
+    match = await pull_request_rules.get_pull_request_rule(ctxt)
     assert [r.name for r in match.rules] == ["merge"]
     assert [r.name for r in match.matching_rules] == []
 
@@ -679,7 +680,7 @@ def test_get_pull_request_rule():
         ]
     )
 
-    match = pull_request_rules.get_pull_request_rule(ctxt)
+    match = await pull_request_rules.get_pull_request_rule(ctxt)
     assert [r.name for r in match.rules] == ["merge"]
     assert [r.name for r in match.matching_rules] == ["merge"]
     assert [
@@ -730,7 +731,7 @@ def test_get_pull_request_rule():
             },
         ]
     )
-    match = pull_request_rules.get_pull_request_rule(ctxt)
+    match = await pull_request_rules.get_pull_request_rule(ctxt)
 
     assert [r.name for r in match.rules] == [
         "merge",
@@ -778,7 +779,7 @@ def test_get_pull_request_rule():
         ]
     )
 
-    match = pull_request_rules.get_pull_request_rule(ctxt)
+    match = await pull_request_rules.get_pull_request_rule(ctxt)
     assert [r.name for r in match.rules] == ["default"]
     assert [r.name for r in match.matching_rules] == ["default"]
 
@@ -797,7 +798,7 @@ def test_get_pull_request_rule():
     )
 
     del ctxt.__dict__["reviews"]
-    del ctxt.__dict__["consolidated_reviews"]
+    del ctxt._cache["consolidated_reviews"]
 
     # Team conditions with no review missing
     pull_request_rules = pull_request_rule_from_list(
@@ -813,7 +814,7 @@ def test_get_pull_request_rule():
         ]
     )
 
-    match = pull_request_rules.get_pull_request_rule(ctxt)
+    match = await pull_request_rules.get_pull_request_rule(ctxt)
     assert [r.name for r in match.rules] == ["default"]
     assert [r.name for r in match.matching_rules] == ["default"]
 
@@ -831,7 +832,7 @@ def test_get_pull_request_rule():
         ]
     )
 
-    match = pull_request_rules.get_pull_request_rule(ctxt)
+    match = await pull_request_rules.get_pull_request_rule(ctxt)
     assert [r.name for r in match.rules] == ["default"]
     assert [r.name for r in match.matching_rules] == ["default"]
     assert match.matching_rules[0].name == "default"
@@ -840,7 +841,7 @@ def test_get_pull_request_rule():
     # Forbidden labels, when forbiden label set
     ctxt.pull["labels"] = [{"name": "status/wip"}]
 
-    match = pull_request_rules.get_pull_request_rule(ctxt)
+    match = await pull_request_rules.get_pull_request_rule(ctxt)
     assert [r.name for r in match.rules] == ["default"]
     assert [r.name for r in match.matching_rules] == ["default"]
     assert match.matching_rules[0].name == "default"
@@ -852,7 +853,7 @@ def test_get_pull_request_rule():
     # Forbidden labels, when other label set
     ctxt.pull["labels"] = [{"name": "allowed"}]
 
-    match = pull_request_rules.get_pull_request_rule(ctxt)
+    match = await pull_request_rules.get_pull_request_rule(ctxt)
     assert [r.name for r in match.rules] == ["default"]
     assert [r.name for r in match.matching_rules] == ["default"]
     assert match.matching_rules[0].name == "default"
@@ -868,7 +869,7 @@ def test_get_pull_request_rule():
             }
         ]
     )
-    match = pull_request_rules.get_pull_request_rule(ctxt)
+    match = await pull_request_rules.get_pull_request_rule(ctxt)
     assert [r.name for r in match.rules] == ["default"]
     assert [r.name for r in match.matching_rules] == ["default"]
     assert match.matching_rules[0].name == "default"

--- a/mergify_engine/tests/unit/test_worker.py
+++ b/mergify_engine/tests/unit/test_worker.py
@@ -774,7 +774,7 @@ async def test_stream_processor_retrying_after_read_error(run_engine, _, redis):
     installation = context.Installation(123, "owner", {}, None)
     with pytest.raises(worker.StreamRetry):
         async with p._translate_exception_to_retries(installation.stream_name):
-            await p._thread.exec(worker.run_engine, installation, "repo", 1234, [])
+            await p._thread.exec(worker.run_engine(installation, "repo", 1234, []))
 
 
 @pytest.mark.asyncio

--- a/mergify_engine/utils.py
+++ b/mergify_engine/utils.py
@@ -118,18 +118,6 @@ def compute_hmac(data):
     return str(mac.hexdigest())
 
 
-async def async_main(*awaitables):
-    # NOTE(sileht): This looks useless but
-    #   asyncio.run(asyncio.gather(...))
-    # does not work, because when the gather() coroutine is created, it need the current
-    # loop but asyncio.run() haven't create it yet, so it doesn't work.
-    return await asyncio.gather(*awaitables, return_exceptions=True)
-
-
-def async_run(*awaitables):
-    return asyncio.run(async_main(*awaitables))
-
-
 class Gitter(object):
     def __init__(self, logger):
         self.tmp = tempfile.mkdtemp(prefix="mergify-gitter")

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skipsdist = true
 [testenv]
 basepython = python3.9
 setenv =
+   PYTHONASYNCIODEBUG=1
    MERGIFYENGINE_TEST_SETTINGS=fake.env
 usedevelop = true
 extras = test


### PR DESCRIPTION
With this change asyncio.run() is used into two places only,
at the beginning of engine thread and the simulator thread.
