### PR TITLE
refactor(actions_runner): remove log filter

### DIFF
--- a/mergify_engine/engine/actions_runner.py
+++ b/mergify_engine/engine/actions_runner.py
@@ -12,7 +12,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import base64
-import copy
 import typing
 
 from datadog import statsd
@@ -168,27 +167,6 @@ async def gen_summary(
     return title, summary
 
 
-def _filterred_sources_for_logging(data, inplace=False):
-    if not inplace:
-        data = copy.deepcopy(data)
-
-    if isinstance(data, dict):
-        data.pop("node_id", None)
-        data.pop("tree_id", None)
-        data.pop("_links", None)
-        data.pop("external_id", None)
-        for key, value in list(data.items()):
-            if key.endswith("url"):
-                del data[key]
-            else:
-                data[key] = _filterred_sources_for_logging(value, inplace=True)
-        return data
-    elif isinstance(data, list):
-        return [_filterred_sources_for_logging(elem, inplace=True) for elem in data]
-    else:
-        return data
-
-
 async def post_summary(
     ctxt: context.Context,
     pull_request_rules: rules.PullRequestRules,
@@ -220,7 +198,7 @@ async def post_summary(
                 "name": ctxt.SUMMARY_NAME,
                 "summary": summary,
             },
-            sources=_filterred_sources_for_logging(ctxt.sources),
+            sources=ctxt.sources,
             conclusions=conclusions,
             previous_conclusions=previous_conclusions,
         )
@@ -238,7 +216,7 @@ async def post_summary(
                 "name": ctxt.SUMMARY_NAME,
                 "summary": summary,
             },
-            sources=_filterred_sources_for_logging(ctxt.sources),
+            sources=ctxt.sources,
             conclusions=conclusions,
             previous_conclusions=previous_conclusions,
         )


### PR DESCRIPTION
The current filter does not seem to be useful: it expect a list of
dictionaries, and from this list it removes a bunch of keys such as "node_id"
or "tree_id".

The current code sends as argument a list of T_PayloadEventSource which does
not contains any of this.

I imagine this was needed when sources were (probably?) directly a list of
GitHubEventType, but it's not the case anymore, and a lot of filtering is
already done before we log.