### PR TITLE
feat(web): allow to limit number of redis connections

### DIFF
--- a/mergify_engine/config.py
+++ b/mergify_engine/config.py
@@ -114,6 +114,12 @@ Schema = voluptuous.Schema(
         voluptuous.Required(
             "REDIS_SSL_VERIFY_MODE_CERT_NONE", default=False
         ): CoercedBool,
+        voluptuous.Required(
+            "REDIS_STREAM_WEB_MAX_CONNECTIONS", default=None
+        ): voluptuous.Any(None, voluptuous.Coerce(int)),
+        voluptuous.Required(
+            "REDIS_CACHE_WEB_MAX_CONNECTIONS", default=None
+        ): voluptuous.Any(None, voluptuous.Coerce(int)),
         voluptuous.Required("STORAGE_URL", default="redis://localhost:6379?db=8"): str,
         voluptuous.Required("STREAM_URL", default=None): voluptuous.Any(None, str),
         voluptuous.Required("STREAM_PROCESSES", default=1): voluptuous.Coerce(int),
@@ -177,6 +183,8 @@ GIT_EMAIL: str
 CONTEXT: str
 ACCOUNT_TOKENS: typing.Dict[str, str]
 REDIS_SSL_VERIFY_MODE_CERT_NONE: bool
+REDIS_STREAM_WEB_MAX_CONNECTIONS: typing.Optional[int]
+REDIS_CACHE_WEB_MAX_CONNECTIONS: typing.Optional[int]
 
 configuration_file = os.getenv("MERGIFYENGINE_TEST_SETTINGS")
 if configuration_file:

--- a/mergify_engine/utils.py
+++ b/mergify_engine/utils.py
@@ -48,12 +48,13 @@ def redis_from_url(url: str, **options: typing.Any) -> aredis.StrictRedis:
 
 
 async def create_aredis_for_cache(
-    max_idle_time: int = 60,
+    max_idle_time: int = 60, max_connections: typing.Optional[int] = None
 ) -> RedisCache:
     client = redis_from_url(
         config.STORAGE_URL,
         decode_responses=True,
         max_idle_time=max_idle_time,
+        max_connections=max_connections,
     )
     await client.client_setname(f"cache:{_PROCESS_IDENTIFIER}")
     return RedisCache(client)
@@ -68,8 +69,12 @@ async def aredis_for_cache() -> typing.AsyncIterator[RedisCache]:
         client.connection_pool.disconnect()
 
 
-async def create_aredis_for_stream(max_idle_time: int = 60) -> RedisStream:
-    r = redis_from_url(config.STREAM_URL, max_idle_time=max_idle_time)
+async def create_aredis_for_stream(
+    max_idle_time: int = 60, max_connections: typing.Optional[int] = None
+) -> RedisStream:
+    r = redis_from_url(
+        config.STREAM_URL, max_idle_time=max_idle_time, max_connections=max_connections
+    )
     await r.client_setname(f"stream:{_PROCESS_IDENTIFIER}")
     return RedisStream(r)
 

--- a/mergify_engine/web/__init__.py
+++ b/mergify_engine/web/__init__.py
@@ -48,21 +48,23 @@ _AREDIS_CACHE: utils.RedisCache
 
 
 @app.on_event("startup")
-async def startup():
+async def startup() -> None:
     global _AREDIS_STREAM, _AREDIS_CACHE
-    _AREDIS_STREAM = await utils.create_aredis_for_stream()
-    _AREDIS_CACHE = await utils.create_aredis_for_cache()
+    _AREDIS_STREAM = await utils.create_aredis_for_stream(
+        max_connections=config.REDIS_STREAM_WEB_MAX_CONNECTIONS
+    )
+    _AREDIS_CACHE = await utils.create_aredis_for_cache(
+        max_connections=config.REDIS_CACHE_WEB_MAX_CONNECTIONS
+    )
 
 
 @app.on_event("shutdown")
-async def shutdown():
+async def shutdown() -> None:
     global _AREDIS_STREAM, _AREDIS_CACHE
     _AREDIS_CACHE.connection_pool.max_idle_time = 0
     _AREDIS_CACHE.connection_pool.disconnect()
     _AREDIS_STREAM.connection_pool.max_idle_time = 0
     _AREDIS_STREAM.connection_pool.disconnect()
-    _AREDIS_CACHE = None
-    _AREDIS_STREAM = None
     await utils.stop_pending_aredis_tasks()
 
 


### PR DESCRIPTION
The default pool limit is 2**31, this allows to configure it.
