### PR TITLE
fix: oauth_token format

### DIFF
--- a/mergify_engine/actions/comment.py
+++ b/mergify_engine/actions/comment.py
@@ -65,20 +65,20 @@ class CommentAction(actions.Action):
 
         if bot_account := self.config["bot_account"]:
             user_tokens = await ctxt.repository.installation.get_user_tokens()
-            oauth_token = user_tokens.get_token_for(bot_account)
-            if not oauth_token:
+            github_user = user_tokens.get_token_for(bot_account)
+            if not github_user:
                 return check_api.Result(
                     check_api.Conclusion.FAILURE,
                     f"Unable to comment: user `{bot_account}` is unknown. ",
                     f"Please make sure `{bot_account}` has logged in Mergify dashboard.",
                 )
         else:
-            oauth_token = None
+            github_user = None
 
         try:
             await ctxt.client.post(
                 f"{ctxt.base_url}/issues/{ctxt.pull['number']}/comments",
-                oauth_token=oauth_token,  # type: ignore
+                oauth_token=github_user["oauth_access_token"] if github_user else None,
                 json={"body": message},
             )
         except http.HTTPClientSideError as e:  # pragma: no cover

--- a/mergify_engine/actions/copy.py
+++ b/mergify_engine/actions/copy.py
@@ -284,10 +284,12 @@ class CopyAction(actions.Action):
                 typing.AsyncGenerator[github_types.GitHubPullRequest, None],
                 ctxt.client.items(
                     f"{ctxt.base_url}/pulls",
-                    base=branch_name,
-                    sort="created",
-                    state="all",
-                    head=f"{ctxt.pull['base']['user']['login']}:{bp_branch}",
+                    params={
+                        "base": branch_name,
+                        "sort": "created",
+                        "state": "all",
+                        "head": f"{ctxt.pull['base']['user']['login']}:{bp_branch}",
+                    },
                 ),
             )
         ]

--- a/mergify_engine/actions/delete_head_branch.py
+++ b/mergify_engine/actions/delete_head_branch.py
@@ -43,7 +43,8 @@ class DeleteHeadBranchAction(actions.Action):
                 pulls_using_this_branch = [
                     branch
                     async for branch in ctxt.client.items(
-                        f"{ctxt.base_url}/pulls", base=ctxt.pull["head"]["ref"]
+                        f"{ctxt.base_url}/pulls",
+                        params={"base": ctxt.pull["head"]["ref"]},
                     )
                 ]
                 if pulls_using_this_branch:

--- a/mergify_engine/actions/merge_base.py
+++ b/mergify_engine/actions/merge_base.py
@@ -449,20 +449,20 @@ class MergeBaseAction(actions.Action):
         bot_account = self.config["merge_bot_account"]
         if bot_account:
             user_tokens = await ctxt.repository.installation.get_user_tokens()
-            oauth_token = user_tokens.get_token_for(bot_account)
-            if not oauth_token:
+            github_user = user_tokens.get_token_for(bot_account)
+            if not github_user:
                 return check_api.Result(
                     check_api.Conclusion.FAILURE,
                     f"Unable to rebase: user `{bot_account}` is unknown. ",
                     f"Please make sure `{bot_account}` has logged in Mergify dashboard.",
                 )
         else:
-            oauth_token = None
+            github_user = None
 
         try:
             await ctxt.client.put(
                 f"{ctxt.base_url}/pulls/{ctxt.pull['number']}/merge",
-                oauth_token=oauth_token,  # type: ignore
+                oauth_token=github_user["oauth_access_token"] if github_user else None,
                 json=data,
             )
         except http.HTTPClientSideError as e:  # pragma: no cover

--- a/mergify_engine/actions/review.py
+++ b/mergify_engine/actions/review.py
@@ -118,19 +118,19 @@ class ReviewAction(actions.Action):
         bot_account = self.config["bot_account"]
         if bot_account:
             user_tokens = await ctxt.repository.installation.get_user_tokens()
-            oauth_token = user_tokens.get_token_for(bot_account)
-            if not oauth_token:
+            github_user = user_tokens.get_token_for(bot_account)
+            if not github_user:
                 return check_api.Result(
                     check_api.Conclusion.FAILURE,
                     f"Unable to review: user `{bot_account}` is unknown. ",
                     f"Please make sure `{bot_account}` has logged in Mergify dashboard.",
                 )
         else:
