### PR TITLE
fix(signals): postpone module import

### DIFF
--- a/mergify_engine/signals.py
+++ b/mergify_engine/signals.py
@@ -61,12 +61,13 @@ global SIGNALS
 SIGNALS: typing.Dict[str, SignalT] = {}
 
 
-try:
-    import mergify_engine_signals
-except ImportError:
-    LOG.info("No signals found")
-    pass
-else:
+def setup() -> None:
+    try:
+        import mergify_engine_signals
+    except ImportError:
+        LOG.info("No signals found")
+        return
+
     # Only support new native python >= 3.6 namespace packages
     for mod in pkgutil.iter_modules(
         mergify_engine_signals.__path__, mergify_engine_signals.__name__ + "."

--- a/mergify_engine/tests/unit/test_signals.py
+++ b/mergify_engine/tests/unit/test_signals.py
@@ -125,6 +125,8 @@ async def test_signals(redis_cache):
         },
     )
 
+    assert len(signals.SIGNALS) == 0
+    signals.setup()
     assert len(signals.SIGNALS) == 1
 
     with mock.patch("datadog.statsd.increment") as increment:

--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -39,6 +39,7 @@ from mergify_engine import exceptions
 from mergify_engine import github_events
 from mergify_engine import github_types
 from mergify_engine import logs
+from mergify_engine import signals
 from mergify_engine import subscription
 from mergify_engine import utils
 from mergify_engine.clients import github
@@ -843,6 +844,7 @@ async def run_forever() -> None:
 
 def main() -> None:
     logs.setup_logging()
+    signals.setup()
     return asyncio.run(run_forever())
 
 


### PR DESCRIPTION
This ensure the logging system is setuped. Otherwise we may not
see errors raise by signal modules.
