### PR TITLE
feat: add signaling mechanism

### DIFF
--- a/mergify_engine/actions/assign.py
+++ b/mergify_engine/actions/assign.py
@@ -22,6 +22,7 @@ from mergify_engine import actions
 from mergify_engine import check_api
 from mergify_engine import context
 from mergify_engine import rules
+from mergify_engine import signals
 from mergify_engine.clients import http
 from mergify_engine.rules import types
 
@@ -73,6 +74,7 @@ class AssignAction(actions.Action):
                     f"GitHub error: [{e.status_code}] `{e.message}`",
                 )
 
+            await signals.send(ctxt, "action.assign.added")
             return check_api.Result(
                 check_api.Conclusion.SUCCESS,
                 "Assignees added",
@@ -103,6 +105,7 @@ class AssignAction(actions.Action):
                     f"GitHub error: [{e.status_code}] `{e.message}`",
                 )
 
+            await signals.send(ctxt, "action.assign.removed")
             return check_api.Result(
                 check_api.Conclusion.SUCCESS,
                 "Assignees removed",

--- a/mergify_engine/actions/backport.py
+++ b/mergify_engine/actions/backport.py
@@ -21,6 +21,7 @@ from mergify_engine import config
 from mergify_engine import context
 from mergify_engine import duplicate_pull
 from mergify_engine import rules
+from mergify_engine import signals
 from mergify_engine.actions import copy
 
 
@@ -28,6 +29,7 @@ class BackportAction(copy.CopyAction):
     is_command: bool = True
 
     KIND: duplicate_pull.KindT = "backport"
+    HOOK_EVENT_NAME: signals.EventName = "action.backport"
     BRANCH_PREFIX: str = "bp"
     SUCCESS_MESSAGE: str = "Backports have been created"
     FAILURE_MESSAGE: str = "No backport have been created"

--- a/mergify_engine/actions/close.py
+++ b/mergify_engine/actions/close.py
@@ -20,6 +20,7 @@ from mergify_engine import actions
 from mergify_engine import check_api
 from mergify_engine import context
 from mergify_engine import rules
+from mergify_engine import signals
 from mergify_engine.clients import http
 from mergify_engine.rules import types
 
@@ -69,6 +70,7 @@ class CloseAction(actions.Action):
                 e.message,
             )
 
+        await signals.send(ctxt, "action.close")
         return check_api.Result(
             check_api.Conclusion.SUCCESS, "The pull request has been closed", message
         )

--- a/mergify_engine/actions/comment.py
+++ b/mergify_engine/actions/comment.py
@@ -20,6 +20,7 @@ from mergify_engine import actions
 from mergify_engine import check_api
 from mergify_engine import context
 from mergify_engine import rules
+from mergify_engine import signals
 from mergify_engine import subscription
 from mergify_engine.clients import http
 from mergify_engine.rules import types
@@ -86,4 +87,5 @@ class CommentAction(actions.Action):
                 "Unable to post comment",
                 f"GitHub error: [{e.status_code}] `{e.message}`",
             )
+        await signals.send(ctxt, "action.comment")
         return check_api.Result(check_api.Conclusion.SUCCESS, "Comment posted", message)

--- a/mergify_engine/actions/copy.py
+++ b/mergify_engine/actions/copy.py
@@ -27,6 +27,7 @@ from mergify_engine import context
 from mergify_engine import duplicate_pull
 from mergify_engine import github_types
 from mergify_engine import rules
+from mergify_engine import signals
 from mergify_engine.clients import http
 from mergify_engine.rules import types
 
@@ -51,6 +52,7 @@ class CopyAction(actions.Action):
     is_command: bool = True
 
     KIND: duplicate_pull.KindT = "copy"
+    HOOK_EVENT_NAME: signals.EventName = "action.copy"
     BRANCH_PREFIX: str = "copy"
     SUCCESS_MESSAGE: str = "Pull request copies have been created"
     FAILURE_MESSAGE: str = "No copy have been created"