-            oauth_token = None
+            github_user = None
 
         await ctxt.client.post(
             f"{ctxt.base_url}/pulls/{ctxt.pull['number']}/reviews",
-            oauth_token=oauth_token,  # type: ignore
+            oauth_token=github_user["oauth_access_token"] if github_user else None,
             json=payload,
         )
         await signals.send(ctxt, "action.review")

--- a/mergify_engine/branch_updater.py
+++ b/mergify_engine/branch_updater.py
@@ -259,7 +259,7 @@ async def update_with_api(ctxt: context.Context) -> None:
     try:
         await ctxt.client.put(
             f"{ctxt.base_url}/pulls/{ctxt.pull['number']}/update-branch",
-            api_version="lydian",  # type: ignore[call-arg]
+            api_version="lydian",
             json={"expected_head_sha": ctxt.pull["head"]["sha"]},
         )
     except http.HTTPClientSideError as e:

--- a/mergify_engine/check_api.py
+++ b/mergify_engine/check_api.py
@@ -79,15 +79,15 @@ async def get_checks_for_ref(
     check_name: typing.Optional[str] = None,
 ) -> typing.List[github_types.GitHubCheckRun]:
     if check_name is None:
-        kwargs = {}
+        params = {}
     else:
-        kwargs = {"check_name": check_name}
+        params = {"check_name": check_name}
     checks: typing.List[github_types.GitHubCheckRun] = [
         check
         async for check in ctxt.client.items(
             f"{ctxt.base_url}/commits/{sha}/check-runs",
             list_items="check_runs",
-            **kwargs,
+            params=params,
         )
     ]
     return checks

