### PR TITLE
fix(requirements): don't use pip editable installation for deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiofiles==0.6.0
+aredis @ git+http://github.com/sileht/aredis.git@da1cf542a340cae343348b5dec0bab8f7b758334
 cachetools==4.2.1
 certifi==2020.12.5
 cffi==1.14.5
@@ -48,5 +49,4 @@ voluptuous==0.12.1
 watchgod==0.7
 websockets==8.1
 Werkzeug==1.0.1
--e git+http://github.com/sileht/aredis.git@prod-mergify#egg=aredis
 -e .

--- a/tox.ini
+++ b/tox.ini
@@ -61,11 +61,10 @@ skip_install = true
 deps =
 commands_pre =
 commands =
-  bash -c "sed -e '/^-e/d' requirements.txt > constraints.txt"
-  bash -c "pip install -c constraints.txt -e . -e git+http://github.com/sileht/aredis.git@prod-mergify#egg=aredis"
+  bash -c "sed -e '/^-e/d' -e '/^aredis/d' requirements.txt > constraints.txt"
+  bash -c "pip install -c constraints.txt -e . git+http://github.com/sileht/aredis.git@prod-mergify#egg=aredis"
   pip uninstall --yes mergify-engine
   bash -c "pip freeze --exclude-editable >| requirements.txt"
-  bash -c "echo '-e git+http://github.com/sileht/aredis.git@prod-mergify#egg=aredis' >> requirements.txt"
   bash -c "echo '-e .' >> requirements.txt"
 whitelist_externals =
     bash


### PR DESCRIPTION
This doesn't play well with heroku-buildpack-python if the project is
located in a subdirectory.

We don't really need to have it editable, it will not be cached anymore
but we don't care.
