### PR TITLE
refactor(queue API): removing GitHub API call

### DIFF
--- a/mergify_engine/tests/functional/base.py
+++ b/mergify_engine/tests/functional/base.py
@@ -279,6 +279,7 @@ class EventReader:
 class FunctionalTestBase(unittest.IsolatedAsyncioTestCase):
     # NOTE(sileht): The repository have been manually created in mergifyio-testing
     # organization and then forked in mergify-test2 user account
+    REPO_ID = 258840104
     REPO_NAME = "functional-testing-repo"
     FORK_PERSONAL_TOKEN = config.EXTERNAL_USER_PERSONAL_TOKEN
     SUBSCRIPTION_ACTIVE = False

--- a/mergify_engine/tests/functional/test_engine.py
+++ b/mergify_engine/tests/functional/test_engine.py
@@ -748,6 +748,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
         await self.wait_for("pull_request", {"action": "synchronize"})
         await self.run_engine()
 
+        # with the older endpoint
         r = await self.app.get(
             f"/queues/{config.TESTING_ORGANIZATION_ID}",
             headers={
@@ -761,6 +762,17 @@ no changes added to commit (use "git add" and/or "git commit -a")
                 self.master_branch_name: [p2.number]
             }
         }
+
+        # with the new endpoint
+        r = await self.app.get(
+            f"/queues_v2/{config.TESTING_ORGANIZATION_ID}",
+            headers={
+                "X-Hub-Signature": "sha1=whatever",
+                "Content-type": "application/json",
+            },
+        )
+
+        assert r.json() == {f"{self.REPO_ID}": {self.master_branch_name: [p2.number]}}
 
         p2 = self.r_o_admin.get_pull(p2.number)
         commits2 = list(p2.get_commits())

--- a/mergify_engine/web/__init__.py
+++ b/mergify_engine/web/__init__.py
@@ -255,6 +255,22 @@ async def queues_by_owner_id(owner_id):
     return responses.JSONResponse(status_code=200, content=queues)
 
 
+@app.get(
+    "/queues_v2/{owner_id}",  # noqa: FS003
+    dependencies=[fastapi.Depends(auth.signature)],
+)
+async def queues(owner_id):
+    global _AREDIS_CACHE
+    queues = collections.defaultdict(dict)
+    async for queue in _AREDIS_CACHE.scan_iter(match=f"merge-queue~{owner_id}~*"):
+        _, _, repo_id, branch = queue.split("~")
+        queues[repo_id][branch] = [
+            int(pull) async for pull, _ in _AREDIS_CACHE.zscan_iter(queue)
+        ]
+
+    return responses.JSONResponse(status_code=200, content=queues)
+
+
 @app.post("/event", dependencies=[fastapi.Depends(auth.signature)])
 async def event_handler(
     request: requests.Request,


### PR DESCRIPTION
add a second temporary queues route before updating the dashboard part
