### PR TITLE
fix: improve terminology

### DIFF
--- a/mergify_engine/engine/actions_runner.py
+++ b/mergify_engine/engine/actions_runner.py
@@ -166,7 +166,7 @@ async def gen_summary(
         if completed_rules == 0 and potential_rules == 0 and faulty_rules == 0:
             summary_title.append("no rules match, no planned actions")
     else:
-        summary_title = ["no rules setuped, just listening for commands"]
+        summary_title = ["no rules configured, just listening for commands"]
 
     return " and ".join(summary_title), summary
 


### PR DESCRIPTION
## Description of the change

`setuped` isn't a word and standard dictionaries.

![image](https://user-images.githubusercontent.com/2119212/116735468-8974a180-a9bc-11eb-9ba6-ea084950b7b8.png)

This change replaces it with `configured` which is a word

## Related issues

## Checklists

### Development

- [ ] All checks must pass (Semantic Pull Request, pep8, requirements, unit tests, functional tests, security checks, …)
- [ ] The code changed/added as part of this pull request must be covered with tests
- [ ] Hotfixes must have a link to Sentry issue and the ``hotfix`` label
- [ ] Features must have a link to a Linear task

### Code Review

Code review policies are handled and automated by Mergify.

* When all tests pass, reviewers will be assigned automatically.
* When change is approved by at least one review and no pending review are
  remaining, pull request is retested against its base branch.
* The pull request is then merged automatically.
