### PR TITLE
fix(depends-on): don't log error when body is None

### DIFF
--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -873,8 +873,7 @@ class Context(object):
     )
 
     def get_depends_on(self) -> typing.Set[github_types.GitHubPullRequestNumber]:
-        if self.pull["body"] is None:
-            self.log.error("depends-on computed on empty body", pull=self.pull)
+        if not self.pull["body"]:
             return set()
         return {
             github_types.GitHubPullRequestNumber(int(pull))


### PR DESCRIPTION
After double checks the new logging output, the body can indeed be
None when freshly fetched from GitHub.

This removes the temporary logging.

Fixes MERGIFY-ENGINE-26T