### PR TITLE
fix(depends-on): body may be null

### DIFF
--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -873,6 +873,9 @@ class Context(object):
     )
 
     def get_depends_on(self) -> typing.Set[github_types.GitHubPullRequestNumber]:
+        if self.pull["body"] is None:
+            self.log.error("depends-on computed on empty body", pull=self.pull)
+            return set()
         return {
             github_types.GitHubPullRequestNumber(int(pull))
             for owner, repo, pull in self.DEPENDS_ON.findall(self.pull["body"])


### PR DESCRIPTION
This log the issue instead of failing.

I don't really get how body can be None, I have checked some pull
requests from Sentry and the body is not None, so I'm confused.

Fixes MERGIFY-ENGINE-26S
