### PR TITLE
chore: pass the owner_id in the subscription API call

### DIFF
--- a/mergify_engine/subscription.py
+++ b/mergify_engine/subscription.py
@@ -223,10 +223,13 @@ class SubscriptionDashboardOnPremise(SubscriptionBase):
     async def _retrieve_subscription_from_db(
         cls: typing.Type[SubscriptionT], redis: utils.RedisCache, owner_id: int
     ) -> SubscriptionT:
+
+        print(config.SUBSCRIPTION_BASE_URL)
+        print(f"{config.SUBSCRIPTION_BASE_URL}/on-premise/subscription/{owner_id}")
         async with http.AsyncClient() as client:
             try:
                 resp = await client.get(
-                    f"{config.SUBSCRIPTION_BASE_URL}/on-premise/subscription",
+                    f"{config.SUBSCRIPTION_BASE_URL}/on-premise/subscription/{owner_id}",
                     headers={"Authorization": f"token {config.SUBSCRIPTION_TOKEN}"},
                 )
             except http.HTTPUnauthorized:

--- a/mergify_engine/subscription.py
+++ b/mergify_engine/subscription.py
@@ -239,11 +239,16 @@ class SubscriptionDashboardOnPremise(SubscriptionBase):
                 raise exceptions.MergifyNotInstalled()
             except http.HTTPForbidden:
                 LOG.critical(
-                    "The subscription attached SUBSCRIPTION_TOKEN is not valid"
+                    "The subscription attached to SUBSCRIPTION_TOKEN is not valid"
                 )
                 raise exceptions.MergifyNotInstalled()
             else:
                 sub = resp.json()
+                if not sub["subscription_active"]:
+                    LOG.critical(
+                        "The subscription attached to SUBSCRIPTION_TOKEN is not active"
+                    )
+                    raise exceptions.MergifyNotInstalled()
                 return cls.from_dict(redis, owner_id, sub)
 
 

--- a/mergify_engine/tests/unit/test_subscription.py
+++ b/mergify_engine/tests/unit/test_subscription.py
@@ -185,7 +185,7 @@ async def test_subscription_on_premise_valid(
     httpserver: httpserver.HTTPServer,
 ) -> None:
 
-    httpserver.expect_request("/on-premise/subscription").respond_with_json(
+    httpserver.expect_request("/on-premise/subscription/1234").respond_with_json(
         {
             "subscription_active": True,
             "subscription_reason": "azertyuio",
@@ -219,7 +219,7 @@ async def test_subscription_on_premise_wrong_token(
     httpserver: httpserver.HTTPServer,
 ) -> None:
 
-    httpserver.expect_request("/on-premise/subscription").respond_with_json(
+    httpserver.expect_request("/on-premise/subscription/1234").respond_with_json(
         {"message": "error"}, status=401
     )
 
@@ -242,7 +242,7 @@ async def test_subscription_on_premise_invalid_sub(
     httpserver: httpserver.HTTPServer,
 ) -> None:
 
-    httpserver.expect_request("/on-premise/subscription").respond_with_json(
+    httpserver.expect_request("/on-premise/subscription/1234").respond_with_json(
         {"message": "error"}, status=403
     )
 


### PR DESCRIPTION
## chore: pass the owner_id in the subscription API call


## fix: don't return a subscription object is active is false
