### PR TITLE
fix(simulator): use same config parser as the engine

### DIFF
--- a/mergify_engine/web/simulator.py
+++ b/mergify_engine/web/simulator.py
@@ -57,13 +57,27 @@ def PullRequestUrl(v):
     return owner, repo, pull_number
 
 
+def SimulatorMergifyConfig(v: bytes) -> rules.MergifyConfig:
+    try:
+        return rules.get_mergify_config(
+            context.MergifyConfigFile(
+                {
+                    "type": "file",
+                    "content": "whatever",
+                    "sha": github_types.SHAType("whatever"),
+                    "path": ".mergify.yml",
+                    "decoded_content": v,
+                }
+            )
+        )
+    except rules.InvalidRules as e:
+        raise e.error
+
+
 SimulatorSchema = voluptuous.Schema(
     {
         voluptuous.Required("pull_request"): voluptuous.Any(None, PullRequestUrl()),
-        voluptuous.Required("mergify.yml"): voluptuous.And(
-            voluptuous.Coerce(rules.YAML),
-            rules.UserConfigurationSchema,
-        ),
+        voluptuous.Required("mergify.yml"): voluptuous.Coerce(SimulatorMergifyConfig),
     }
 )
 


### PR DESCRIPTION
This uses the same config parser as the engine to handle
defaults.

Change-Id: I0ab5f12168a546cf91802bd00270235039b63626
