### PR TITLE
fix(gitter): report all git errno 128 error as fatal

### DIFF
--- a/mergify_engine/gitter.py
+++ b/mergify_engine/gitter.py
@@ -130,6 +130,8 @@ class Gitter(object):
                             output,
                         )
 
+                if p.returncode == 128:
+                    raise GitFatalError(p.returncode, output)
                 raise GitError(p.returncode, output)
             else:
                 return output


### PR DESCRIPTION
As documented https://www.git-scm.com/docs/api-error-handling

128 means git die, so if we didn't handle the git message with a better
exception we must just report the output as fatal.

Related #1654

Change-Id: I4f1131195a767db4981137f4d41b409875a5c411