### PR TITLE
ci(releaser): install pandoc correctly

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -32,7 +32,8 @@ jobs:
           set -e
           set -o pipefail
 
-          pip install reno pandoc
+          pip install reno
+          apt install -y pandoc
 
           git fetch --tag
           VERSION=$(reno -q semver-next)


### PR DESCRIPTION
We currently install the python lib called pandoc instead
of the pandoc binary.

Change-Id: Iff4943a752156af32b25aa821ddba7085e06aabf
