### PR TITLE
fix(datadog): disable redis slowlog monitoring

### DIFF
--- a/datadog/conf.d/redisdb.yaml
+++ b/datadog/conf.d/redisdb.yaml
@@ -4,12 +4,14 @@ instances:
   - host: <CACHE HOST>
     port: <CACHE PORT>
     password: <CACHE PASSWORD>
+    slowlog-max-len: 0
     tags:
       - role:cache
 
   - host: <STREAM HOST>
     port: <STREAM PORT>
     password: <STREAM PASSWORD>
+    slowlog-max-len: 0
     keys:
       - streams
       - attempts


### PR DESCRIPTION
It's not clear why it doesn't work, maybe https://github.com/andymccurdy/redis-py/pull/1352

So disable it

(pkg/collector/runner/runner.go:292 in work) | Error running check redisdb: [{"message": "sequence item 0: expected a bytes-like object, int found", "traceback": "Traceback (most recent call last):
  File \"/app/.apt/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py\", line 876, in run
    self.check(instance)
  File \"/app/.apt/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/redisdb/redisdb.py\", line 501, in check
    self._check_slowlog()
  File \"/app/.apt/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/redisdb/redisdb.py\", line 452, in _check_slowlog
    slowlogs = conn.slowlog_get(max_slow_entries)
  File \"/app/.apt/opt/datadog-agent/embedded/lib/python3.8/site-packages/redis/client.py\", line 1466, in slowlog_get
    return self.execute_command(*args, decode_responses=decode_responses)
  File \"/app/.apt/opt/datadog-agent/embedded/lib/python3.8/site-packages/redis/client.py\", line 901, in execute_command
    return self.parse_response(conn, command_name, **options)
  File \"/app/.apt/opt/datadog-agent/embedded/lib/python3.8/site-packages/redis/client.py\", line 921, in parse_response
    return self.response_callbacks[command_name](response, **options)
  File \"/app/.apt/opt/datadog-agent/embedded/lib/python3.8/site-packages/redis/client.py\", line 415, in parse_slowlog_get
    return [{
  File \"/app/.apt/opt/datadog-agent/embedded/lib/python3.8/site-packages/redis/client.py\", line 419, in <listcomp>
    'command': space.join(item[3])
TypeError: sequence item 0: expected a bytes-like object, int found
"}]
