### PR TITLE
feat(github): add Datadog metric for http client request time

### DIFF
--- a/mergify_engine/clients/github.py
+++ b/mergify_engine/clients/github.py
@@ -395,7 +395,10 @@ class AsyncGithubInstallationClient(http.AsyncClient):
     async def request(self, method, url, *args, **kwargs):
         reply = None
         try:
-            reply = await super().request(method, url, *args, **kwargs)
+            with statsd.timed(
+                "http.client.request.time", tags=[f"hostname:{self.base_url.host}"]
+            ):
+                reply = await super().request(method, url, *args, **kwargs)
         except http.HTTPClientSideError as e:
             if e.status_code == 403:
                 _check_rate_limit(e.response)


### PR DESCRIPTION
This should help getting information on GitHub request latency.