### PR TITLE
chore: move send_refresh out of github_events

### DIFF
--- a/mergify_engine/actions/refresh.py
+++ b/mergify_engine/actions/refresh.py
@@ -16,7 +16,6 @@ import typing
 from mergify_engine import actions
 from mergify_engine import check_api
 from mergify_engine import context
-from mergify_engine import github_events
 from mergify_engine import rules
 from mergify_engine import utils
 
@@ -30,7 +29,7 @@ class RefreshAction(actions.Action):
         self, ctxt: context.Context, rule: rules.EvaluatedRule
     ) -> check_api.Result:
         with utils.aredis_for_stream() as redis_stream:
-            await github_events.send_refresh(
+            await utils.send_refresh(
                 ctxt.redis,
                 redis_stream,
                 ctxt.pull["base"]["repo"],

--- a/mergify_engine/github_events.py
+++ b/mergify_engine/github_events.py
@@ -16,7 +16,6 @@
 
 import dataclasses
 import typing
-import uuid
 
 import daiquiri
 from datadog import statsd
@@ -468,35 +467,3 @@ async def extract_pull_numbers_from_event(
         return pulls
     else:
         return []
-
-
-async def send_refresh(
-    redis_cache: utils.RedisCache,
-    redis_stream: utils.RedisStream,
-    repository: github_types.GitHubRepository,
-    pull_request_number: typing.Optional[github_types.GitHubPullRequestNumber] = None,
-    ref: typing.Optional[github_types.GitHubRefType] = None,
-    action: github_types.GitHubEventRefreshActionType = "user",
-) -> None:
-    data = github_types.GitHubEventRefresh(
-        {
-            "action": action,
-            "ref": ref,
-            "repository": repository,
-            "pull_request_number": pull_request_number,
-            "sender": {
-                "login": github_types.GitHubLogin("<internal>"),
-                "id": github_types.GitHubAccountIdType(0),
-                "type": "User",
-                "avatar_url": "",
-            },
-            "organization": repository["owner"],
-            "installation": {
-                "id": github_types.GitHubInstallationIdType(0),
-                "account": repository["owner"],
-            },
-        }
-    )
-    await filter_and_dispatch(
-        redis_cache, redis_stream, "refresh", str(uuid.uuid4()), data
-    )

--- a/mergify_engine/queue/__init__.py
+++ b/mergify_engine/queue/__init__.py
@@ -101,8 +101,6 @@ class QueueBase(abc.ABC):
         ] = None,
     ) -> None:
 
-        from mergify_engine import github_events  # circular reference
-
         with utils.aredis_for_stream() as redis_stream:
             for pull_number in await self.get_pulls():
                 if (
@@ -110,7 +108,7 @@ class QueueBase(abc.ABC):
                     and except_pull_request == pull_number
                 ):
                     continue
-                await github_events.send_refresh(
+                await utils.send_refresh(
                     self.repository.installation.redis,
                     redis_stream,
                     repository,

--- a/mergify_engine/queue/merge_train.py
+++ b/mergify_engine/queue/merge_train.py
@@ -24,7 +24,6 @@ import first
 from mergify_engine import check_api
 from mergify_engine import constants
 from mergify_engine import context
-from mergify_engine import github_events
 from mergify_engine import github_types
 from mergify_engine import json
 from mergify_engine import queue
@@ -412,7 +411,7 @@ You don't need to do anything. Mergify will close this pull request automaticall
         )
 
         with utils.aredis_for_stream() as redis_stream:
-            await github_events.send_refresh(
+            await utils.send_refresh(
                 self.train.repository.installation.redis,
                 redis_stream,
                 original_ctxt.pull["base"]["repo"],
@@ -562,7 +561,7 @@ You don't need to do anything. Mergify will close this pull request automaticall
         # NOTE(sileht): refresh it, so the queue action will merge it and delete the
         # tmp_pull_ctxt branch
         with utils.aredis_for_stream() as redis_stream:
-            await github_events.send_refresh(
+            await utils.send_refresh(
                 self.train.repository.installation.redis,
                 redis_stream,
                 original_ctxt.pull["base"]["repo"],

--- a/mergify_engine/web/root.py
+++ b/mergify_engine/web/root.py
@@ -103,7 +103,7 @@ async def refresh_repo(
                 status_code=404, content="repository not found"
             )
 
-    await github_events.send_refresh(redis_cache, redis_stream, repository)
+    await utils.send_refresh(redis_cache, redis_stream, repository)
     return responses.Response("Refresh queued", status_code=202)
 
 
@@ -135,7 +135,7 @@ async def refresh_pull(
                 status_code=404, content="repository not found"
             )
 
-    await github_events.send_refresh(
+    await utils.send_refresh(
         redis_cache,
         redis_stream,
         repository,
@@ -168,7 +168,7 @@ async def refresh_branch(
                 status_code=404, content="repository not found"
             )
 
-    await github_events.send_refresh(
+    await utils.send_refresh(
         redis_cache,
         redis_stream,
         repository,


### PR DESCRIPTION
This will avoid most circular import isssues
