### PR TITLE
fix(logs): don't set root logger to DEBUG

### DIFF
--- a/mergify_engine/config.py
+++ b/mergify_engine/config.py
@@ -48,11 +48,10 @@ def CoercedLoggingLevel(value: str) -> int:
 
 
 def CommaSeparatedStringList(value: str) -> typing.List[str]:
-    return value.split(",")
-
-
-def CommaSeparatedIntList(value: str) -> typing.List[int]:
-    return [int(s) for s in value.split(",")]
+    if value:
+        return value.split(",")
+    else:
+        return []
 
 
 def AccountTokens(v: str) -> typing.Dict[str, str]:


### PR DESCRIPTION
We was generated the list [""] instead of []. And "" is the root Logger
and it got configured to DEBUG level.

This fixes that.

Change-Id: Iae95e26ce671292101fc7d0c8a5a7974857e9232