### PR TITLE
fix(tests): skip workflow tests on GHE

### DIFF
--- a/mergify_engine/tests/functional/actions/test_merge.py
+++ b/mergify_engine/tests/functional/actions/test_merge.py
@@ -16,6 +16,7 @@
 import datetime
 import logging
 
+import pytest
 import yaml
 
 from mergify_engine import config
@@ -252,6 +253,12 @@ class TestMergeAction(base.FunctionalTestBase):
         pulls_in_queue = await q.get_pulls()
         assert pulls_in_queue == [p2["number"], p1["number"]]
 
+    # FIXME(sileht): Provide a tools to generate oauth_token without
+    # the need if the dashboard
+    @pytest.mark.skipif(
+        config.GITHUB_URL != "https://github.com",
+        reason="We use a PAT token instead of an OAUTH_TOKEN",
+    )
     async def test_merge_github_workflow(self):
         rules = {
             "pull_request_rules": [

--- a/mergify_engine/tests/functional/actions/test_queue.py
+++ b/mergify_engine/tests/functional/actions/test_queue.py
@@ -1336,6 +1336,12 @@ class TestQueueAction(base.FunctionalTestBase):
         p1 = await self.get_pull(p1["number"])
         assert p1["merged"]
 
+    # FIXME(sileht): Provide a tools to generate oauth_token without
+    # the need if the dashboard
+    @pytest.mark.skipif(
+        config.GITHUB_URL != "https://github.com",
+        reason="We use a PAT token instead of an OAUTH_TOKEN",
+    )
     async def test_pull_have_base_branch_merged_commit_with_changed_workflow(self):
         rules = {
             "queue_rules": [


### PR DESCRIPTION
Currently for GHE some tests are run with a PAT instead of OAUTH token.

Until we have something to generate oauth_token without the dashboard,
disable tests that can't work with a PAT token.

Fixes MRGFY-460