### PR TITLE
fix: workaround to detect closed PR

### DIFF
--- a/mergify_engine/actions/close.py
+++ b/mergify_engine/actions/close.py
@@ -35,7 +35,7 @@ class CloseAction(actions.Action):
     async def run(
         self, ctxt: context.Context, rule: rules.EvaluatedRule
     ) -> check_api.Result:
-        if ctxt.pull["state"] == "closed":
+        if ctxt.closed:
             return check_api.Result(
                 check_api.Conclusion.SUCCESS, "Pull request is already closed", ""
             )

--- a/mergify_engine/actions/delete_head_branch.py
+++ b/mergify_engine/actions/delete_head_branch.py
@@ -38,7 +38,7 @@ class DeleteHeadBranchAction(actions.Action):
                 check_api.Conclusion.SUCCESS, "Pull request come from fork", ""
             )
 
-        if ctxt.pull["state"] == "closed":
+        if ctxt.closed:
             if not self.config["force"]:
                 pulls_using_this_branch = [
                     branch

--- a/mergify_engine/actions/merge.py
+++ b/mergify_engine/actions/merge.py
@@ -167,7 +167,7 @@ class MergeAction(merge_base.MergeBaseAction):
         self, ctxt: context.Context, rule: "rules.EvaluatedRule"
     ) -> bool:
         # It's closed, it's not going to change
-        if ctxt.pull["state"] == "closed":
+        if ctxt.closed:
             return True
 
         if ctxt.has_been_synchronized():

--- a/mergify_engine/actions/merge_base.py
+++ b/mergify_engine/actions/merge_base.py
@@ -308,7 +308,7 @@ class MergeBaseAction(actions.Action):
         output = await self.merge_report(ctxt)
         if output:
             await q.remove_pull(ctxt)
-            if ctxt.pull["state"] == "closed":
+            if ctxt.closed:
                 return output
             else:
                 return self.cancelled_check_report
@@ -649,7 +649,7 @@ class MergeBaseAction(actions.Action):
             conclusion = check_api.Conclusion.SUCCESS
             title = f"The pull request has been merged {mode}"
             summary = f"The pull request has been merged {mode} at *{ctxt.pull['merge_commit_sha']}*"
-        elif ctxt.pull["state"] == "closed":
+        elif ctxt.closed:
             conclusion = check_api.Conclusion.CANCELLED
             title = "The pull request has been closed manually"
             summary = ""

--- a/mergify_engine/actions/queue.py
+++ b/mergify_engine/actions/queue.py
@@ -287,7 +287,7 @@ class QueueAction(merge_base.MergeBaseAction):
         self, ctxt: context.Context, rule: "rules.EvaluatedRule"
     ) -> bool:
         # It's closed, it's not going to change
-        if ctxt.pull["state"] == "closed":
+        if ctxt.closed:
             return True
 
         if ctxt.has_been_synchronized():

--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -732,7 +732,7 @@ class Context(object):
             return self.pull["merged"]
 
         elif name == "closed":
-            return self.pull["state"] == "closed"
+            return self.closed
 
         elif name == "milestone":
             return (
@@ -1028,10 +1028,7 @@ class Context(object):
         return True
 
     def _is_background_github_processing_completed(self) -> bool:
-        return (
-            self.pull["state"] == "closed"
-            or self.pull["mergeable_state"] not in self.UNUSABLE_STATES
-        )
+        return self.closed or self.pull["mergeable_state"] not in self.UNUSABLE_STATES
 
     async def update(self) -> None:
         # TODO(sileht): Remove me,
@@ -1153,6 +1150,10 @@ class Context(object):
         ]
         self._cache["files"] = files
         return files
+
+    @property
+    def closed(self) -> bool:
+        return self.pull["state"] == "closed" or self.pull["merged"]
 
     @property
     def pull_from_fork(self) -> bool:

--- a/mergify_engine/engine/queue_runner.py
+++ b/mergify_engine/engine/queue_runner.py
@@ -59,7 +59,7 @@ async def have_unexpected_changes(
 async def handle(queue_rules: rules.QueueRules, ctxt: context.Context) -> None:
     # FIXME: Maybe create a command to force the retesting to put back the PR in the queue?
 
-    if ctxt.pull["state"] == "closed":
+    if ctxt.closed:
         ctxt.log.info(
             "train car temporary pull request has been closed", sources=ctxt.sources
         )


### PR DESCRIPTION
GitHub automerge doesn't always close pull request when it merge them...

This is a known GitHub bug, but GitHub is not in an hurry to fix it.

This is a workaround that consider merged pull request as closed.

Fixes MERGIFY-ENGINE-26Z
Change-Id: Ie2c44ce9c049a6c786290834e6da7614104ab9a2

Change-Id: I82989fb9562ff085c2089ed03a55e3c93f2db610