### PR TITLE
fix(queue): fix summary title with one ref

### DIFF
--- a/mergify_engine/queue/merge_train.py
+++ b/mergify_engine/queue/merge_train.py
@@ -204,6 +204,8 @@ class TrainCar:
 
         if include_my_self:
             return f"{', '.join(refs)} and {self._get_user_refs()}"
+        elif len(refs) == 1:
+            return refs[-1]
         else:
             return f"{', '.join(refs[:-1])} and {refs[-1]}"
 


### PR DESCRIPTION
If the train car has no parent pull requests, we built sentence like:

`The pull request embarked with  and master (6b13c3d) is mergeable`

This change removes the useless ` and`

Change-Id: Ia647f1660a3f6195d68cfaca5d3c8b1d37b916c8