### PR TITLE
refactor(rules): allow to parse multiple pull requests

### DIFF
--- a/mergify_engine/actions/merge.py
+++ b/mergify_engine/actions/merge.py
@@ -140,7 +140,7 @@ class MergeAction(merge_base.MergeBaseAction):
             return True
 
         pull_rule_checks_status = await merge_base.get_rule_checks_status(
-            ctxt, ctxt.pull_request, rule
+            ctxt.log, [ctxt.pull_request], rule
         )
         return pull_rule_checks_status == check_api.Conclusion.FAILURE
 

--- a/mergify_engine/actions/merge_base.py
+++ b/mergify_engine/actions/merge_base.py
@@ -15,6 +15,7 @@
 # under the License.
 import abc
 import enum
+import logging
 import re
 import typing
 
@@ -101,8 +102,8 @@ def strict_merge_parameter(v):
 
 
 async def get_rule_checks_status(
-    ctxt: context.Context,
-    pull: context.BasePullRequest,
+    log: logging.LoggerAdapter,
+    pulls: typing.List[context.BasePullRequest],
     rule: typing.Union["rules.EvaluatedRule", "rules.EvaluatedQueueRule"],
     *,
     unmatched_conditions_return_failure: bool = True,
@@ -134,8 +135,8 @@ async def get_rule_checks_status(
             condition_with_all_check.update_attribute_name("check")
 
     # NOTE(sileht): Something unrelated to checks unmatch?
-    await conditions_without_checks(pull)
-    ctxt.log.debug(
+    await conditions_without_checks(pulls)
+    log.debug(
         "something unrelated to checks doesn't match? %s",
         conditions_without_checks.get_summary(),
     )
@@ -146,8 +147,8 @@ async def get_rule_checks_status(
             return check_api.Conclusion.PENDING
 
     # NOTE(sileht): Have all checks reported their status?
-    await conditions_with_all_checks(pull)
-    ctxt.log.debug(
+    await conditions_with_all_checks(pulls)
+    log.debug(
         "did check report their status? %s",
         conditions_with_all_checks.get_summary(),
     )
@@ -155,8 +156,8 @@ async def get_rule_checks_status(
         return check_api.Conclusion.PENDING
 
     # NOTE(sileht): Are remaining unmatch checks success or pending?
-    await conditions_with_check_not_failing(pull)
-    ctxt.log.debug(
+    await conditions_with_check_not_failing(pulls)
+    log.debug(
         "did checks report success-or-neutral-or-pending? %s",
         conditions_with_check_not_failing.get_summary(),
     )

--- a/mergify_engine/actions/queue.py
+++ b/mergify_engine/actions/queue.py
@@ -129,7 +129,7 @@ Then, re-embark the pull request into the merge queue by posting the comment
             # NOTE(sileht): This car doesn't have tmp pull, so we have the
             # MERGE_QUEUE_SUMMARY and train reset here
             queue_rule_evaluated = await self.queue_rule.get_pull_request_rule(
-                ctxt, ctxt.pull_request
+                ctxt.repository, ctxt.pull["base"]["ref"], [ctxt.pull_request]
             )
             await delayed_refresh.plan_next_refresh(
                 ctxt, [queue_rule_evaluated], ctxt.pull_request
@@ -142,8 +142,8 @@ Then, re-embark the pull request into the merge queue by posting the comment
                 await q.reset()
             else:
                 status = await merge_base.get_rule_checks_status(
-                    ctxt,
-                    ctxt.pull_request,
+                    ctxt.log,
+                    [ctxt.pull_request],
                     queue_rule_evaluated,
                     unmatched_conditions_return_failure=False,
                 )
@@ -240,7 +240,7 @@ Then, re-embark the pull request into the merge queue by posting the comment
 
         if not await ctxt.is_behind:
             queue_rule_evaluated = await self.queue_rule.get_pull_request_rule(
-                ctxt, ctxt.pull_request
+                ctxt.repository, ctxt.pull["base"]["ref"], [ctxt.pull_request]
             )
             if queue_rule_evaluated.conditions.match:
                 return True
@@ -267,7 +267,7 @@ Then, re-embark the pull request into the merge queue by posting the comment
         car = typing.cast(merge_train.Train, q).get_car(ctxt)
         if car and car.state == "updated":
             queue_rule_evaluated = await self.queue_rule.get_pull_request_rule(
-                ctxt, ctxt.pull_request
+                ctxt.repository, ctxt.pull["base"]["ref"], [ctxt.pull_request]
             )
             return queue_rule_evaluated.conditions.match
 
@@ -291,7 +291,7 @@ Then, re-embark the pull request into the merge queue by posting the comment
         car = q.get_car(ctxt)
         if car and car.state == "updated":
             queue_rule_evaluated = await self.queue_rule.get_pull_request_rule(
-                ctxt, ctxt.pull_request
+                ctxt.repository, ctxt.pull["base"]["ref"], [ctxt.pull_request]
             )
             await delayed_refresh.plan_next_refresh(
                 ctxt, [queue_rule_evaluated], ctxt.pull_request
@@ -299,7 +299,7 @@ Then, re-embark the pull request into the merge queue by posting the comment
 
             # NOTE(sileht) check first if PR should be removed from the queue
             pull_rule_checks_status = await merge_base.get_rule_checks_status(
-                ctxt, ctxt.pull_request, rule
+                ctxt.log, [ctxt.pull_request], rule
             )
             if pull_rule_checks_status == check_api.Conclusion.FAILURE:
                 return True
@@ -307,8 +307,8 @@ Then, re-embark the pull request into the merge queue by posting the comment
             # NOTE(sileht): This car have been updated/rebased, so we should not cancel
             # the merge until we have a check that doesn't pass
             queue_rule_checks_status = await merge_base.get_rule_checks_status(
-                ctxt,
-                ctxt.pull_request,
+                ctxt.log,
+                [ctxt.pull_request],
                 queue_rule_evaluated,
                 unmatched_conditions_return_failure=False,
             )
@@ -328,7 +328,7 @@ Then, re-embark the pull request into the merge queue by posting the comment
 
         evaluated_pull = await car.get_pull_request_to_evaluate()
         queue_rule_evaluated = await self.queue_rule.get_pull_request_rule(
-            ctxt, evaluated_pull
+            ctxt.repository, ctxt.pull["base"]["ref"], [evaluated_pull]
         )
         return await car.generate_merge_queue_summary(queue_rule_evaluated)
 

--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -220,6 +220,15 @@ class Repository(object):
 
     # FIXME(sileht): https://github.com/python/mypy/issues/5723
     _cache: RepositoryCache = dataclasses.field(default_factory=RepositoryCache, repr=False)  # type: ignore
+    log: logging.LoggerAdapter = dataclasses.field(init=False, repr=False)
+
+    def __post_init__(self):
+        self.log = daiquiri.getLogger(
+            self.__class__.__qualname__,
+            gh_owner=self.installation.owner_login,
+            gh_repo=self.repo["name"],
+            gh_private=self.repo["private"],
+        )
 
     @property
     def base_url(self) -> str:

--- a/mergify_engine/engine/actions_runner.py
+++ b/mergify_engine/engine/actions_runner.py
@@ -65,7 +65,7 @@ async def get_already_merged_summary(
                 elif attr == "closed":
                     condition.update("closed")
 
-            await custom_conditions(ctxt.pull_request)
+            await custom_conditions([ctxt.pull_request])
             if custom_conditions.match:
                 action_merge_found_and_ran = True
 

--- a/mergify_engine/engine/queue_runner.py
+++ b/mergify_engine/engine/queue_runner.py
@@ -93,7 +93,9 @@ async def handle(queue_rules: rules.QueueRules, ctxt: context.Context) -> None:
         return
 
     pull_request = await car.get_pull_request_to_evaluate()
-    evaluated_queue_rule = await queue_rule.get_pull_request_rule(ctxt, pull_request)
+    evaluated_queue_rule = await queue_rule.get_pull_request_rule(
+        ctxt.repository, ctxt.pull["base"]["ref"], [pull_request]
+    )
     await delayed_refresh.plan_next_refresh(ctxt, [evaluated_queue_rule], pull_request)
 
     unexpected_changes = await have_unexpected_changes(ctxt, car)
@@ -106,8 +108,8 @@ async def handle(queue_rules: rules.QueueRules, ctxt: context.Context) -> None:
         real_status = status = check_api.Conclusion.PENDING
     else:
         real_status = status = await merge_base.get_rule_checks_status(
-            ctxt,
-            pull_request,
+            ctxt.log,
+            [pull_request],
             evaluated_queue_rule,
             unmatched_conditions_return_failure=False,
         )

--- a/mergify_engine/queue/merge_train.py
+++ b/mergify_engine/queue/merge_train.py
@@ -217,7 +217,7 @@ class TrainCar(PseudoTrainCar):
             raise TrainCarPullRequestCreationFailure(self) from exc
 
         evaluated_queue_rule = await queue_rule.get_pull_request_rule(
-            ctxt, ctxt.pull_request
+            self.train.repository, self.train.ref, [ctxt.pull_request]
         )
         await self.update_summaries(
             check_api.Conclusion.PENDING,
@@ -311,7 +311,9 @@ class TrainCar(PseudoTrainCar):
             self.queue_pull_request_number
         )
         evaluated_queue_rule = await queue_rule.get_pull_request_rule(
-            ctxt, context.QueuePullRequest(ctxt, tmp_ctxt)
+            self.train.repository,
+            self.train.ref,
+            [context.QueuePullRequest(ctxt, tmp_ctxt)],
         )
         await self.update_summaries(
             check_api.Conclusion.PENDING,

--- a/mergify_engine/tests/functional/test_engine.py
+++ b/mergify_engine/tests/functional/test_engine.py
@@ -503,7 +503,7 @@ class TestEngineV2Scenario(base.FunctionalTestBase):
         ctxt = await context.Context.create(repository, p, [])
 
         logins = await live_resolvers.teams(
-            ctxt,
+            repository,
             [
                 "user",
                 "@mergifyio-testing/testing",
@@ -519,7 +519,7 @@ class TestEngineV2Scenario(base.FunctionalTestBase):
         )
 
         logins = await live_resolvers.teams(
-            ctxt,
+            repository,
             [
                 "user",
                 "@testing",
@@ -535,13 +535,13 @@ class TestEngineV2Scenario(base.FunctionalTestBase):
         )
 
         with self.assertRaises(live_resolvers.LiveResolutionFailure):
-            await live_resolvers.teams(ctxt, ["@unknown/team"])
+            await live_resolvers.teams(repository, ["@unknown/team"])
 
         with self.assertRaises(live_resolvers.LiveResolutionFailure):
-            await live_resolvers.teams(ctxt, ["@mergifyio-testing/not-exists"])
+            await live_resolvers.teams(repository, ["@mergifyio-testing/not-exists"])
 
         with self.assertRaises(live_resolvers.LiveResolutionFailure):
-            await live_resolvers.teams(ctxt, ["@invalid/team/break-here"])
+            await live_resolvers.teams(repository, ["@invalid/team/break-here"])
 
         summary = [
             c for c in await ctxt.pull_engine_check_runs if c["name"] == "Summary"

--- a/mergify_engine/tests/unit/actions/test_queue.py
+++ b/mergify_engine/tests/unit/actions/test_queue.py
@@ -277,5 +277,7 @@ async def test_get_rule_checks_status(
     match = await rules.get_pull_request_rule(ctxt)
     evaluated_rule = match.matching_rules[0]
     assert (
-        await merge_base.get_rule_checks_status(ctxt, ctxt.pull_request, evaluated_rule)
+        await merge_base.get_rule_checks_status(
+            ctxt.log, [ctxt.pull_request], evaluated_rule
+        )
     ) == conclusion

--- a/mergify_engine/tests/unit/rules/test_rules.py
+++ b/mergify_engine/tests/unit/rules/test_rules.py
@@ -50,11 +50,11 @@ def fake_expander(v: str) -> typing.List[str]:
 async def test_expanders():
     rc = rules.RuleCondition("author=@team")
     rc.partial_filter.value_expanders["author"] = fake_expander
-    await rc(mock.Mock(author="foo"))
+    await rc([mock.Mock(author="foo")])
     assert rc.match
 
     copy_rc = rc.copy()
-    await copy_rc(mock.Mock(author="foo"))
+    await copy_rc([mock.Mock(author="foo")])
     assert copy_rc.match
 
 
@@ -902,23 +902,23 @@ async def test_get_pull_request_rule(redis_cache: utils.RedisCache) -> None:
 
     gh_owner = github_types.GitHubAccount(
         {
-            "login": github_types.GitHubLogin("foobar"),
-            "id": github_types.GitHubAccountIdType(0),
+            "login": github_types.GitHubLogin("another-jd"),
+            "id": github_types.GitHubAccountIdType(2644),
             "type": "User",
             "avatar_url": "",
         }
     )
     gh_repo = github_types.GitHubRepository(
         {
-            "full_name": "foobar/name",
+            "id": github_types.GitHubRepositoryIdType(123321),
             "name": github_types.GitHubRepositoryName("name"),
+            "full_name": "another-jd/name",
             "private": False,
-            "id": github_types.GitHubRepositoryIdType(0),
-            "owner": gh_owner,
             "archived": False,
             "url": "",
             "html_url": "",
-            "default_branch": github_types.GitHubRefType("ref"),
+            "default_branch": github_types.GitHubRefType(""),
+            "owner": gh_owner,
         }
     )
     installation = context.Installation(
@@ -959,56 +959,16 @@ async def test_get_pull_request_rule(redis_cache: utils.RedisCache) -> None:
                 "base": {
                     "label": "repo",
                     "ref": github_types.GitHubRefType("master"),
-                    "repo": {
-                        "id": github_types.GitHubRepositoryIdType(123321),
-                        "name": github_types.GitHubRepositoryName("name"),
-                        "full_name": "another-jd/name",
-                        "private": False,
-                        "archived": False,
-                        "url": "",
-                        "html_url": "",
-                        "default_branch": github_types.GitHubRefType(""),
-                        "owner": {
-                            "login": github_types.GitHubLogin("another-jd"),
-                            "id": github_types.GitHubAccountIdType(2644),
-                            "type": "User",
-                            "avatar_url": "",
-                        },
-                    },
-                    "user": {
-                        "login": github_types.GitHubLogin("another-jd"),
-                        "id": github_types.GitHubAccountIdType(2644),
-                        "type": "User",
-                        "avatar_url": "",
-                    },
+                    "repo": gh_repo,
+                    "user": gh_owner,
                     "sha": github_types.SHAType("mew"),
                 },
                 "head": {
                     "label": "foo",
                     "ref": github_types.GitHubRefType("myfeature"),
                     "sha": github_types.SHAType("<sha>"),
-                    "repo": {
-                        "id": github_types.GitHubRepositoryIdType(123321),
-                        "name": github_types.GitHubRepositoryName("head"),
-                        "full_name": "another-jd/head",
-                        "private": False,
-                        "archived": False,
-                        "url": "",
-                        "html_url": "",
-                        "default_branch": github_types.GitHubRefType(""),
-                        "owner": {
-                            "login": github_types.GitHubLogin("another-jd"),
-                            "id": github_types.GitHubAccountIdType(2644),
-                            "type": "User",
-                            "avatar_url": "",
-                        },
-                    },
-                    "user": {
-                        "login": github_types.GitHubLogin("another-jd"),
-                        "id": github_types.GitHubAccountIdType(2644),
-                        "type": "User",
-                        "avatar_url": "",
-                    },
+                    "repo": gh_repo,
+                    "user": gh_owner,
                 },
                 "title": "My awesome job",
                 "body": "",

--- a/mergify_engine/tests/unit/test_behind.py
+++ b/mergify_engine/tests/unit/test_behind.py
@@ -70,7 +70,9 @@ async def test_pull_behind(commits_tree_generator, redis_cache):
     client.item.return_value = item()  # /branch/#foo
 
     installation = context.Installation(123, "user", {}, client, redis_cache)
-    repository = context.Repository(installation, {"name": "name", "id": 123456})
+    repository = context.Repository(
+        installation, {"name": "name", "id": 123456, "private": False}
+    )
     ctxt = await context.Context.create(
         repository,
         {

--- a/mergify_engine/tests/unit/test_command.py
+++ b/mergify_engine/tests/unit/test_command.py
@@ -112,7 +112,9 @@ async def _create_context(redis_cache, client):
 
     installation = context.Installation(123, "Mergifyio", sub, client, redis_cache)
 
-    repository = context.Repository(installation, {"name": "demo", "id": 123})
+    repository = context.Repository(
+        installation, {"name": "demo", "id": 123, "private": True}
+    )
 
     return await context.Context.create(
         repository,


### PR DESCRIPTION
This updates the rule conditions objects to able multiple
context.PullRequest object at once.

This will be used for check the queue rules with future batch features.

Change-Id: Id33ce6830d92aa49f3f630b3714085bbde47cf19
