### PR TITLE
fix(conditions): fix evaluation of multiple pull requests

### DIFF
--- a/mergify_engine/actions/merge_base.py
+++ b/mergify_engine/actions/merge_base.py
@@ -112,21 +112,22 @@ async def get_rule_checks_status(
     if rule.conditions.match:
         return check_api.Conclusion.SUCCESS
 
+    conditions_initial = rule.conditions.copy()
     conditions_without_checks = rule.conditions.copy()
     conditions_with_all_checks = rule.conditions.copy()
     conditions_with_check_not_failing = rule.conditions.copy()
     for (
-        evaluated_condition,
+        condition_initial,
         condition_without_check,
         condition_with_all_check,
         condition_with_check_not_failing,
     ) in zip(
-        rule.conditions.walk(),
+        conditions_initial.walk(),
         conditions_without_checks.walk(),
         conditions_with_all_checks.walk(),
         conditions_with_check_not_failing.walk(),
     ):
-        attr = evaluated_condition.get_attribute_name()
+        attr = condition_initial.get_attribute_name()
         if attr.startswith("check-") or attr.startswith("status-"):
             condition_without_check.update("number>0")
             condition_with_check_not_failing.update_attribute_name(

--- a/mergify_engine/engine/commands_runner.py
+++ b/mergify_engine/engine/commands_runner.py
@@ -144,7 +144,9 @@ async def run_command(
 
     report = await command.action.run(
         ctxt,
-        rules.EvaluatedRule(rules.Rule("", None, rules.RuleConditions([]), {}, False)),
+        rules.EvaluatedRule(
+            rules.Rule("", None, rules.PullRequestRuleConditions([]), {}, False)
+        ),
     )
 
     if command.args:

--- a/mergify_engine/tests/functional/actions/test_queue.py
+++ b/mergify_engine/tests/functional/actions/test_queue.py
@@ -1832,7 +1832,9 @@ class TestTrainApiCalls(base.FunctionalTestBase):
         )
         await car.create_pull(
             rules.QueueRule(
-                name="foo", conditions=rules.RuleConditions([]), config=queue_config
+                name="foo",
+                conditions=rules.QueueRuleConditions([]),
+                config=queue_config,
             )
         )
         assert car.queue_pull_request_number is not None
@@ -1886,7 +1888,9 @@ class TestTrainApiCalls(base.FunctionalTestBase):
         with pytest.raises(merge_train.TrainCarPullRequestCreationFailure) as exc_info:
             await car.create_pull(
                 rules.QueueRule(
-                    name="foo", conditions=rules.RuleConditions([]), config=queue_config
+                    name="foo",
+                    conditions=rules.QueueRuleConditions([]),
+                    config=queue_config,
                 )
             )
             assert exc_info.value.car == car

--- a/mergify_engine/tests/unit/actions/test_merge.py
+++ b/mergify_engine/tests/unit/actions/test_merge.py
@@ -315,7 +315,7 @@ async def test_queue_summary(redis_cache):
 ---
 
 """ + constants.MERGIFY_PULL_REQUEST_DOC == await action._get_queue_summary(
-            ctxt, mock.Mock(conditions=rules.RuleConditions([])), q
+            ctxt, mock.Mock(conditions=rules.QueueRuleConditions([])), q
         )
 
 


### PR DESCRIPTION
This change the ways we evaluate multiple pull requests.

This permits to keep the evaluated filter tree for each pull request.

This will allows to create a better summary for queue rules with batch.

Change-Id: I76990df1f6e50eb1a30c89a992d85f5f2c577a6e
