### PR TITLE
fix: ensure Context.sources is empty on each engine run

### DIFF
--- a/mergify_engine/engine/__init__.py
+++ b/mergify_engine/engine/__init__.py
@@ -222,6 +222,10 @@ async def run(
     LOG.debug("engine get context")
     ctxt.log.debug("engine start processing context")
 
+    # NOTE(sileht): Reset sources as a pull request may be evaluated multiple
+    # times during worker batch.
+    ctxt.sources = []
+
     issue_comment_sources: typing.List[T_PayloadEventIssueCommentSource] = []
 
     for source in sources:


### PR DESCRIPTION
Since we cache for the duration of a batch, the sources may not be empty
when we start the engine.

This fixes that, so no event will be seen twice.

Change-Id: I39566487afd974407866bef0977137518ebf050b