### PR TITLE
fix(debug): don't raise on BrokenPipe

### DIFF
--- a/mergify_engine/debug.py
+++ b/mergify_engine/debug.py
@@ -343,4 +343,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Debugger for mergify")
     parser.add_argument("url", help="Pull request url")
     args = parser.parse_args()
-    asyncio.run(report(args.url))
+    try:
+        asyncio.run(report(args.url))
+    except BrokenPipeError:
+        pass


### PR DESCRIPTION
This makes mergify-debug | head working

Fixes MERGIFY-ENGINE-26B