### PR TITLE
feat(worker): split avg:engine.streams.events.latency metric

### DIFF
--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -782,8 +782,13 @@ end
             statsd.histogram("engine.streams.batch-size", len(sources))  # type: ignore[no-untyped-call]
             for source in sources:
                 if "timestamp" in source:
+                    if source["event_type"] == "push":
+                        metric = "engine.streams.push-events.latency"
+                    else:
+                        metric = "engine.streams.events.latency"
+
                     statsd.histogram(  # type: ignore[no-untyped-call]
-                        "engine.streams.events.latency",
+                        metric,
                         (
                             date.utcnow() - date.fromisoformat(source["timestamp"])
                         ).total_seconds(),


### PR DESCRIPTION
We don't proceed push events in a timely fashion, remove them to events
latency metric.

Change-Id: Iee0be6186bd18965b54ca4329c814f447cd6f9ae