### PR TITLE
fix(worker): be a bit more aggressive for retry

### DIFF
--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -339,7 +339,7 @@ class StreamProcessor:
                 raise
 
             attempts = await self.redis_stream.hincrby("attempts", org_bucket_name)
-            retry_in = 3 ** min(attempts, 3) * backoff
+            retry_in = 2 ** min(attempts, 3) * backoff
             retry_at = date.utcnow() + retry_in
             score = retry_at.timestamp()
             await self.redis_stream.zaddoption(


### PR DESCRIPTION
All retries (Network, 50X, ...) are 1 minutes except 403 at 3 minutes.

With 3**min(x, 3) * 1 minutes its means we retry at 3, 9, 27, 27, ...

This changes it to 2 ** min(x, 3) * 1 minute  its means we retry at 2, 4, 8, 8, ...

Change-Id: Id73e298b12dac4bc41edd5a1cd7ee7f75c8554d4