### PR TITLE
fix(queue/merge): don't process queue if pull is not queued

### DIFF
--- a/mergify_engine/actions/merge.py
+++ b/mergify_engine/actions/merge.py
@@ -142,13 +142,17 @@ class MergeAction(merge_base.MergeBaseAction):
         return False
 
     async def _should_be_cancel(
-        self, ctxt: context.Context, rule: "rules.EvaluatedRule"
+        self, ctxt: context.Context, rule: "rules.EvaluatedRule", q: queue.QueueBase
     ) -> bool:
         # It's closed, it's not going to change
         if ctxt.closed:
             return True
 
         if await ctxt.has_been_synchronized_by_user():
+            return True
+
+        position = await q.get_position(ctxt)
+        if position is None:
             return True
 
         pull_rule_checks_status = await merge_base.get_rule_checks_status(

--- a/mergify_engine/actions/merge_base.py
+++ b/mergify_engine/actions/merge_base.py
@@ -200,7 +200,7 @@ class MergeBaseAction(actions.Action):
 
     @abc.abstractmethod
     async def _should_be_cancel(
-        self, ctxt: context.Context, rule: "rules.EvaluatedRule"
+        self, ctxt: context.Context, rule: "rules.EvaluatedRule", q: queue.QueueBase
     ) -> bool:
         pass
 
@@ -378,7 +378,7 @@ class MergeBaseAction(actions.Action):
         if self.config[
             "strict"
         ] is not StrictMergeParameter.false and not await self._should_be_cancel(
-            ctxt, rule
+            ctxt, rule, q
         ):
             try:
                 if await self._should_be_merged(ctxt, q):


### PR DESCRIPTION
If merge_base.run() returns failure and on next engine run conditins
unmatch, when we run cancel()if one of the CI is pending we wait it
finish. But since the pull request in not in queue we don't need to
wait, we can cancel the action instantly.

Fixes MERGIFY-ENGINE-1WK

Change-Id: I31c0ed175b2dcdea1a5ddc6ea5bf08739db18c8b
