### PR TITLE
docs(merge): simplify documentation

### DIFF
--- a/docs/source/actions/queue.rst
+++ b/docs/source/actions/queue.rst
@@ -19,6 +19,8 @@ merged in their base branch.
 Why Queues?
 -----------
 
+.. _merge queue problem:
+
 The Problem
 ~~~~~~~~~~~
 


### PR DESCRIPTION
This relies on the queue documentation a little more to simplify the merge
action.