### PR TITLE
fix(duplicate): report git error even if not categorized

### DIFF
--- a/mergify_engine/actions/copy.py
+++ b/mergify_engine/actions/copy.py
@@ -177,7 +177,7 @@ class CopyAction(actions.Action):
                 )
                 return (
                     check_api.Conclusion.FAILURE,
-                    f"{self.KIND.capitalize()} to branch `{branch_name}` failed",
+                    f"{self.KIND.capitalize()} to branch `{branch_name}` failed: {e.reason}",
                 )
 
         if new_pull:


### PR DESCRIPTION
User didn't like the current message "Backport failed." even
we quickly categorize the error when this occurs.

This change reports the reason to users, this make them happy and help
to known if we already correct/categorize that one or not.

Change-Id: I99d163634a717b6e191523500edb2e8caed751b2