### PR TITLE
chore(installer): reduce number of steps

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,6 +1,7 @@
 extends: default
 ignore: |
   .git
+  installer/node_modules
 rules:
   document-start: disable
   truthy: disable

--- a/installer/src/App.css
+++ b/installer/src/App.css
@@ -1,3 +1,7 @@
 .btn-primary, .btn-primary:hover, .btn-primary:active, .btn-primary:visited {
     background-color: #067ABD !important;
 }
+
+.breadcrumb-item + .breadcrumb-item::before {
+   content: ">" !important;
+}

--- a/mergify_engine/web/root.py
+++ b/mergify_engine/web/root.py
@@ -73,14 +73,6 @@ async def redis_errors(
     return responses.JSONResponse(status_code=503)
 
 
-@app.get("/installation")  # noqa: FS003
-async def installation() -> responses.Response:
-    return responses.Response(
-        "Your mergify installation succeed, the installer have been disabled.",
-        status_code=200,
-    )
-
-
 @app.post(
     "/refresh/{owner}/{repo_name}",  # noqa: FS003
     dependencies=[fastapi.Depends(auth.signature)],
@@ -356,5 +348,12 @@ async def event_handler(
 
 
 @app.get("/")
-async def index():  # pragma: no cover
+async def index(
+    setup_action: typing.Optional[str] = None,
+) -> responses.Response:  # pragma: no cover
+    if setup_action:
+        return responses.Response(
+            "Your Mergify installation succeeded.",
+            status_code=200,
+        )
     return responses.RedirectResponse(url="https://mergify.io/")


### PR DESCRIPTION
## chore: don't yamllint node_modules


## chore(installer): reduce number of steps

This merge the Download config and Install App page.

We set the setup_url in manifest, so after the installation, we got
redirect to the installer and we can display a success message.

This make the new flow has only 5 screens instead of 7:
* Enter the GitHub login, click Create
* Confirm creation on GitHub
* Download the config and click Install
* Confirm installation on GitHub
* Got success message
