### PR TITLE
chore: avoid useless logging

### DIFF
--- a/mergify_engine/engine/__init__.py
+++ b/mergify_engine/engine/__init__.py
@@ -261,7 +261,8 @@ async def run(
     if not ctxt.sources:
         return
 
-    await _ensure_summary_on_head_sha(ctxt)
+    if mergify_config["pull_request_rules"].has_user_rules():
+        await _ensure_summary_on_head_sha(ctxt)
 
     # NOTE(jd): that's fine for now, but I wonder if we wouldn't need a higher abstraction
     # to have such things run properly. Like hooks based on events that you could

--- a/mergify_engine/engine/actions_runner.py
+++ b/mergify_engine/engine/actions_runner.py
@@ -470,13 +470,15 @@ async def handle(
     match = await pull_request_rules.get_pull_request_rule(ctxt)
     checks = {c["name"]: c for c in await ctxt.pull_engine_check_runs}
 
-    summary_check = checks.get(ctxt.SUMMARY_NAME)
-    previous_conclusions = load_conclusions(ctxt, summary_check)
+    if pull_request_rules.has_user_rules():
+        summary_check = checks.get(ctxt.SUMMARY_NAME)
+        previous_conclusions = load_conclusions(ctxt, summary_check)
+    else:
+        previous_conclusions = {}
 
     conclusions = await run_actions(ctxt, match, checks, previous_conclusions)
 
-    has_user_rules = any(rule for rule in pull_request_rules.rules if not rule.hidden)
-    if not has_user_rules:
+    if not pull_request_rules.has_user_rules():
         # NOTE(sileht): Only hidden rules are ran, we don't post a summary in
         # such case, currently only delete_head_branch is used in our rules,
         # sources we don't care about storing the result of this action.

--- a/mergify_engine/rules/__init__.py
+++ b/mergify_engine/rules/__init__.py
@@ -241,6 +241,9 @@ class PullRequestRules:
     def __iter__(self):
         return iter(self.rules)
 
+    def has_user_rules(self):
+        return any(rule for rule in self.rules if not rule.hidden)
+
     async def get_pull_request_rule(self, ctxt: context.Context) -> RulesEvaluator:
         return await RulesEvaluator.create(
             self.rules, ctxt, EvaluatedRule.from_rule, True


### PR DESCRIPTION
In case of user hasn't defined pull_request_rules we don't need to look
at Summary and throw a ton of useless logs.