@@ -129,6 +131,7 @@ class CopyAction(actions.Action):
                     kind=self.KIND,
                     branch_prefix=self.BRANCH_PREFIX,
                 )
+                await signals.send(ctxt, self.HOOK_EVENT_NAME)
             except duplicate_pull.DuplicateAlreadyExists:
                 new_pull = await self.get_existing_duplicate_pull(ctxt, branch_name)
             except duplicate_pull.DuplicateFailed as e:

--- a/mergify_engine/actions/delete_head_branch.py
+++ b/mergify_engine/actions/delete_head_branch.py
@@ -22,6 +22,7 @@ from mergify_engine import actions
 from mergify_engine import check_api
 from mergify_engine import context
 from mergify_engine import rules
+from mergify_engine import signals
 from mergify_engine.clients import http
 
 
@@ -69,6 +70,7 @@ class DeleteHeadBranchAction(actions.Action):
                         "Unable to delete the head branch",
                         f"GitHub error: [{e.status_code}] `{e.message}`",
                     )
+            await signals.send(ctxt, "action.delete_head_branch")
             return check_api.Result(
                 check_api.Conclusion.SUCCESS,
                 f"Branch `{ctxt.pull['head']['ref']}` has been deleted",

--- a/mergify_engine/actions/dismiss_reviews.py
+++ b/mergify_engine/actions/dismiss_reviews.py
@@ -20,6 +20,7 @@ from mergify_engine import actions
 from mergify_engine import check_api
 from mergify_engine import context
 from mergify_engine import rules
+from mergify_engine import signals
 from mergify_engine.clients import http
 from mergify_engine.rules import types
 
@@ -87,6 +88,7 @@ class DismissReviewsAction(actions.Action):
                     "\n".join(errors),
                 )
             else:
+                await signals.send(ctxt, "action.dismiss_reviews")
                 return check_api.Result(
                     check_api.Conclusion.SUCCESS, "Review dismissed", ""
                 )

--- a/mergify_engine/actions/merge_base.py
+++ b/mergify_engine/actions/merge_base.py
@@ -30,6 +30,7 @@ from mergify_engine import context
 from mergify_engine import json as mergify_json
 from mergify_engine import queue
 from mergify_engine import rules
+from mergify_engine import signals
 from mergify_engine import subscription
 from mergify_engine import utils
 from mergify_engine.clients import http
@@ -517,6 +518,7 @@ class MergeBaseAction(actions.Action):
             else:
                 return await self._handle_merge_error(e, ctxt, rule, q)
         else:
+            await signals.send(ctxt, "action.merge")
             await ctxt.update()
             ctxt.log.info("merged")
             if self.config[

--- a/mergify_engine/actions/post_check.py
+++ b/mergify_engine/actions/post_check.py
@@ -20,6 +20,7 @@ from mergify_engine import actions
 from mergify_engine import check_api
 from mergify_engine import context
 from mergify_engine import rules
+from mergify_engine import signals
 from mergify_engine import subscription
 from mergify_engine.rules import types
 
@@ -98,6 +99,7 @@ class PostCheckAction(actions.Action):
                 str(rmf),
             )
 
+        await signals.send(ctxt, "action.post_check")
         if rule.missing_conditions:
             return check_api.Result(check_api.Conclusion.FAILURE, title, summary)
         else:

--- a/mergify_engine/actions/rebase.py
+++ b/mergify_engine/actions/rebase.py
@@ -22,6 +22,7 @@ from mergify_engine import check_api
 from mergify_engine import config
 from mergify_engine import context
 from mergify_engine import rules
+from mergify_engine import signals
 from mergify_engine import subscription
 from mergify_engine.rules import types
 
@@ -73,11 +74,6 @@ class RebaseAction(actions.Action):
 
             try:
                 await branch_updater.rebase_with_git(ctxt, self.config["bot_account"])