--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -233,9 +233,9 @@ class Repository(object):
         :return: The filename and its content.
         """
 
-        kwargs = {}
+        params = {}
         if ref:
-            kwargs["ref"] = ref
+            params["ref"] = str(ref)
 
         filenames = self.MERGIFY_CONFIG_FILENAMES.copy()
         if preferred_filename:
@@ -248,7 +248,7 @@ class Repository(object):
                     github_types.GitHubContentFile,
                     await self.installation.client.item(
                         f"{self.base_url}/contents/{filename}",
-                        **kwargs,
+                        params=params,
                     ),
                 )
             except http.HTTPNotFound:

--- a/mergify_engine/duplicate_pull.py
+++ b/mergify_engine/duplicate_pull.py
@@ -370,7 +370,9 @@ async def duplicate(
                         "base": branch_name,
                         "head": bp_branch,
                     },
-                    oauth_token=bot_account_user["oauth_access_token"] if bot_account_user else None,  # type: ignore
+                    oauth_token=bot_account_user["oauth_access_token"]
+                    if bot_account_user
+                    else None,
                 )
             ).json(),
         )

--- a/mergify_engine/engine/commands_runner.py
+++ b/mergify_engine/engine/commands_runner.py
@@ -96,7 +96,7 @@ async def on_each_event(event: github_types.GitHubEventIssueComment) -> None:
                 f"/repos/{owner}/{repo}/issues/comments/{event['comment']['id']}/reactions",
                 json={"content": "+1"},
                 api_version="squirrel-girl",
-            )  # type: ignore[call-arg]
+            )
 
 
 async def run_pending_commands_tasks(

--- a/mergify_engine/github_types.py
+++ b/mergify_engine/github_types.py
@@ -488,3 +488,7 @@ class GitHubGitRef(typing.TypedDict):
 class GitHubRequestedReviewers(typing.TypedDict):
     users: typing.List[GitHubAccount]
     teams: typing.List[GitHubTeam]
+
+
+GitHubApiVersion = typing.Literal["squirrel-girl", "lydian", "groot"]
+GitHubOAuthToken = typing.NewType("GitHubOAuthToken", str)

--- a/mergify_engine/queue/merge_train.py
+++ b/mergify_engine/queue/merge_train.py
@@ -203,7 +203,7 @@ class TrainCar(PseudoTrainCar):
         try:
             await ctxt.client.put(
                 f"{ctxt.base_url}/pulls/{ctxt.pull['number']}/update-branch",
-                api_version="lydian",  # type: ignore[call-arg]
+                api_version="lydian",
                 json={"expected_head_sha": ctxt.pull["head"]["sha"]},
             )
         except http.HTTPClientSideError as exc:

--- a/mergify_engine/tests/functional/actions/test_assign.py
+++ b/mergify_engine/tests/functional/actions/test_assign.py
@@ -36,7 +36,7 @@ class TestAssignAction(base.FunctionalTestBase):
 
         await self.run_engine()
 
-        pulls = await self.get_pulls(base=self.master_branch_name)
+        pulls = await self.get_pulls(params={"base": self.master_branch_name})
         self.assertEqual(1, len(pulls))
         self.assertEqual(
             sorted(["mergify-test1"]),
@@ -60,7 +60,7 @@ class TestAssignAction(base.FunctionalTestBase):
 
         await self.run_engine()
 
-        pulls = await self.get_pulls(base=self.master_branch_name)
+        pulls = await self.get_pulls(params={"base": self.master_branch_name})
         self.assertEqual(1, len(pulls))
         self.assertEqual(
             sorted(["mergify-test1"]),
@@ -84,7 +84,7 @@ class TestAssignAction(base.FunctionalTestBase):
 
         await self.run_engine()
 
-        pulls = await self.get_pulls(base=self.master_branch_name)
+        pulls = await self.get_pulls(params={"base": self.master_branch_name})
         self.assertEqual(1, len(pulls))
         self.assertEqual(
             sorted(["mergify-test2"]),
@@ -108,7 +108,7 @@ class TestAssignAction(base.FunctionalTestBase):
         await self.add_assignee(p["number"], "mergify-test1")
         await self.run_engine()
 
-        pulls = await self.get_pulls(base=self.master_branch_name)
+        pulls = await self.get_pulls(params={"base": self.master_branch_name})
         self.assertEqual(1, len(pulls))
         self.assertEqual(
             sorted(["mergify-test1"]),
@@ -132,7 +132,7 @@ class TestAssignAction(base.FunctionalTestBase):
         await self.add_assignee(p["number"], "mergify-test1")
         await self.run_engine()
 
-        pulls = await self.get_pulls(base=self.master_branch_name)
+        pulls = await self.get_pulls(params={"base": self.master_branch_name})
         self.assertEqual(1, len(pulls))
         self.assertEqual(
             [],

--- a/mergify_engine/tests/functional/actions/test_backport.py
+++ b/mergify_engine/tests/functional/actions/test_backport.py
@@ -66,11 +66,13 @@ class BackportActionTestBase(base.FunctionalTestBase):
 
         assert await self.is_pull_merged(p["number"])
 
-        pulls = await self.get_pulls(state="all", base=self.master_branch_name)
+        pulls = await self.get_pulls(
+            params={"state": "all", "base": self.master_branch_name}
+        )
         assert 1 == len(pulls)
         assert "closed" == pulls[0]["state"]
 
-        pulls = await self.get_pulls(state="all", base=stable_branch)
+        pulls = await self.get_pulls(params={"state": "all", "base": stable_branch})
         assert 2 == len(pulls)
         assert not await self.is_pull_merged(pulls[0]["number"])
         assert not await self.is_pull_merged(pulls[1]["number"])
@@ -291,7 +293,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
         stable_branch = self.get_full_branch_name("stable/#3.1")
         p, checks = await self._do_backport_conflicts(True, ["backported"])
 
-        pull = (await self.get_pulls(base=stable_branch))[0]
+        pull = (await self.get_pulls(params={"base": stable_branch}))[0]
 
         assert "success" == checks[0]["conclusion"]
         assert "Backports have been created" == checks[0]["output"]["title"]

--- a/mergify_engine/tests/functional/actions/test_delete_head_branch.py
+++ b/mergify_engine/tests/functional/actions/test_delete_head_branch.py
@@ -60,7 +60,9 @@ class TestDeleteHeadBranchAction(base.FunctionalTestBase):
 
         await self.run_engine()
 
-        pulls = await self.get_pulls(state="all", base=self.master_branch_name)
+        pulls = await self.get_pulls(
+            params={"state": "all", "base": self.master_branch_name}
+        )
         self.assertEqual(2, len(pulls))
 
         branches = await self.get_branches()
@@ -99,9 +101,11 @@ class TestDeleteHeadBranchAction(base.FunctionalTestBase):
 
         await self.wait_for("check_run", {"check_run": {"conclusion": "neutral"}})
 
-        pulls = await self.get_pulls(state="all", base=self.master_branch_name)
+        pulls = await self.get_pulls(
+            params={"state": "all", "base": self.master_branch_name}
+        )
         assert 1 == len(pulls)
-        pulls = await self.get_pulls(state="all", base=first_branch)
+        pulls = await self.get_pulls(params={"state": "all", "base": first_branch})
         assert 1 == len(pulls)
 
         branches = await self.get_branches()
@@ -145,9 +149,11 @@ class TestDeleteHeadBranchAction(base.FunctionalTestBase):
         )
         await self.run_engine()
 
-        pulls = await self.get_pulls(state="all", base=self.master_branch_name)
+        pulls = await self.get_pulls(
+            params={"state": "all", "base": self.master_branch_name}
+        )
         assert 1 == len(pulls)
-        pulls = await self.get_pulls(state="all", base=first_branch)
+        pulls = await self.get_pulls(params={"state": "all", "base": first_branch})
         assert 1 == len(pulls)
 
         branches = await self.get_branches()

--- a/mergify_engine/tests/functional/actions/test_request_reviews.py
+++ b/mergify_engine/tests/functional/actions/test_request_reviews.py
@@ -40,7 +40,7 @@ class TestRequestReviewsAction(base.FunctionalTestBase):
         p, _ = await self.create_pr()
         await self.run_engine()
 
-        pulls = await self.get_pulls(base=self.master_branch_name)
+        pulls = await self.get_pulls(params={"base": self.master_branch_name})
         assert 1 == len(pulls)
         requests = await self.get_review_requests(pulls[0]["number"])
         assert sorted(["mergify-test1"]) == sorted(
@@ -66,7 +66,7 @@ class TestRequestReviewsAction(base.FunctionalTestBase):
         p, _ = await self.create_pr()
         await self.run_engine()
 
-        pulls = await self.get_pulls(base=self.master_branch_name)
+        pulls = await self.get_pulls(params={"base": self.master_branch_name})
         assert 1 == len(pulls)
         requests = await self.get_review_requests(pulls[0]["number"])
         assert sorted([team["slug"]]) == sorted(
@@ -99,7 +99,7 @@ class TestRequestReviewsAction(base.FunctionalTestBase):
         p, _ = await self.create_pr()
         await self.run_engine()
 
-        pulls = await self.get_pulls(base=self.master_branch_name)
+        pulls = await self.get_pulls(params={"base": self.master_branch_name})
         assert 1 == len(pulls)
         requests = await self.get_review_requests(pulls[0]["number"])
         assert ["mergify-test1"] == [user["login"] for user in requests["users"]]
@@ -150,7 +150,7 @@ class TestRequestReviewsAction(base.FunctionalTestBase):
         p, _ = await self.create_pr()
         await self.run_engine()
 
-        pulls = await self.get_pulls(base=self.master_branch_name)
+        pulls = await self.get_pulls(params={"base": self.master_branch_name})
         assert 1 == len(pulls)
         await self.create_review_request(pulls[0]["number"], ["mergify-test1"])
         await self.run_engine()

--- a/mergify_engine/tests/functional/commands/test_backport.py
+++ b/mergify_engine/tests/functional/commands/test_backport.py
@@ -47,9 +47,13 @@ class TestCommandBackport(base.FunctionalTestBase):
         await self.run_engine()
         await self.wait_for("issue_comment", {"action": "created"})
 
-        pulls_stable = await self.get_pulls(state="all", base=stable_branch)
+        pulls_stable = await self.get_pulls(
+            params={"state": "all", "base": stable_branch}
+        )
         assert 1 == len(pulls_stable)
-        pulls_feature = await self.get_pulls(state="all", base=feature_branch)
+        pulls_feature = await self.get_pulls(
+            params={"state": "all", "base": feature_branch}
+        )
         assert 1 == len(pulls_feature)
         comments = await self.get_issue_comments(p["number"])
         assert len(comments) == 2
@@ -113,9 +117,9 @@ class TestCommandBackport(base.FunctionalTestBase):
         await self.run_engine()
         await self.wait_for("issue_comment", {"action": "created"})
 
-        pulls = await self.get_pulls(state="all", base=stable_branch)
+        pulls = await self.get_pulls(params={"state": "all", "base": stable_branch})
         assert 1 == len(pulls)
-        pulls = await self.get_pulls(state="all", base=feature_branch)
+        pulls = await self.get_pulls(params={"state": "all", "base": feature_branch})
         assert 1 == len(pulls)
         comments = await self.get_issue_comments(p["number"])
         assert len(comments) == 2
@@ -145,9 +149,13 @@ class TestCommandBackport(base.FunctionalTestBase):
         await self.run_engine()
         await self.wait_for("issue_comment", {"action": "created"})
 
-        pulls_stable = await self.get_pulls(state="all", base=stable_branch)
+        pulls_stable = await self.get_pulls(
+            params={"state": "all", "base": stable_branch}
+        )
         assert 1 == len(pulls_stable)
-        pulls_feature = await self.get_pulls(state="all", base=feature_branch)
+        pulls_feature = await self.get_pulls(
+            params={"state": "all", "base": feature_branch}
+        )
         assert 1 == len(pulls_feature)
         comments = await self.get_issue_comments(p["number"])
         assert len(comments) == 3

--- a/mergify_engine/tests/functional/commands/test_copy.py
+++ b/mergify_engine/tests/functional/commands/test_copy.py
@@ -45,9 +45,13 @@ class TestCommandCopy(base.FunctionalTestBase):
         await self.wait_for("issue_comment", {"action": "created"})
         await self.run_engine()
 
-        pulls_stable = await self.get_pulls(state="all", base=stable_branch)
+        pulls_stable = await self.get_pulls(
+            params={"state": "all", "base": stable_branch}
+        )
         assert 1 == len(pulls_stable)
-        pulls_feature = await self.get_pulls(state="all", base=feature_branch)
+        pulls_feature = await self.get_pulls(
+            params={"state": "all", "base": feature_branch}
+        )
         assert 1 == len(pulls_feature)
         comments = await self.get_issue_comments(p["number"])
         assert len(comments) == 2

--- a/mergify_engine/tests/functional/test_engine.py
+++ b/mergify_engine/tests/functional/test_engine.py
@@ -271,7 +271,7 @@ expected alphabetic or numeric character, but found"""
         master_sha = (await self.get_head_commit())["sha"]
         assert previous_master_sha != master_sha
 
