### PR TITLE
fix(backport/copy): ensure cherry-pick are retried/reported correctly

### DIFF
--- a/mergify_engine/duplicate_pull.py
+++ b/mergify_engine/duplicate_pull.py
@@ -304,7 +304,17 @@ async def duplicate(
             #    "--shallow-since='%s'" % last_commit_date)
             try:
                 await git("cherry-pick", "-x", commit["sha"])
+            except (
+                gitter.GitAuthenticationFailure,
+                gitter.GitErrorRetriable,
+                gitter.GitFatalError,
+            ):
+                raise
             except gitter.GitError as e:  # pragma: no cover
+                for message in GIT_MESSAGE_TO_EXCEPTION.keys():
+                    if message in e.output:
+                        raise
+
                 ctxt.log.info("fail to cherry-pick %s: %s", commit["sha"], e.output)
                 output = await git("status")
                 cherry_pick_error += f"Cherry-pick of {commit['sha']} has failed:\n```\n{output}```\n\n\n"


### PR DESCRIPTION
If a GitHub outage occurs, temporary auth issue, the cherry-pick command
failed and the git tree has no staged change or new commit. In such case
we assume the change is already part of the branch which is wrong.

This changes reraise all known git issue to ensure their are retried or
reported correctly.

Related #1654

Change-Id: Ib99c4a8354fa0bf2b26740be5a7a682020bae045
