### PR TITLE
feat: temporary publish docs from pull build on gcp

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,6 +89,14 @@ jobs:
           sudo apt-get install graphviz
           pip install tox
           tox -e docs
+      # NOTE(sileht): workflow run on/pull_request doesn't have access to
+      # secrets
+      # So, we upload it as artefact, then another workflow docs-pr.yaml will
+      # upload it on gcp.
+      - uses: actions/upload-artifact@v2
+        with:
+          name: docs-pr-${{ github.event.pull_request.number }}
+          path: docs/build
 
   docker:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -1,0 +1,48 @@
+name: Upload temporary docs of pull request to GCP
+
+on:
+  workflow_run:
+    workflows: ["Continuous Integration"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - id: download-artefact
+        uses: actions/github-script@v3.1.0
+        with:
+          result-encoding: string
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name.startsWith("docs-pr-")
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/docs.zip', Buffer.from(download.data));
+            return matchArtifact.name.split("-")[2]
+      - run: unzip docs.zip
+
+      - uses: google-github-actions/setup-gcloud@master
+        with:
+          service_account_email: ${{ secrets.GCP_DOCS_EMAIL }}
+          service_account_key: ${{ secrets.GCP_DOCS_KEY }}
+          export_default_credentials: true
+      - uses: google-github-actions/upload-cloud-storage@main
+        with:
+          path: docs/build
+          destination: mergify-docs-pr/${{steps.download-artefact.outputs.result}}


### PR DESCRIPTION
Because pull_request workflow run on forked repository doesn't have
access to secret this is done in two steps:
1. docs is uploaded as GitHub artefact
2. a priviledged workflow copy the artefact to gcp

Change-Id: I5dca961bb515876da004631a8890c3549b951a04
