### PR TITLE
refactor(worker): remove stream_name from Context.Installation

### DIFF
--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -45,9 +45,6 @@ from mergify_engine.clients import github
 from mergify_engine.clients import http
 
 
-if typing.TYPE_CHECKING:
-    from mergify_engine import worker
-
 SUMMARY_SHA_EXPIRATION = 60 * 60 * 24 * 31 * 1  # 1 Month
 
 
@@ -78,12 +75,6 @@ class Installation:
         dataclasses.field(default_factory=dict)
     )
     _user_tokens: typing.Optional[user_tokens.UserTokens] = None
-
-    @property
-    def stream_name(self) -> "worker.StreamNameType":
-        return typing.cast(
-            "worker.StreamNameType", f"stream~{self.owner_login}~{self.owner_id}"
-        )
 
     async def get_user_tokens(self) -> user_tokens.UserTokens:
         # NOTE(sileht): For the simulator all contexts are built with a user

--- a/mergify_engine/tests/unit/test_worker.py
+++ b/mergify_engine/tests/unit/test_worker.py
@@ -806,7 +806,9 @@ async def test_stream_processor_retrying_after_read_error(
 
     installation = context.Installation(123, "owner", {}, None, None)
     with pytest.raises(worker.StreamRetry):
-        async with p._translate_exception_to_retries(installation.stream_name):
+        async with p._translate_exception_to_retries(
+            worker.StreamNameType("stream~owner~123")
+        ):
             await worker.run_engine(installation, 123, "repo", 1234, [])
 
 


### PR DESCRIPTION
This has nothing to do with the Context. And in future work, the stream
name will not be guessable like this and must be read from the "streams"
redis key.

Change-Id: Icc3dcd1c2112b439bf3716f845a6d42f8e8da4d4