### PR TITLE
fix: retry merge when head branch change

### DIFF
--- a/mergify_engine/actions/merge_base.py
+++ b/mergify_engine/actions/merge_base.py
@@ -523,14 +523,12 @@ class MergeBaseAction(actions.Action):
     ) -> check_api.Result:
         if "Head branch was modified" in e.message:
             ctxt.log.info(
-                "Head branch was modified in the meantime",
+                "Head branch was modified in the meantime, retrying",
                 status_code=e.status_code,
                 error_message=e.message,
             )
-            return check_api.Result(
-                check_api.Conclusion.CANCELLED,
-                "Head branch was modified in the meantime",
-                "The head branch was modified, the merge action has been cancelled.",
+            return await self.get_queue_status(
+                ctxt, rule, q, is_behind=await ctxt.is_behind
             )
         elif "Base branch was modified" in e.message:
             # NOTE(sileht): The base branch was modified between pull.is_behind call and


### PR DESCRIPTION
We must not yet cancel the merge when PUT /merge fail because head
branch change.

Here the sequence of events that lead to a PR dropped from the queue:

* merge run()
  * base branch is updated on our side (but not yet on GH side)
* got a label event
  * pull[head][sha] is still the old one
  * then we check is_behind() and got false (base branch got update on
    GH side)
  * and try to merge the PR with the old sha
  * it fail and set the state to CANCELLED

Since the pull request has been update by us, people doesn't expect the
PR to be unqueued.

This change set the state to PENDING in such case, so decision to drop
or not the PR is postponed to when we will received the synchronize
event of our rebase.

Change-Id: I31a980ff55b5c469f471f5b987140f92f7171b74