-        pulls = await self.get_pulls(base=self.master_branch_name)
+        pulls = await self.get_pulls(params={"base": self.master_branch_name})
         assert 0 == len(pulls)
 
     async def test_merge_strict_default(self):
@@ -326,7 +326,7 @@ expected alphabetic or numeric character, but found"""
         master_sha = (await self.get_head_commit())["sha"]
         assert previous_master_sha != master_sha
 
-        pulls = await self.get_pulls(base=self.master_branch_name)
+        pulls = await self.get_pulls(params={"base": self.master_branch_name})
         assert 0 == len(pulls)
 
     async def test_merge_smart_strict(self):
@@ -420,7 +420,7 @@ expected alphabetic or numeric character, but found"""
         master_sha = (await self.get_head_commit())["sha"]
         assert previous_master_sha != master_sha
 
-        pulls = await self.get_pulls(base=self.master_branch_name)
+        pulls = await self.get_pulls(params={"base": self.master_branch_name})
         assert 0 == len(pulls)
 
     async def test_merge_failure_smart_strict(self):
@@ -490,7 +490,7 @@ expected alphabetic or numeric character, but found"""
         master_sha = (await self.get_head_commit())["sha"]
         assert previous_master_sha != master_sha
 
-        pulls = await self.get_pulls(base=self.master_branch_name)
+        pulls = await self.get_pulls(params={"base": self.master_branch_name})
         assert 1 == len(pulls)
 
     async def test_teams(self):
@@ -789,7 +789,9 @@ expected alphabetic or numeric character, but found"""
 
         assert await self.is_pull_merged(p["number"])
 
