### PR TITLE
refactor(filter): make it generic

### DIFF
--- a/mergify_engine/actions/merge_base.py
+++ b/mergify_engine/actions/merge_base.py
@@ -139,7 +139,7 @@ async def get_rule_checks_status(
     # NOTE(sileht): Have all checks reported their status?
     await conditions_with_all_checks(ctxt.pull_request)
     ctxt.log.debug(
-        "are checks reported their status? %s",
+        "did check report their status? %s",
         conditions_with_all_checks.get_summary(),
     )
     if not conditions_with_all_checks.match:


### PR DESCRIPTION
This makes the Filter class Generic.

The binary implementation is now called FilterBinary

A future implementation will be done to return the more recent
timestamp.

Change-Id: Ice711d1f106d445badf6dc5539fc1b309887b35a