### PR TITLE
fix(rules): duplication

### DIFF
--- a/mergify_engine/rules/__init__.py
+++ b/mergify_engine/rules/__init__.py
@@ -95,7 +95,9 @@ class RuleCondition:
             return str(self.partial_filter)
 
     def copy(self) -> "RuleCondition":
-        return RuleCondition(self.condition, self.description)
+        rc = RuleCondition(self.condition, self.description)
+        rc.partial_filter.value_expanders = self.partial_filter.value_expanders
+        return rc
 
     async def __call__(self, obj: filter.GetAttrObjectT) -> bool:
         if self._used:

--- a/mergify_engine/tests/unit/rules/test_rules.py
+++ b/mergify_engine/tests/unit/rules/test_rules.py
@@ -42,6 +42,22 @@ def test_valid_condition():
     assert str(c) == "head~=bar"
 
 
+def fake_expander(v: str) -> typing.List[str]:
+    return ["foo", "bar"]
+
+
+@pytest.mark.asyncio
+async def test_expanders():
+    rc = rules.RuleCondition("author=@team")
+    rc.partial_filter.value_expanders["author"] = fake_expander
+    await rc(mock.Mock(author="foo"))
+    assert rc.match
+
+    copy_rc = rc.copy()
+    await copy_rc(mock.Mock(author="foo"))
+    assert copy_rc.match
+
+
 def test_invalid_condition_re():
     with pytest.raises(voluptuous.Invalid):
         rules.RuleCondition("head~=(bar")


### PR DESCRIPTION
When rule are duplicate we must copy the value_expanders of the filter,
otherwise future evaluation cannot resolve teams.

Change-Id: Ice7005f14f65d8060d02ac505dbafc6bbcf9ab3c
