### PR TITLE
fix(backport/copy): handle when duplicate fail with no commit

### DIFF
--- a/mergify_engine/duplicate_pull.py
+++ b/mergify_engine/duplicate_pull.py
@@ -378,7 +378,10 @@ async def duplicate(
         )
     except http.HTTPClientSideError as e:
         if e.status_code == 422 and "No commits between" in e.message:
-            raise DuplicateNotNeeded(e.message)
+            if cherry_pick_error:
+                raise DuplicateFailed(cherry_pick_error)
+            else:
+                raise DuplicateNotNeeded(e.message)
         raise
 
     effective_labels = []


### PR DESCRIPTION
cherry-pick may failed without creating commits. This change handles
this case to correctly report it to user.

Fixes MRGFY-438
