### PR TITLE
fix(gitter): don't rely on return code

### DIFF
--- a/mergify_engine/gitter.py
+++ b/mergify_engine/gitter.py
@@ -129,8 +129,6 @@ class Gitter(object):
                             output,
                         )
 
-                if p.returncode == 128:
-                    raise GitFatalError(p.returncode, output)
                 raise GitError(p.returncode, output)
             else:
                 return output


### PR DESCRIPTION
Unfortunatly, there is case where valid cherry-pick failure return 128

So we can only rely on the message.

Fixes MERGIFY-ENGINE-2A9

Change-Id: Ibe359f7ff689cc5c0db25c040daac87d781313c3