### PR TITLE
fix(worker): free Context().sources when engine.run() finish

### DIFF
--- a/mergify_engine/engine/__init__.py
+++ b/mergify_engine/engine/__init__.py
@@ -222,10 +222,6 @@ async def run(
     LOG.debug("engine get context")
     ctxt.log.debug("engine start processing context")
 
-    # NOTE(sileht): Reset sources as a pull request may be evaluated multiple
-    # times during worker batch.
-    ctxt.sources = []
-
     issue_comment_sources: typing.List[T_PayloadEventIssueCommentSource] = []
 
     for source in sources:


### PR DESCRIPTION
No need to keep all of that in memory.

Change-Id: I4b1ef73eb3d54d1e8b72796d245601d1309bc593