-        pulls = await self.get_pulls(state="all", base=self.master_branch_name)
+        pulls = await self.get_pulls(
+            params={"state": "all", "base": self.master_branch_name}
+        )
         assert 1 == len(pulls)
         assert p["number"] == pulls[0]["number"]
         assert "closed" == pulls[0]["state"]

--- a/mergify_engine/tests/functional/test_github_async_client.py
+++ b/mergify_engine/tests/functional/test_github_async_client.py
@@ -46,16 +46,21 @@ class TestGithubClient(base.FunctionalTestBase):
         pulls = [p async for p in client.items(url)]
         self.assertEqual(3, len(pulls))
 
-        pulls = [p async for p in client.items(url, per_page=1)]
+        pulls = [p async for p in client.items(url, params={"per_page": 1})]
         self.assertEqual(3, len(pulls))
 
-        pulls = [p async for p in client.items(url, per_page=1, page=2)]
+        pulls = [p async for p in client.items(url, params={"per_page": 1, "page": 2})]
         self.assertEqual(2, len(pulls))
 
-        pulls = [p async for p in client.items(url, base=other_branch, state="all")]
+        pulls = [
+            p
+            async for p in client.items(
+                url, params={"base": other_branch, "state": "all"}
+            )
+        ]
         self.assertEqual(1, len(pulls))
 
