### PR TITLE
chore(http): set the client request ratio

### DIFF
--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -512,6 +512,7 @@ class StreamProcessor:
                 break
 
             pulls_processed += 1
+            installation.client.set_requests_ratio(pulls_processed)
 
             logger = daiquiri.getLogger(
                 __name__,


### PR DESCRIPTION
This has been dropped during the big streams to buckets migration.

Just reintroduces it.

Change-Id: I80a7e49dd92025f957a2951935f60785000eda10