### PR TITLE
chore(queue): don't store queue rule config in redis

### DIFF
--- a/mergify_engine/queue/__init__.py
+++ b/mergify_engine/queue/__init__.py
@@ -35,7 +35,6 @@ class PullQueueConfig(typing.TypedDict):
     bot_account: typing.Optional[github_types.GitHubLogin]
     update_bot_account: typing.Optional[github_types.GitHubLogin]
     name: rules.QueueName
-    queue_config: rules.QueueConfig
 
 
 QueueT = typing.TypeVar("QueueT", bound="QueueBase")

--- a/mergify_engine/queue/naive.py
+++ b/mergify_engine/queue/naive.py
@@ -76,14 +76,6 @@ class Queue(queue.QueueBase):
                     "update_bot_account": None,
                     "update_method": "merge",
                     "name": rules.QueueName(""),
-                    "queue_config": rules.QueueConfig(
-                        {
-                            "priority": 1,
-                            "speculative_checks": 1,
-                            "batch_size": 1,
-                            "allow_inplace_speculative_checks": True,
-                        }
-                    ),
                 }
             )
         config: queue.PullQueueConfig = json.loads(config_str)

--- a/mergify_engine/tests/functional/actions/test_queue.py
+++ b/mergify_engine/tests/functional/actions/test_queue.py
@@ -2325,7 +2325,6 @@ class TestTrainApiCalls(base.FunctionalTestBase):
             effective_priority=0,
             bot_account=None,
             update_bot_account=None,
-            queue_config=queue_config,
         )
 
         car = merge_train.TrainCar(
@@ -2396,7 +2395,6 @@ class TestTrainApiCalls(base.FunctionalTestBase):
             effective_priority=0,
             bot_account=None,
             update_bot_account=None,
-            queue_config=queue_config,
         )
 
         car = merge_train.TrainCar(


### PR DESCRIPTION
This is not needed anymore, we always have the last version of the
configuration everywhere now.

Fixes MRGFY-522

Change-Id: I8fe7fe9ad4baf1a4a6b82bfb29052c87247657e5
