### PR TITLE
fix(queue): automatically remove pull queued multiple times

### DIFF
--- a/mergify_engine/queue/merge_train.py
+++ b/mergify_engine/queue/merge_train.py
@@ -789,9 +789,28 @@ class Train(queue.QueueBase):
             )
             return
 
+        # NOTE(sileht): workaround for cleaning unwanted PRs queued by this bug:
+        # https://github.com/Mergifyio/mergify-engine/pull/2958
+        await self._remove_duplicate_pulls()
+
         await self._populate_cars(mergify_config["queue_rules"])
         await self._save()
         self.log.info("train cars refreshed")
+
+    async def _remove_duplicate_pulls(self) -> None:
+        known_prs = set()
+        for i, car in enumerate(self._cars):
+            if car.user_pull_request_number in known_prs:
+                await self._slice_cars_at(i)
+                break
+            else:
+                known_prs.add(car.user_pull_request_number)
+        wp_to_keep = []
+        for wp in self._waiting_pulls:
+            if wp.user_pull_request_number not in known_prs:
+                known_prs.add(wp.user_pull_request_number)
+                wp_to_keep.append(wp)
+        self._waiting_pulls = wp_to_keep
 
     async def reset(self) -> None:
         await self._slice_cars_at(0)


### PR DESCRIPTION
While it's in theory not possible, a bug make it possible
https://github.com/Mergifyio/mergify-engine/pull/2958

This change cleans up the mess automatically.

Change-Id: I76978db7408e57c9e16372b490bd848734b4b74c