### PR TITLE
fix: clear option to disable rebase_fallback

### DIFF
--- a/docs/source/actions/merge.rst
+++ b/docs/source/actions/merge.rst
@@ -31,7 +31,8 @@ The ``merge`` action merges the pull request into its base branch. The
      - ``merge``
      - If ``method`` is set to ``rebase``, but the pull request cannot be
        rebased, the method defined in ``rebase_fallback`` will be used instead.
-       Possible values are ``merge``, ``squash``, ``null``.
+       Possible values are ``merge``, ``squash``, ``none``. ``none`` will
+       report an error if rebase is not possible.
    * - ``strict``
      - Boolean, ``smart`` or ``smart+fasttrack``
      - ``false``

--- a/docs/source/actions/queue.rst
+++ b/docs/source/actions/queue.rst
@@ -189,7 +189,8 @@ These are the options of the ``queue`` action:
      - ``merge``
      - If ``method`` is set to ``rebase``, but the pull request cannot be
        rebased, the method defined in ``rebase_fallback`` will be used instead.
-       Possible values are ``merge``, ``squash``, ``null``.
+       Possible values are ``merge``, ``squash``, ``none``. ``none`` will
+       report an error if rebase is not possible.
    * - ``merge_bot_account``
      - string
      -

--- a/mergify_engine/actions/merge.py
+++ b/mergify_engine/actions/merge.py
@@ -38,8 +38,9 @@ class MergeAction(merge_base.MergeBaseAction):
         voluptuous.Required("method", default="merge"): voluptuous.Any(
             "rebase", "merge", "squash"
         ),
+        # NOTE(sileht): None is supported for legacy reason
         voluptuous.Required("rebase_fallback", default="merge"): voluptuous.Any(
-            "merge", "squash", None
+            "merge", "squash", "none", None
         ),
         voluptuous.Required("strict", default=False): voluptuous.All(
             voluptuous.Any(

--- a/mergify_engine/actions/merge_base.py
+++ b/mergify_engine/actions/merge_base.py
@@ -473,9 +473,11 @@ class MergeBaseAction(actions.Action):
     ) -> check_api.Result:
         if self.config["method"] != "rebase" or ctxt.pull["rebaseable"]:
             method = self.config["method"]
-        elif self.config["rebase_fallback"]:
+        elif self.config["rebase_fallback"] in ["merge", "squash"]:
             method = self.config["rebase_fallback"]
         else:
+            if self.config["rebase_fallback"] is None:
+                ctxt.log.info("legacy rebase_fallback=null used")
             return check_api.Result(
                 check_api.Conclusion.ACTION_REQUIRED,
                 "Automatic rebasing is not possible, manual intervention required",

--- a/mergify_engine/actions/queue.py
+++ b/mergify_engine/actions/queue.py
@@ -44,7 +44,7 @@ class QueueAction(merge_base.MergeBaseAction):
             "rebase", "merge", "squash"
         ),
         voluptuous.Required("rebase_fallback", default="merge"): voluptuous.Any(
-            "merge", "squash", None
+            "merge", "squash", "none", None
         ),
         voluptuous.Required("merge_bot_account", default=None): voluptuous.Any(
             None, types.GitHubLogin


### PR DESCRIPTION
The current value to disable `rebase_fallback` was the json `null`
value. Since the option is string it's not obvious that you should not
quote `null`. And `null` is not documented.

This changes introduce `none` string, that just a alias to json null.
And it documents it.

Fixes MRGFY-352