### PR TITLE
chore: bump GH client threshold

### DIFF
--- a/mergify_engine/clients/github.py
+++ b/mergify_engine/clients/github.py
@@ -32,7 +32,7 @@ from mergify_engine.clients import http
 
 
 RATE_LIMIT_THRESHOLD = 20
-LOGGING_REQUESTS_THRESHOLD = 10
+LOGGING_REQUESTS_THRESHOLD = 100
 
 LOG = daiquiri.getLogger(__name__)
 


### PR DESCRIPTION
Since the client is per-context and per-PR anymore, it makes sense to bump it.