### PR TITLE
chore: reraise redis connection errors

### DIFF
--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -110,6 +110,7 @@ class T_PayloadEvent(typing.TypedDict):
     wait=tenacity.wait_exponential(multiplier=0.2),
     stop=tenacity.stop_after_attempt(5),
     retry=tenacity.retry_if_exception_type(aredis.ConnectionError),
+    reraise=True,
 )
 async def push(
     redis: utils.RedisStream,


### PR DESCRIPTION
tenacity hide some informations in sentry when the original exception is
wrapped into a RetryError. So just reraise the original one.