-                return check_api.Result(
-                    check_api.Conclusion.SUCCESS,
-                    "Branch has been successfully rebased",
-                    "",
-                )
             except branch_updater.BranchUpdateFailure as e:
                 return check_api.Result(
                     check_api.Conclusion.FAILURE, e.title, e.message
@@ -87,7 +83,12 @@ class RebaseAction(actions.Action):
                 return check_api.Result(
                     check_api.Conclusion.FAILURE, "Branch rebase failed", str(e)
                 )
-
+            await signals.send(ctxt, "action.rebase")
+            return check_api.Result(
+                check_api.Conclusion.SUCCESS,
+                "Branch has been successfully rebased",
+                "",
+            )
         else:
             return check_api.Result(
                 check_api.Conclusion.SUCCESS, "Branch already up to date", ""

--- a/mergify_engine/actions/refresh.py
+++ b/mergify_engine/actions/refresh.py
@@ -17,6 +17,7 @@ from mergify_engine import actions
 from mergify_engine import check_api
 from mergify_engine import context
 from mergify_engine import rules
+from mergify_engine import signals
 from mergify_engine import utils
 
 
@@ -35,6 +36,7 @@ class RefreshAction(actions.Action):
                 ctxt.pull["base"]["repo"],
                 pull_request_number=ctxt.pull["number"],
             )
+        await signals.send(ctxt, "action.refresh")
         return check_api.Result(
             check_api.Conclusion.SUCCESS, title="Pull request refreshed", summary=""
         )

--- a/mergify_engine/actions/request_reviews.py
+++ b/mergify_engine/actions/request_reviews.py
@@ -20,6 +20,7 @@ from mergify_engine import actions
 from mergify_engine import check_api
 from mergify_engine import context
 from mergify_engine import rules
+from mergify_engine import signals
 from mergify_engine import subscription
 from mergify_engine import utils
 from mergify_engine.clients import http
@@ -196,6 +197,8 @@ class RequestReviewsAction(actions.Action):
                         "Unable to create review request",
                         f"GitHub error: [{e.status_code}] `{e.message}`",
                     )
+                await signals.send(ctxt, "action.request_reviewers")
+
             if already_at_max or will_exceed_max:
                 return check_api.Result(
                     check_api.Conclusion.NEUTRAL,

--- a/mergify_engine/actions/review.py
+++ b/mergify_engine/actions/review.py
@@ -21,6 +21,7 @@ from mergify_engine import check_api
 from mergify_engine import config
 from mergify_engine import context
 from mergify_engine import rules
+from mergify_engine import signals
 from mergify_engine import subscription
 from mergify_engine.rules import types
 
@@ -132,5 +133,5 @@ class ReviewAction(actions.Action):
             oauth_token=oauth_token,  # type: ignore
             json=payload,
         )
-
+        await signals.send(ctxt, "action.review")
         return check_api.Result(check_api.Conclusion.SUCCESS, "Review posted", "")

--- a/mergify_engine/actions/update.py
+++ b/mergify_engine/actions/update.py
@@ -20,6 +20,7 @@ from mergify_engine import branch_updater
 from mergify_engine import check_api
 from mergify_engine import context
 from mergify_engine import rules
+from mergify_engine import signals
 
 
 class UpdateAction(actions.Action):
@@ -40,6 +41,7 @@ class UpdateAction(actions.Action):
                     e.message,
                 )
             else:
