### PR TITLE
chore: use pip contraints instead of requirements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
+          echo '-e .' >> requirements.txt
           curl -sSL \
             "https://github.com/buildpacks/pack/releases/download/v0.18.1/pack-v0.18.1-linux.tgz" \
             | tar -xz pack

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 aiofiles==0.6.0
-aredis @ git+http://github.com/sileht/aredis.git@da1cf542a340cae343348b5dec0bab8f7b758334
 cachetools==4.2.1
 certifi==2020.12.5
 cffi==1.14.5
@@ -49,4 +48,3 @@ voluptuous==0.12.1
 watchgod==0.7
 websockets==8.1
 Werkzeug==1.0.1
--e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
     msgpack
     jinja2
     werkzeug
+    aredis @ git+http://github.com/sileht/aredis.git@prod-mergify
 
 [options.extras_require]
 test =

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,7 @@ setenv =
    MERGIFYENGINE_STREAM_URL=redis://localhost:6363?db=3
 usedevelop = true
 extras = test
-# Now that the engine is setup, install the hardcoded requirement list
-commands_pre = pip install -r requirements.txt
+install_command = pip install -c requirements.txt {opts} {packages}
 commands = {toxinidir}/run-tests.sh pytest -v --pyargs mergify_engine {posargs}
 
 [testenv:cover]
@@ -50,7 +49,6 @@ commands = {toxinidir}/run-tests.sh honcho -f Procfile-test start
 
 [testenv:requirements]
 recreate = true
-skip_install = true
 commands = pip check
 
 [testenv:genreqs]
@@ -59,13 +57,13 @@ skip_install = true
 deps =
 commands_pre =
 commands =
-  bash -c "sed -e '/^-e/d' -e '/^aredis/d' requirements.txt > constraints.txt"
-  bash -c "pip install -c constraints.txt -e . git+http://github.com/sileht/aredis.git@prod-mergify#egg=aredis"
+  pip install -c requirements.txt -e .
   pip uninstall --yes mergify-engine
   bash -c "pip freeze --exclude-editable >| requirements.txt"
-  bash -c "echo '-e .' >> requirements.txt"
+  sed -i "/^aredis/d" requirements.txt
 whitelist_externals =
-    bash
+  bash
+  sed
 
 [testenv:venv]
 deps = .


### PR DESCRIPTION
Our requirements are in setup.cfg, while our requirements is more
contraints. To make all of this works for heroku we put "-e ." inside
requirements.txt.

Infortunatly, this make impossible to install the engine with pip
install -e mergify-engine-dir.

This change uses pip contraints instead of requirements. We can now
install mergify-engine with just `pip install -e mergify-engine-dir`.

And if we want strict dependency checking we can still use `pip install
-c mergify-engine-dir/contraints.txt -e mergify-engine-dir`. We keep the
name requirements.txt to please dependabot.
