### PR TITLE
fix(teams): don't deserialize 204

### DIFF
--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -466,7 +466,7 @@ class Repository(object):
                 # note(sileht) read permissions are not part of the permissions
                 # list as the api endpoint returns 404 if permission read is missing
                 # so no need to check permission
-                await self.installation.client.item(
+                await self.installation.client.get(
                     f"/orgs/{self.installation.owner_login}/teams/{team}/repos/{self.installation.owner_login}/{self.name}",
                 )
                 read_permission = True

--- a/mergify_engine/tests/unit/actions/test_request_reviews.py
+++ b/mergify_engine/tests/unit/actions/test_request_reviews.py
@@ -243,7 +243,7 @@ async def test_team_permissions_missing(redis_cache):
     )
     client = mock.MagicMock()
     client.auth.installation.__getitem__.return_value = 123
-    client.item = mock.AsyncMock(
+    client.get = mock.AsyncMock(
         side_effect=http.HTTPNotFound(
             message="not found", response=mock.ANY, request=mock.ANY
         )
@@ -276,7 +276,7 @@ async def test_team_permissions_ok(redis_cache):
     )
     client = mock.MagicMock()
     client.auth.installation.__getitem__.return_value = 123
-    client.item = mock.AsyncMock(return_value={})
+    client.get = mock.AsyncMock(return_value={})
     ctxt = await prepare_context(client, redis_cache)
     result = await action.run(ctxt, None)
     assert result.summary == ""

--- a/mergify_engine/tests/unit/test_context.py
+++ b/mergify_engine/tests/unit/test_context.py
@@ -254,7 +254,7 @@ async def test_team_permission_cache(redis_cache: utils.RedisCache) -> None:
             self.repo = repo
             self.called = 0
 
-        async def item(self, url, *args, **kwargs):
+        async def get(self, url, *args, **kwargs):
             self.called += 1
             if (
                 url


### PR DESCRIPTION
The team permission endpoint may return 204 with no payload.

This change handles this.

Fixes MERGIFY-ENGINE-25T
