### PR TITLE
chore: increase threshold of logged requests

### DIFF
--- a/mergify_engine/clients/github.py
+++ b/mergify_engine/clients/github.py
@@ -32,7 +32,7 @@ from mergify_engine.clients import http
 
 
 RATE_LIMIT_THRESHOLD = 20
-LOGGING_REQUESTS_THRESHOLD = 20
+LOGGING_REQUESTS_THRESHOLD = 40
 LOGGING_REQUESTS_THRESHOLD_ABSOLUTE = 400
 
 LOG = daiquiri.getLogger(__name__)


### PR DESCRIPTION
At first glance, the mean is 25, now.

This will remove some useless logs ~ 0.25%