### PR TITLE
fix(docs): finish upload to gcp

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -1,0 +1,34 @@
+name: Documentation
+permissions: read-all
+
+on:
+  pull_request:
+    branches:
+      - main
+      - git_push_stack/**
+
+jobs:
+  docs:
+    timeout-minutes: 5
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-python@v2.2.2
+        with:
+          python-version: 3.9
+      - run: |
+          sudo apt-get install graphviz
+          pip install tox
+          tox -e docs
+      # NOTE(sileht): workflow run on/pull_request doesn't have access to
+      # secrets
+      # So, we upload it as artifact, then another workflow
+      # docs-upload-gcp.yaml will upload it on gcp.
+      - uses: actions/upload-artifact@v2
+        with:
+          name: docs-pr-${{ github.event.pull_request.number }}
+          path: docs/build
+
+      # yamllint disable-line rule:line-length
+      - run: echo "::set-output name=docs::https://docs-preview.mergify.io/${{ github.event.pull_request.number }}/docs"
+        shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,27 +77,6 @@ jobs:
           pip install tox
           tox -e py39
 
-  docs:
-    timeout-minutes: 5
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions/setup-python@v2.2.2
-        with:
-          python-version: 3.9.5
-      - run: |
-          sudo apt-get install graphviz
-          pip install tox
-          tox -e docs
-      # NOTE(sileht): workflow run on/pull_request doesn't have access to
-      # secrets
-      # So, we upload it as artefact, then another workflow docs-pr.yaml will
-      # upload it on gcp.
-      - uses: actions/upload-artifact@v2
-        with:
-          name: docs-pr-${{ github.event.pull_request.number }}
-          path: docs/build
-
   docker:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/docs-upload-gcp.yaml
+++ b/.github/workflows/docs-upload-gcp.yaml
@@ -1,19 +1,21 @@
-name: Upload temporary docs of pull request to GCP
+name: Upload temporary docs to GCP
 
 on:
   workflow_run:
-    workflows: ["Continuous Integration"]
+    workflows: ["Documentation"]
     types:
       - completed
 
 jobs:
-  upload:
+  docs-upload-to-gcp:
     runs-on: ubuntu-latest
     if: >
       ${{ github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - id: download-artefact
+      - run: apt update -y && apt install -y unzip python
+      - run: mkdir docs
+      - id: download-artifact
         uses: actions/github-script@v4.0.2
         with:
           result-encoding: string
@@ -35,7 +37,7 @@ jobs:
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/docs.zip', Buffer.from(download.data));
             return matchArtifact.name.split("-")[2]
-      - run: unzip docs.zip
+      - run: unzip docs.zip -d docs
 
       - uses: google-github-actions/setup-gcloud@master
         with:
@@ -44,5 +46,18 @@ jobs:
           export_default_credentials: true
       - uses: google-github-actions/upload-cloud-storage@main
         with:
-          path: docs/build
-          destination: mergify-docs-pr/${{steps.download-artefact.outputs.result}}
+          path: docs
+          destination: mergify-docs-preview/${{steps.download-artifact.outputs.result}}
+      - uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var pr = "${{ steps.download-artifact.outputs.result }}";
+            var resp = await github.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: "${{ github.event.workflow_run.head_sha }}",
+              name: "Documentation Preview",
+              status: "completed",
+              conclusion: "success",
+              details_url: `https://docs-preview.mergify.io/${pr}/docs`,
+            });

--- a/.github/workflows/docs-upload-gh-pages.yaml
+++ b/.github/workflows/docs-upload-gh-pages.yaml
@@ -1,11 +1,11 @@
-name: upload-docs
+name: Upload docs to GitHub pages
 on:
   push:
     branches:
       - main
 
 jobs:
-  docs:
+  docs-upload-to-gh-pages:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️


### PR DESCRIPTION
This:
* splits out Documentation job from ci.yaml. This allows to upload to
documentation even if other part of the CI fail
* post a check run with the url of the documentation

Cloudfare Worker is used to redirect docs-preview.mergify.io to our
public gcp bucket.

Change-Id: I3890e3c2699e79cb50ab946e5ba1000fc975fb30