-        pulls = [p async for p in client.items(url, base="unknown")]
+        pulls = [p async for p in client.items(url, params={"base": "unknown"})]
         self.assertEqual(0, len(pulls))
 
         pull = await client.item(f"{url}/{p1['number']}")

--- a/mergify_engine/tests/unit/rules/test_rules.py
+++ b/mergify_engine/tests/unit/rules/test_rules.py
@@ -386,9 +386,9 @@ async def test_get_mergify_config_location_from_cache(
     assert client.item.call_count == 3
     client.item.assert_has_calls(
         [
-            mock.call("/repos/foo/bar/contents/.mergify.yml"),
-            mock.call("/repos/foo/bar/contents/.mergify/config.yml"),
-            mock.call("/repos/foo/bar/contents/.github/mergify.yml"),
+            mock.call("/repos/foo/bar/contents/.mergify.yml", params={}),
+            mock.call("/repos/foo/bar/contents/.mergify/config.yml", params={}),
+            mock.call("/repos/foo/bar/contents/.github/mergify.yml", params={}),
         ]
     )
 
@@ -408,7 +408,7 @@ async def test_get_mergify_config_location_from_cache(
     assert client.item.call_count == 1
     client.item.assert_has_calls(
         [
-            mock.call("/repos/foo/bar/contents/.github/mergify.yml"),
+            mock.call("/repos/foo/bar/contents/.github/mergify.yml", params={}),
         ]
     )
 

--- a/mergify_engine/tests/unit/test_clients.py
+++ b/mergify_engine/tests/unit/test_clients.py
@@ -122,7 +122,10 @@ async def test_client_user_token(httpserver: httpserver.HTTPServer) -> None:
         async with github.AsyncGithubInstallationClient(
             github.get_auth(github_types.GitHubLogin("owner"))
         ) as client:
-            ret = await client.get(httpserver.url_for("/"), oauth_token="<user-token>")  # type: ignore[call-arg]
+            ret = await client.get(
+                httpserver.url_for("/"),
+                oauth_token=github_types.GitHubOAuthToken("<user-token>"),
+            )
             assert ret.json()["work"]
 
     assert len(httpserver.log) == 2

--- a/mergify_engine/user_tokens.py
+++ b/mergify_engine/user_tokens.py
@@ -32,7 +32,7 @@ LOG = daiquiri.getLogger(__name__)
 
 class UserTokensUser(typing.TypedDict):
     login: github_types.GitHubLogin
-    oauth_access_token: str
+    oauth_access_token: github_types.GitHubOAuthToken
     name: typing.Optional[str]
     email: typing.Optional[str]
 
@@ -56,7 +56,7 @@ class UserTokens:
         return [
             {
                 "login": github_types.GitHubLogin(login),
-                "oauth_access_token": oauth_access_token,
+                "oauth_access_token": github_types.GitHubOAuthToken(oauth_access_token),
                 "email": None,
                 "name": None,
             }


### PR DESCRIPTION
The oauth_token format have changed recently. Unfortunatly mypy didn't
catch it as type: ignore was everywhere.

The issue could have been seen only by rerecording a test using
bot_account.

This change fixes all bot_account oauth_access_token and remove all
type: ignore related github Api calls.
