### PR TITLE
fix: never ever report redis connection issue in actions

### DIFF
--- a/mergify_engine/exceptions.py
+++ b/mergify_engine/exceptions.py
@@ -15,6 +15,8 @@ import dataclasses
 import datetime
 import typing
 
+import aredis
+
 from mergify_engine.clients import http
 
 
@@ -94,4 +96,8 @@ def need_retry(
         # correctly by mergify_engine.utils.Github()
         elif exception.response.status_code == 403:
             return datetime.timedelta(minutes=3)
+
+    elif isinstance(exception, aredis.exceptions.ConnectionError):
+        return datetime.timedelta(minutes=1)
+
     return None


### PR DESCRIPTION
This will make the engine always retry after a redis connection issue
instead of reporting failure to user.