### PR TITLE
refactor(context): only check for user permission if it's worth it

### DIFF
--- a/mergify_engine/github_types.py
+++ b/mergify_engine/github_types.py
@@ -289,6 +289,19 @@ GitHubReviewStateType = typing.Literal[
 ]
 
 
+# https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
+GitHubCommentAuthorAssociation = typing.Literal[
+    "COLLABORATOR",
+    "CONTRIBUTOR",
+    "FIRST_TIMER",
+    "FIRST_TIME_CONTRIBUTOR",
+    "MANNEQUIN",
+    "MEMBER",
+    "NONE",
+    "OWNER",
+]
+
+
 class GitHubReview(typing.TypedDict):
     id: GitHubReviewIdType
     user: GitHubAccount
@@ -296,6 +309,7 @@ class GitHubReview(typing.TypedDict):
     pull_request: GitHubPullRequest
     repository: GitHubRepository
     state: GitHubReviewStateType
+    author_association: GitHubCommentAuthorAssociation
 
 
 class GitHubEventPullRequestReview(GitHubEvent):


### PR DESCRIPTION
This adds a check for author_association on reviews: if it's NONE, there's 0
chance the user has a write permission on the repository, so the request can be
bypassed altogether.