### PR TITLE
ci: move hotfix rule on top

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -39,6 +39,20 @@ queue_rules:
     batch_size: 5
 
 pull_request_rules:
+  - name: automatic merge for hotfix
+    conditions:
+      - base=main
+      - author=@devs
+      - check-success=Semantic Pull Request
+      - body~=(?m)^Fixes MERGIFY-ENGINE-
+      - label=hotfix
+      - "#changes-requested-reviews-by=0"
+      - label!=work-in-progress
+      - label!=manual merge
+    actions:
+      queue:
+        name: hotfix
+
   - name: automatic merge
     conditions:
       - base=main
@@ -55,20 +69,6 @@ pull_request_rules:
       - label!=manual merge
     actions:
       queue:
-
-  - name: automatic merge for hotfix
-    conditions:
-      - base=main
-      - author=@devs
-      - check-success=Semantic Pull Request
-      - body~=(?m)^Fixes MERGIFY-ENGINE-
-      - label=hotfix
-      - "#changes-requested-reviews-by=0"
-      - label!=work-in-progress
-      - label!=manual merge
-    actions:
-      queue:
-        name: hotfix
 
   - name: automatic merge from dependabot
     conditions:


### PR DESCRIPTION
If the hotfix rule and the normal rule match, the only the first one
run. So move the hotfix first.

Change-Id: I5ac7bdebd173d90b5af7fd52c0bcad77f3042e45