### PR TITLE
feat(merge): always run cancel

### DIFF
--- a/mergify_engine/actions/__init__.py
+++ b/mergify_engine/actions/__init__.py
@@ -68,6 +68,7 @@ class Action(abc.ABC):
     is_command = False
 
     always_run = False
+    always_cancel = False
 
     # FIXME: this might be more precise if we replace voluptuous by pydantic somehow?
     config: typing.Dict[str, typing.Any]

--- a/mergify_engine/actions/dismiss_reviews.py
+++ b/mergify_engine/actions/dismiss_reviews.py
@@ -39,6 +39,7 @@ class DismissReviewsAction(actions.Action):
     }
 
     always_run = True
+    always_cancel = True
 
     silent_report = True
 

--- a/mergify_engine/actions/post_check.py
+++ b/mergify_engine/actions/post_check.py
@@ -48,6 +48,7 @@ class PostCheckAction(actions.Action):
     }
 
     always_run = True
+    always_cancel = True
     allow_retrigger_mergify = True
 
     async def _post(

--- a/mergify_engine/actions/rebase.py
+++ b/mergify_engine/actions/rebase.py
@@ -40,6 +40,7 @@ class RebaseAction(actions.Action):
     is_command = True
 
     always_run = True
+    always_cancel = True
 
     silent_report = True
 

--- a/mergify_engine/actions/request_reviews.py
+++ b/mergify_engine/actions/request_reviews.py
@@ -60,6 +60,7 @@ class RequestReviewsAction(actions.Action):
     silent_report = True
 
     always_run = True
+    always_cancel = True
 
     def _get_random_reviewers(
         self, random_number: int, pr_author: str

--- a/mergify_engine/actions/update.py
+++ b/mergify_engine/actions/update.py
@@ -26,6 +26,7 @@ from mergify_engine import signals
 class UpdateAction(actions.Action):
     is_command = True
     always_run = True
+    always_cancel = True
     silent_report = True
     validator: typing.ClassVar[typing.Dict[typing.Any, typing.Any]] = {}
 

--- a/mergify_engine/check_api.py
+++ b/mergify_engine/check_api.py
@@ -124,6 +124,7 @@ async def set_check_run(
     name: str,
     result: Result,
     external_id: typing.Optional[str] = None,
+    update_only: bool = False,
 ) -> github_types.GitHubCheckRun:
     if result.conclusion is Conclusion.PENDING:
         status = Status.IN_PROGRESS
@@ -165,6 +166,9 @@ async def set_check_run(
         key=lambda c: c["id"],
         reverse=True,
     )
+
+    if checks and update_only:
+        return
 
     # Only keep the newer checks, cancelled others
     for check_to_cancelled in checks[1:]:


### PR DESCRIPTION
This change will always run cancel() of merge action.
In case where we lose the summary and something is queued,
it can be automatically removed from the queue by close or refresh
events.