### PR TITLE
docs: fix section handling

### DIFF
--- a/docs/source/_static/mergify.css
+++ b/docs/source/_static/mergify.css
@@ -85,11 +85,13 @@ nav.navbar {
 
 /* Fix headers for scrolling */
 
-section > section {
+section > section,
+.section > .section {
   margin-bottom: 0.75rem;
 }
 
-section > h1 {
+section > h1,
+.section > h1 {
     padding-top: 80px;
     margin-top: -80px;
 }
@@ -98,7 +100,12 @@ section > h2,
 section > h3,
 section > h4,
 section > h5,
-section > h6 {
+section > h6,
+.section > h2,
+.section > h3,
+.section > h4,
+.section > h5,
+.section > h6 {
     padding-top: 80px;
     margin-top: -50px;
 }

--- a/docs/source/_static/mergify.js
+++ b/docs/source/_static/mergify.js
@@ -1,6 +1,7 @@
 $(function() {
   // The default href for the current navbar on load is # which does not match the first h1 title and breaks scrollspy
   $("li.toctree-l1.current > a[href='#']").attr("href", $(".section > h1 > a").attr('href'));
+  $("li.toctree-l1.current > a[href='#']").attr("href", $("section > h1 > a").attr('href'));
 
   $('body').scrollspy({ target: 'div.sphinxsidebar', offset: 48 })
 


### PR DESCRIPTION
Sphinx sometimes uses <section> or <div class="section">.
I'm not sure what changes the behaviour, but in doubt, supports both.