+                await signals.send(ctxt, "action.update")
                 return check_api.Result(
                     check_api.Conclusion.SUCCESS,
                     "Branch has been successfully updated",

--- a/mergify_engine/signals.py
+++ b/mergify_engine/signals.py
@@ -1,0 +1,85 @@
+# -*- encoding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import abc
+import importlib
+import pkgutil
+import typing
+
+import daiquiri
+
+from mergify_engine import context
+from mergify_engine import github_types
+
+
+LOG = daiquiri.getLogger(__name__)
+
+EventName = typing.Literal[
+    "action.assign.added",
+    "action.assign.removed",
+    "action.backport",
+    "action.copy",
+    "action.close",
+    "action.comment",
+    "action.delete_head_branch",
+    "action.dismiss_reviews",
+    "action.label",
+    "action.merge",
+    "action.post_check",
+    "action.rebase",
+    "action.refresh",
+    "action.request_reviewers",
+    "action.review",
+    "action.update",
+]
+
+SignalT = typing.Callable[
+    [github_types.GitHubAccount, EventName], typing.Coroutine[None, None, None]
+]
+
+
+class SignalBase(abc.ABC):
+    @abc.abstractmethod
+    async def __call__(
+        self, account: github_types.GitHubAccount, event: EventName
+    ) -> None:
+        pass
+
+
+global SIGNALS
+SIGNALS: typing.Dict[str, SignalT] = {}
+
+
+try:
+    import mergify_engine_signals
+except ImportError:
+    LOG.info("No signals found")
+    pass
+else:
+    # Only support new native python >= 3.6 namespace packages
+    for mod in pkgutil.iter_modules(
+        mergify_engine_signals.__path__, mergify_engine_signals.__name__ + "."
+    ):
+        try:
+            SIGNALS[mod.name] = importlib.import_module(mod.name).Signal()  # type: ignore
+        except ImportError:
+            LOG.error("failed to load signal: %s", mod.name, exc_info=True)
+
+
+async def send(ctxt: context.Context, event: EventName) -> None:
+    for name, signal in SIGNALS.items():
+        try:
+            await signal(ctxt.pull["base"]["user"], event)
+        except Exception:
+            LOG.error("failed to run signal: %s", name, exc_info=True)

--- a/mergify_engine/tests/unit/test_signals.py
+++ b/mergify_engine/tests/unit/test_signals.py
@@ -1,0 +1,134 @@
+# -*- encoding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from unittest import mock
+
+import pytest
+
+from mergify_engine import context
+from mergify_engine import github_types
+from mergify_engine import signals
+from mergify_engine import subscription
+
+
+@pytest.mark.asyncio
+async def test_signals(redis_cache):
+    gh_owner = github_types.GitHubAccount(
+        {
+            "login": github_types.GitHubLogin("user"),
+            "id": github_types.GitHubAccountIdType(0),
+            "type": "User",
+            "avatar_url": "",
+        }
+    )
+
+    gh_repo = github_types.GitHubRepository(
+        {
+            "archived": False,
+            "url": "",
+            "default_branch": github_types.GitHubRefType(""),
+            "id": github_types.GitHubRepositoryIdType(456),
+            "full_name": "user/ref",
+            "name": github_types.GitHubRepositoryName("name"),
+            "private": False,
+            "owner": gh_owner,
+        }
+    )
+
+    client = mock.AsyncMock()
+    client.auth.get_access_token.return_value = "<token>"
+
+    sub = subscription.Subscription(redis_cache, 0, False, "", frozenset())
+    installation = context.Installation(
+        gh_owner["id"],
+        gh_owner["login"],
+        sub,
+        client,
+        redis_cache,
+    )
+    repository = context.Repository(installation, gh_repo["name"], gh_repo["id"])
+    ctxt = await context.Context.create(
+        repository,
+        {
+            "title": "",
+            "id": github_types.GitHubPullRequestId(0),
+            "maintainer_can_modify": False,
+            "rebaseable": False,
+            "draft": False,
+            "merge_commit_sha": None,
+            "labels": [],
+            "number": github_types.GitHubPullRequestNumber(6),
+            "commits": 1,
+            "merged": True,
+            "state": "closed",
+            "changed_files": 1,
+            "html_url": "<html_url>",
+            "base": {
+                "label": "",
+                "sha": github_types.SHAType("sha"),
+                "user": {
+                    "login": github_types.GitHubLogin("user"),
+                    "id": github_types.GitHubAccountIdType(0),
+                    "type": "User",
+                    "avatar_url": "",
+                },
+                "ref": github_types.GitHubRefType("ref"),
+                "label": "",
+                "repo": gh_repo,
+            },
+            "head": {
+                "label": "",
+                "sha": github_types.SHAType("old-sha-one"),
+                "ref": github_types.GitHubRefType("fork"),
+                "user": {
+                    "login": github_types.GitHubLogin("user"),
+                    "id": github_types.GitHubAccountIdType(0),
+                    "type": "User",
+                    "avatar_url": "",
+                },
+                "repo": {
+                    "archived": False,
+                    "url": "",
+                    "default_branch": github_types.GitHubRefType(""),
+                    "id": github_types.GitHubRepositoryIdType(123),
+                    "full_name": "fork/other",
+                    "name": github_types.GitHubRepositoryName("other"),
+                    "private": False,
+                    "owner": {
+                        "login": github_types.GitHubLogin("user"),
+                        "id": github_types.GitHubAccountIdType(0),
+                        "type": "User",
+                        "avatar_url": "",
+                    },
+                },
+            },
+            "user": {
+                "login": github_types.GitHubLogin("user"),
+                "id": github_types.GitHubAccountIdType(0),
+                "type": "User",
+                "avatar_url": "",
+            },
+            "merged_by": None,
+            "merged_at": None,
+            "mergeable_state": "clean",
+        },
+    )
+
+    assert len(signals.SIGNALS) == 1
+
+    with mock.patch("datadog.statsd.increment") as increment:
+        await signals.send(ctxt, "action.update")
+        increment.assert_called_once_with(
+            "engine.signals.action.count", tags=["event:update"]
+        )

--- a/mergify_engine_signals/datadog_signal/__init__.py
+++ b/mergify_engine_signals/datadog_signal/__init__.py
@@ -1,0 +1,26 @@
+# -*- encoding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from datadog import statsd
+
+from mergify_engine import github_types
+from mergify_engine import signals
+
+
+class Signal(signals.SignalBase):
+    async def __call__(
+        self, account: github_types.GitHubAccount, event: signals.EventName
+    ) -> None:
+        if event.startswith("action"):
+            statsd.increment("engine.signals.action.count", tags=[f"event:{event[7:]}"])

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifier =
 [options]
 packages =
     mergify_engine
+    mergify_engine_signals.datadog_signal
 
 include_package_data = true
 
@@ -95,7 +96,7 @@ warn_unused_ignores = true
 warn_unused_configs = true
 disallow_any_generics = true
 warn_return_any = true
-files = mergify_engine
+files = mergify_engine,mergify_engine_signals
 disallow_subclassing_any = true
 warn_redundant_casts = true
 strict_equality = true

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ import setuptools
 
 
 setuptools.setup(
-    setup_requires=["setuptools>=30.3.0"],
+    setup_requires=["setuptools>=40.1.0"],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -107,7 +107,7 @@ commands =
   flake8
   isort -c .
   mypy
-  bandit -r mergify_engine -x mergify_engine/tests
+  bandit -r mergify_engine mergify_engine_signals -x mergify_engine/tests
   yamllint .
   bash tools/check-obsolete-fixtures.sh
 
@@ -156,6 +156,6 @@ enable-extensions = G,FS003
 force_single_line = true
 lines_after_imports = 2
 force_sort_within_sections = true
-known_first_party = mergify_engine
+known_first_party = mergify_engine,mergify_engine_signals
 known_third_party = datadog
 default_section = THIRDPARTY


### PR DESCRIPTION
This introduce a signal mechanism with an example
plugin for datadog.

The new datadog metric "engine.signals.actions.count"

* "engine.actions.count" count when action is ran by rule but it count
  too much thing:
   * some actions run on each batch until they unmatch
   * some other return PENDING until they can complete and get counter
     multiple times.
   * the action may run but do nothing (labels already set, pull
     already up2date or merged)
* "engine.command.count" count when an action is ran as a command

"engine.signals.actions.count" will track action run by rules and commands
but when they really do something on user pull requests.
