### PR TITLE
feat: allow to use null instead of {} in action config

### DIFF
--- a/docs/source/actions/close.rst
+++ b/docs/source/actions/close.rst
@@ -43,4 +43,4 @@ let's say ``do_not_touch.txt``, you could write a rule such as:
         conditions:
           - files=do_not_touch.txt
         actions:
-          close: {}
+          close:

--- a/docs/source/actions/delete_head_branch.rst
+++ b/docs/source/actions/delete_head_branch.rst
@@ -58,4 +58,4 @@ Mergify allows to delete those branches once the pull request has been merged:
         conditions:
           - merged
         actions:
-          delete_head_branch: {}
+          delete_head_branch:

--- a/docs/source/actions/dismiss_reviews.rst
+++ b/docs/source/actions/dismiss_reviews.rst
@@ -61,7 +61,7 @@ as the pull request gets updated with new commits.
         conditions:
           - base=master
         actions:
-          dismiss_reviews: {}
+          dismiss_reviews:
 
 You could also only dismiss the outdated reviews if the author is not a member
 of a particular team. This allows to keep the approval if the author is
@@ -75,4 +75,4 @@ trusted, even if they update their code:
           - base=master
           - author!=@mytrustedteam
         actions:
-          dismiss_reviews: {}
+          dismiss_reviews:

--- a/docs/source/actions/update.rst
+++ b/docs/source/actions/update.rst
@@ -14,13 +14,10 @@ works by merging the base branch into the head branch of the pull request.
 
 .. image:: ../_static/update-branch.png
 
-This action does not have any configuration option, therefore it takes an empty
-dictionary as configuration (``{}`` in YAML).
-
 .. code-block:: yaml
 
     actions:
-      update: {}
+      update:
 
 
 Examples
@@ -46,7 +43,7 @@ pull requests.
           - -draft # filter-out GH draft PRs
           - label="Ready-to-Go"
         actions:
-          update: {}
+          update:
 
 When a pull request is not in conflict nor draft, and has the label
 ``Ready-to-Go``, it will be automatically updated with its base branch.

--- a/mergify_engine/actions/__init__.py
+++ b/mergify_engine/actions/__init__.py
@@ -98,7 +98,13 @@ class Action(abc.ABC):
 
     @classmethod
     def get_schema(cls) -> ActionSchema:
-        return ActionSchema(voluptuous.All(cls.validator, voluptuous.Coerce(cls)))
+        return ActionSchema(
+            voluptuous.All(
+                voluptuous.Coerce(lambda v: {} if v is None else v),
+                cls.validator,
+                voluptuous.Coerce(cls),
+            )
+        )
 
     @staticmethod
     def command_to_config(string: str) -> typing.Dict[str, typing.Any]:

--- a/mergify_engine/rules/__init__.py
+++ b/mergify_engine/rules/__init__.py
@@ -449,9 +449,14 @@ def merge_config(config: typing.Dict[str, typing.Any]) -> typing.Dict[str, typin
                 for action_name, action in actions.items():
                     if action_name not in defaults_actions:
                         continue
+                    elif defaults_actions[action_name] is None:
+                        continue
 
-                    merged_action = defaults_actions[action_name] | action
-                    rule["actions"][action_name].update(merged_action)
+                    if action is None:
+                        rule["actions"][action_name] = defaults_actions[action_name]
+                    else:
+                        merged_action = defaults_actions[action_name] | action
+                        rule["actions"][action_name].update(merged_action)
     return config
 
 

--- a/mergify_engine/tests/unit/rules/test_rules.py
+++ b/mergify_engine/tests/unit/rules/test_rules.py
@@ -413,16 +413,6 @@ async def test_get_mergify_config_location_from_cache(
             pull_request_rules:
               - name: ahah
                 conditions:
-                - base=master
-                actions:
-                  comment:
-            """
-        ),
-        (
-            """
-            pull_request_rules:
-              - name: ahah
-                conditions:
                 actions:
                   coment:
                     message: |
@@ -1219,3 +1209,37 @@ def test_merge_config():
     merged_config = rules.merge_config(config)
 
     assert merged_config == config
+
+
+def test_actions_with_options_none():
+    file = context.MergifyConfigFile(
+        type="file",
+        content="whatever",
+        sha="azertyuiop",
+        path="whatever",
+        decoded_content="""
+defaults:
+  actions:
+    post_check:
+    rebase:
+    comment:
+      bot_account: "foobar"
+pull_request_rules:
+  - name: ahah
+    conditions:
+    - base=master
+    actions:
+      comment:
+      rebase:
+        bot_account: "foobar"
+      post_check:
+            """,
+    )
+
+    config = rules.get_mergify_config(file)
+
+    assert [list(rule.actions.keys()) for rule in config["pull_request_rules"]][0] == [
+        "comment",
+        "rebase",
+        "post_check",
+    ]


### PR DESCRIPTION
Allow to use null instead of {}, when we have no option to pass.

Fixes MRGFY-378
