### PR TITLE
ci(releaser): use ssh key to checkout code

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v2.3.4
         with:
+          ssh-key: "${{ secrets.RELEASER_SSH_KEY }}"
           fetch-depth: 0
 
       - name: Setup Python 🔧


### PR DESCRIPTION
The GITHUB_TOKEN is not allow to trigger other workflows.
So the docker image build (workflow triggered with `on: [tag]`) is not
run.

This change uses a Deploy key. So when the workflow uses `git push`,
associated workflow will be ran.

Change-Id: I645f54912c68a3f4d453b8a83b2a869b8611c0bb