### PR TITLE
fix: don't use redis connection on startup

### DIFF
--- a/mergify_engine/actions/refresh.py
+++ b/mergify_engine/actions/refresh.py
@@ -29,7 +29,7 @@ class RefreshAction(actions.Action):
     async def run(
         self, ctxt: context.Context, rule: rules.EvaluatedRule
     ) -> check_api.Result:
-        async with utils.aredis_for_stream() as redis_stream:
+        with utils.aredis_for_stream() as redis_stream:
             await github_events.send_refresh(
                 ctxt.redis,
                 redis_stream,

--- a/mergify_engine/debug.py
+++ b/mergify_engine/debug.py
@@ -101,7 +101,7 @@ async def report_dashboard_synchro(
 
 async def report_worker_status(owner: github_types.GitHubLogin) -> None:
     stream_name = f"stream~{owner}".encode()
-    r = await utils.create_aredis_for_stream()
+    r = utils.create_aredis_for_stream()
     streams = await r.zrangebyscore("streams", min=0, max="+inf", withscores=True)
 
     for pos, item in enumerate(streams):  # noqa: B007
@@ -155,7 +155,7 @@ async def report_queue(title: str, q: queue.QueueT) -> None:
 async def report(
     url: str,
 ) -> typing.Union[context.Context, github.AsyncGithubInstallationClient, None]:
-    redis_cache = await utils.create_aredis_for_cache(max_idle_time=0)
+    redis_cache = utils.create_aredis_for_cache(max_idle_time=0)
 
     path = url.replace("https://github.com/", "")
 

--- a/mergify_engine/queue/__init__.py
+++ b/mergify_engine/queue/__init__.py
@@ -103,7 +103,7 @@ class QueueBase(abc.ABC):
 
         from mergify_engine import github_events  # circular reference
 
-        async with utils.aredis_for_stream() as redis_stream:
+        with utils.aredis_for_stream() as redis_stream:
             for pull_number in await self.get_pulls():
                 if (
                     except_pull_request is not None

--- a/mergify_engine/queue/merge_train.py
+++ b/mergify_engine/queue/merge_train.py
@@ -393,7 +393,7 @@ You don't need to do anything. Mergify will close this pull request automaticall
             ),
         )
 
-        async with utils.aredis_for_stream() as redis_stream:
+        with utils.aredis_for_stream() as redis_stream:
             await github_events.send_refresh(
                 self.train.repository.installation.redis,
                 redis_stream,
@@ -541,7 +541,7 @@ You don't need to do anything. Mergify will close this pull request automaticall
 
         # NOTE(sileht): refresh it, so the queue action will merge it and delete the
         # tmp_pull_ctxt branch
-        async with utils.aredis_for_stream() as redis_stream:
+        with utils.aredis_for_stream() as redis_stream:
             await github_events.send_refresh(
                 self.train.repository.installation.redis,
                 redis_stream,

--- a/mergify_engine/tests/conftest.py
+++ b/mergify_engine/tests/conftest.py
@@ -35,7 +35,7 @@ def setup_new_event_loop() -> None:
 
 @pytest.fixture()
 async def redis_cache() -> typing.AsyncGenerator[utils.RedisCache, None]:
-    async with utils.aredis_for_cache() as client:
+    with utils.aredis_for_cache() as client:
         await client.flushdb()
         try:
             yield client
@@ -47,7 +47,7 @@ async def redis_cache() -> typing.AsyncGenerator[utils.RedisCache, None]:
 
 @pytest.fixture()
 async def redis_stream() -> typing.AsyncGenerator[utils.RedisStream, None]:
-    async with utils.aredis_for_stream() as client:
+    with utils.aredis_for_stream() as client:
         await client.flushdb()
         try:
             yield client

--- a/mergify_engine/tests/functional/actions/test_post_check.py
+++ b/mergify_engine/tests/functional/actions/test_post_check.py
@@ -120,7 +120,7 @@ Rule list:
 class TestPostCheckActionNoSub(base.FunctionalTestBase):
     async def test_checks_feature_disabled(self):
         self.subscription = subscription.Subscription(
-            await utils.create_aredis_for_cache(max_idle_time=0),
+            utils.create_aredis_for_cache(max_idle_time=0),
             config.INSTALLATION_ID,
             self.SUBSCRIPTION_ACTIVE,
             "You're not nice",

--- a/mergify_engine/tests/functional/base.py
+++ b/mergify_engine/tests/functional/base.py
@@ -391,7 +391,7 @@ class FunctionalTestBase(unittest.IsolatedAsyncioTestCase):
         self.app = httpx.AsyncClient(app=root.app, base_url="http://localhost")
 
         await self.clear_redis_cache()
-        self.redis_cache = await utils.create_aredis_for_cache(max_idle_time=0)
+        self.redis_cache = utils.create_aredis_for_cache(max_idle_time=0)
         self.subscription = subscription.Subscription(
             self.redis_cache,
             config.TESTING_ORGANIZATION_ID,
@@ -524,12 +524,12 @@ class FunctionalTestBase(unittest.IsolatedAsyncioTestCase):
 
     @staticmethod
     async def clear_redis_stream():
-        redis_stream = await utils.create_aredis_for_stream(max_idle_time=0)
-        await redis_stream.flushall()
+        with utils.aredis_for_stream() as redis_stream:
+            await redis_stream.flushall()
 
     @staticmethod
     async def clear_redis_cache():
-        async with utils.aredis_for_cache() as redis_stream:
+        with utils.aredis_for_cache() as redis_stream:
             await redis_stream.flushall()
 
     async def asyncTearDown(self):

--- a/mergify_engine/tests/functional/test_engine.py
+++ b/mergify_engine/tests/functional/test_engine.py
@@ -25,7 +25,6 @@ from mergify_engine import check_api
 from mergify_engine import config
 from mergify_engine import context
 from mergify_engine import engine
-from mergify_engine import utils
 from mergify_engine.clients import github
 from mergify_engine.tests.functional import base
 
@@ -926,7 +925,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
             p["base"]["user"]["login"],
             self.subscription,
             client,
-            await (utils.create_aredis_for_cache(max_idle_time=0)),
+            self.redis_cache,
         )
         repository = context.Repository(installation, p["base"]["repo"]["name"])
         pull = await context.Context.create(repository, p, [])
@@ -972,7 +971,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
             p["base"]["user"]["login"],
             self.subscription,
             client,
-            await (utils.create_aredis_for_cache(max_idle_time=0)),
+            self.redis_cache,
         )
         repository = context.Repository(installation, p["base"]["repo"]["name"])
         pull = await context.Context.create(repository, p, [])

--- a/mergify_engine/utils.py
+++ b/mergify_engine/utils.py
@@ -47,7 +47,7 @@ def redis_from_url(url: str, **options: typing.Any) -> aredis.StrictRedis:
     return aredis.StrictRedis.from_url(final_url, **options)
 
 
-async def create_aredis_for_cache(
+def create_aredis_for_cache(
     max_idle_time: int = 60, max_connections: typing.Optional[int] = None
 ) -> RedisCache:
     client = redis_from_url(
@@ -56,32 +56,31 @@ async def create_aredis_for_cache(
         max_idle_time=max_idle_time,
         max_connections=max_connections,
     )
-    await client.client_setname(f"cache:{_PROCESS_IDENTIFIER}")
     return RedisCache(client)
 
 
-@contextlib.asynccontextmanager
-async def aredis_for_cache() -> typing.AsyncIterator[RedisCache]:
-    client = await create_aredis_for_cache(max_idle_time=0)
+@contextlib.contextmanager
+def aredis_for_cache() -> typing.Iterator[RedisCache]:
+    client = create_aredis_for_cache(max_idle_time=0)
     try:
         yield client
     finally:
         client.connection_pool.disconnect()
 
 
-async def create_aredis_for_stream(
-    max_idle_time: int = 60, max_connections: typing.Optional[int] = None
+def create_aredis_for_stream(
+    max_idle_time: int = 60,
+    max_connections: typing.Optional[int] = None,
 ) -> RedisStream:
     r = redis_from_url(
         config.STREAM_URL, max_idle_time=max_idle_time, max_connections=max_connections
     )
-    await r.client_setname(f"stream:{_PROCESS_IDENTIFIER}")
     return RedisStream(r)
 
 
-@contextlib.asynccontextmanager
-async def aredis_for_stream() -> typing.AsyncIterator[RedisCache]:
-    client = await create_aredis_for_stream(max_idle_time=0)
+@contextlib.contextmanager
+def aredis_for_stream() -> typing.Iterator[RedisCache]:
+    client = create_aredis_for_stream(max_idle_time=0)
     try:
         yield client
     finally:

--- a/mergify_engine/web/redis.py
+++ b/mergify_engine/web/redis.py
@@ -28,10 +28,10 @@ LOG = daiquiri.getLogger(__name__)
 
 async def startup():
     global _AREDIS_STREAM, _AREDIS_CACHE
-    _AREDIS_STREAM = await utils.create_aredis_for_stream(
+    _AREDIS_STREAM = utils.create_aredis_for_stream(
         max_connections=config.REDIS_STREAM_WEB_MAX_CONNECTIONS
     )
-    _AREDIS_CACHE = await utils.create_aredis_for_cache(
+    _AREDIS_CACHE = utils.create_aredis_for_cache(
         max_connections=config.REDIS_CACHE_WEB_MAX_CONNECTIONS
     )
 

--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -746,8 +746,8 @@ class Worker:
         self._stopping.clear()
 
         LOG.info("redis initialisation")
-        self._redis_stream = await utils.create_aredis_for_stream()
-        self._redis_cache = await utils.create_aredis_for_cache()
+        self._redis_stream = utils.create_aredis_for_stream()
+        self._redis_cache = utils.create_aredis_for_cache()
         LOG.info("redis initialised")
 
         if "stream" in self.enabled_services:
@@ -847,7 +847,7 @@ async def async_status() -> None:
     process_count: int = config.STREAM_PROCESSES
     worker_count: int = worker_per_process * process_count
 
-    redis_stream = await utils.create_aredis_for_stream()
+    redis_stream = utils.create_aredis_for_stream()
     stream_selector = StreamSelector(redis_stream, 0, worker_count)
 
     def sorter(item):
@@ -876,7 +876,7 @@ async def async_reschedule_now() -> int:
     parser.add_argument("org", help="Organization")
     args = parser.parse_args()
 
-    redis = await utils.create_aredis_for_stream()
+    redis = utils.create_aredis_for_stream()
     streams = await redis.zrangebyscore("streams", min=0, max="+inf")
     expected_stream = f"stream~{args.org.lower()}~"
     for stream in streams:


### PR DESCRIPTION
Currently if the redis connection is not working
* The asyncio Worker._run() task exits with a never awaited
  `aredis.ConnectionError` exception, and Worker() just waits for
  `_shutdown()` to be called.
* The fastapi/starlette  web.root._startup() hook raises a
  `aredis.ConnectionError` exception and the web dyno is restarted.

Fixes MRGFY-339
