### PR TITLE
feat(actions): allow bot_account to be a Jinja2 template

### DIFF
--- a/docs/source/actions.rst
+++ b/docs/source/actions.rst
@@ -162,7 +162,7 @@ The ``comment`` action adds a comment to the pull request.
      -
      - The message to write as a comment.
    * - ``bot_account``
-     - string
+     - :ref:`data type template`
      -
      - Mergify can impersonate a GitHub user to comment a pull request.
        If no ``bot_account`` is set, Mergify will comment the pull request
@@ -194,7 +194,7 @@ The ``review`` action reviews the pull request.
      -
      - The message to write as a comment.
    * - ``bot_account``
-     - string
+     - :ref:`data type template`
      -
      - Mergify can impersonate a GitHub user to review a pull request.
        If no ``bot_account`` is set, Mergify will review the pull request
@@ -384,7 +384,7 @@ The ``merge`` action merges the pull request into its base branch. The
        rebase`.
 
    * - ``merge_bot_account``
-     - string
+     - :ref:`data type template`
      -
      - Mergify can impersonate a GitHub user to merge pull request.
        If no ``merge_bot_account`` is set, Mergify will merge the pull request
@@ -394,7 +394,7 @@ The ``merge`` action merges the pull request into its base branch. The
        |premium plan tag|
 
    * - ``update_bot_account``
-     - string
+     - :ref:`data type template`
      -
      - For certain actions, such as rebasing branches, Mergify has to
        impersonate a GitHub user. You can specify the account to use with this
@@ -564,7 +564,7 @@ The ``rebase`` action will rebase the pull request against its base branch.
     - Value Description
 
   * - ``update_bot_account``
-    - string
+    - :ref:`data type template`
     -
     - For certain actions, such as rebasing branches, Mergify has to
       impersonate a GitHub user. You can specify the account to use with this

--- a/mergify_engine/actions/comment.py
+++ b/mergify_engine/actions/comment.py
@@ -29,7 +29,7 @@ class CommentAction(actions.Action):
     validator = {
         voluptuous.Required("message"): types.Jinja2,
         voluptuous.Required("bot_account", default=None): voluptuous.Any(
-            None, types.GitHubLogin
+            None, types.Jinja2
         ),
     }
 

--- a/mergify_engine/actions/merge.py
+++ b/mergify_engine/actions/merge.py
@@ -59,13 +59,13 @@ class MergeAction(merge_base.MergeBaseAction):
         # NOTE(sileht): Alias of update_bot_account, it's now undocumented but we have
         # users that use it so, we have to keep it
         voluptuous.Required("bot_account", default=None): voluptuous.Any(
-            None, types.GitHubLogin
+            None, types.Jinja2
         ),
         voluptuous.Required("merge_bot_account", default=None): voluptuous.Any(
-            None, types.GitHubLogin
+            None, types.Jinja2
         ),
         voluptuous.Required("update_bot_account", default=None): voluptuous.Any(
-            None, types.GitHubLogin
+            None, types.Jinja2
         ),
         voluptuous.Required("commit_message", default="default"): voluptuous.Any(
             "default", "title+body"

--- a/mergify_engine/actions/rebase.py
+++ b/mergify_engine/actions/rebase.py
@@ -34,7 +34,7 @@ class RebaseAction(actions.Action):
 
     validator = {
         voluptuous.Required("bot_account", default=None): voluptuous.Any(
-            None, types.GitHubLogin
+            None, types.Jinja2
         ),
     }
 

--- a/mergify_engine/actions/review.py
+++ b/mergify_engine/actions/review.py
@@ -41,7 +41,7 @@ class ReviewAction(actions.Action):
             types.Jinja2, None
         ),
         voluptuous.Required("bot_account", default=None): voluptuous.Any(
-            None, types.GitHubLogin
+            None, types.Jinja2
         ),
     }
 


### PR DESCRIPTION
This unblocks use cases such as the ability to use the pull request author to
merge a PR.