### PR TITLE
ci: only check codeQL on push event

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,14 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 permissions:
   actions: read
@@ -17,11 +6,6 @@ permissions:
 on:
   push:
     branches: [main]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [main]
-  schedule:
-    - cron: '40 23 * * 3'
 
 jobs:
   analyze:


### PR DESCRIPTION
The job takes 10 minutes and we don't require it to merge PR.

So just tests all commits of the main branch.

Change-Id: I72a8ada8f1d2521355332ea212f3b16767bf3eb3