### PR TITLE
ci: fix codeql workflow permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,7 +10,10 @@
 # supported CodeQL languages.
 #
 name: "CodeQL"
-permissions: read-all
+permissions:
+  actions: read
+  security-events: write
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
It need to write on an GitHub special endpoint for push "master" event:

PUT https://api.github.com/repos/Mergifyio/mergify-engine/code-scanning/analysis/status