### PR TITLE
ci: make github actions read only when possible

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: Continuous Integration
+permissions: read-all
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,7 +10,7 @@
 # supported CodeQL languages.
 #
 name: "CodeQL"
-
+permissions: read-all
 on:
   push:
     branches: [master]

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,4 +1,5 @@
 name: Publish Docker image
+permissions: read-all
 on:
   push:
     tags:


### PR DESCRIPTION
Only docs need a write GITHUB_TOKEN. So mark other as read-all only.
