### PR TITLE
fix: aredis custom build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 aiofiles==0.6.0
-aredis==1.1.8
 cachetools==4.2.1
 certifi==2020.12.5
 cffi==1.14.5
@@ -48,4 +47,5 @@ voluptuous==0.12.1
 watchgod==0.7
 websockets==8.1
 Werkzeug==1.0.1
+-e git+http://github.com/sileht/aredis.git@prod-mergify#egg=aredis
 -e .

--- a/tox.ini
+++ b/tox.ini
@@ -61,10 +61,11 @@ skip_install = true
 deps =
 commands_pre =
 commands =
-  bash -c "sed -e '/^-e ./d' requirements.txt > constraints.txt"
-  pip install -c constraints.txt -e .
+  bash -c "sed -e '/^-e/d' requirements.txt > constraints.txt"
+  bash -c "pip install -c constraints.txt -e . -e git+http://github.com/sileht/aredis.git@prod-mergify#egg=aredis"
   pip uninstall --yes mergify-engine
   bash -c "pip freeze --exclude-editable >| requirements.txt"
+  bash -c "echo '-e git+http://github.com/sileht/aredis.git@prod-mergify#egg=aredis' >> requirements.txt"
   bash -c "echo '-e .' >> requirements.txt"
 whitelist_externals =
     bash


### PR DESCRIPTION
The stable version of aredis have two annoying issues for us:

* it doesn't handle correctly asyncio.CancelledError in some code path:
  (fixed in master: https://github.com/NoneGG/aredis/pull/172, https://github.com/NoneGG/aredis/pull/170)
* it doesn't show the reason of initial connection failure
  (https://github.com/NoneGG/aredis/pull/188)

This change uses a custom build until aredis release a version with all
these fixes.