### PR TITLE
chore: don't copy all sender data

### DIFF
--- a/mergify_engine/github_events.py
+++ b/mergify_engine/github_events.py
@@ -53,7 +53,13 @@ def meter_event(
 
 
 def _extract_slim_event(event_type, data):
-    slim_data = {"sender": data["sender"]}
+    slim_data = {
+        "sender": {
+            "id": data["sender"]["id"],
+            "login": data["sender"]["login"],
+            "type": data["sender"]["type"],
+        }
+    }
 
     if event_type == "status":
         # To get PR from sha


### PR DESCRIPTION
We recently recent the code that strip all url from GitHub events.
We miss one place here that copyi the whole sender data into context
sources.

This fixes that.

Change-Id: Ie01c6e77b12ee82ac3377de583fd0e49aa0fa54b