### PR TITLE
fix(summary): reintroduce getting summary from synchronize event

### DIFF
--- a/mergify_engine/actions/dismiss_reviews.py
+++ b/mergify_engine/actions/dismiss_reviews.py
@@ -45,7 +45,7 @@ class DismissReviewsAction(actions.Action):
     async def run(
         self, ctxt: context.Context, rule: rules.EvaluatedRule
     ) -> check_api.Result:
-        if ctxt.have_been_synchronized():
+        if ctxt.has_been_synchronized():
             # FIXME(sileht): Currently sender id is not the bot by the admin
             # user that enroll the repo in Mergify, because branch_updater uses
             # his access_token instead of the Mergify installation token.

--- a/mergify_engine/actions/merge.py
+++ b/mergify_engine/actions/merge.py
@@ -161,7 +161,7 @@ class MergeAction(merge_base.MergeBaseAction):
         if ctxt.pull["state"] == "closed":
             return True
 
-        if ctxt.have_been_synchronized():
+        if ctxt.has_been_synchronized():
             return True
 
         pull_rule_checks_status = await self.get_pull_rule_checks_status(ctxt, rule)

--- a/mergify_engine/actions/queue.py
+++ b/mergify_engine/actions/queue.py
@@ -118,7 +118,7 @@ class QueueAction(merge_base.MergeBaseAction):
             # NOTE(sileht): This car doesn't have tmp pull, so we have the
             # MERGE_QUEUE_SUMMARY and train reset here
             queue_rule_evaluated = await self.queue_rule.get_pull_request_rule(ctxt)
-            need_reset = ctxt.have_been_synchronized() or await ctxt.is_behind
+            need_reset = ctxt.has_been_synchronized() or await ctxt.is_behind
             if need_reset:
                 status = check_api.Conclusion.PENDING
                 ctxt.log.info("train will be reset")
@@ -224,7 +224,7 @@ class QueueAction(merge_base.MergeBaseAction):
         if ctxt.pull["state"] == "closed":
             return True
 
-        if ctxt.have_been_synchronized():
+        if ctxt.has_been_synchronized():
             return True
 
         q = await merge_train.Train.from_context(ctxt)

--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -45,7 +45,7 @@ from mergify_engine.clients import http
 if typing.TYPE_CHECKING:
     from mergify_engine import worker
 
-SUMMARY_SHA_EXPIRATION = 60 * 60 * 24 * 31  # ~ 1 Month
+SUMMARY_SHA_EXPIRATION = 60 * 60 * 24 * 31 * 1  # 1 Month
 
 
 class MergifyConfigFile(github_types.GitHubContentFile):
@@ -970,7 +970,7 @@ class Context(object):
             "ref"
         ].startswith(constants.MERGE_QUEUE_BRANCH_PREFIX)
 
-    def have_been_synchronized(self) -> bool:
+    def has_been_synchronized(self) -> bool:
         for source in self.sources:
             if source["event_type"] == "pull_request":
                 event = typing.cast(github_types.GitHubEventPullRequest, source["data"])

--- a/mergify_engine/engine/queue_runner.py
+++ b/mergify_engine/engine/queue_runner.py
@@ -32,7 +32,7 @@ async def have_unexpected_changes(
         )
         return True
 
-    if ctxt.have_been_synchronized():
+    if ctxt.has_been_synchronized():
         ctxt.log.info(
             "train car has unexpectedly been synchronized",
         )

--- a/mergify_engine/github_events.py
+++ b/mergify_engine/github_events.py
@@ -87,8 +87,11 @@ def _extract_slim_event(event_type, data):
         }
 
     elif event_type == "pull_request":
-        # For pull_request opened/synchronise/closed
+        # For pull_request opened/synchronize/closed
         slim_data["action"] = data["action"]
+        if slim_data["action"] == "synchronize":
+            slim_data["before"] = data["before"]
+            slim_data["after"] = data["after"]
 
     elif event_type == "issue_comment":
         # For commands runner


### PR DESCRIPTION
If a queued pull request didn't get events for more than 1 month, and
suddenly get a synchronize event we can lose the state of the PR.

This change restore a old mechanism that get the summary sha information
via synchronize event, but use it at fallback only.
