### PR TITLE
fix: ensure errors on startup/shutdown are raised

### DIFF
--- a/mergify_engine/tests/functional/base.py
+++ b/mergify_engine/tests/functional/base.py
@@ -577,7 +577,7 @@ class FunctionalTestBase(unittest.IsolatedAsyncioTestCase):
         w = worker.Worker(
             idle_sleep_time=0.42 if RECORD else 0.01, enabled_services=["stream"]
         )
-        w.start()
+        await w.start()
 
         started_at = None
         while True:

--- a/mergify_engine/tests/unit/test_worker.py
+++ b/mergify_engine/tests/unit/test_worker.py
@@ -32,7 +32,7 @@ from mergify_engine.clients import http
 
 async def run_worker(test_timeout=10, **kwargs):
     w = worker.Worker(**kwargs)
-    w.start()
+    await w.start()
     started_at = time.monotonic()
     while (
         w._redis_stream is None or (await w._redis_stream.zcard("streams")) > 0


### PR DESCRIPTION
We don't really need to create a task since no IO occurs during startup
now.

This will ensure that anything unexpected during startup will raise an
exception instantly and not when the worker shutdown.