### PR TITLE
refactor(action): make all action flags explicit

### DIFF
--- a/mergify_engine/actions/assign.py
+++ b/mergify_engine/actions/assign.py
@@ -35,7 +35,12 @@ class AssignAction(actions.Action):
         voluptuous.Required("remove_users", default=[]): [types.Jinja2],
     }
 
-    silent_report = True
+    flags = (
+        actions.ActionFlag.ALLOW_AS_ACTION
+        | actions.ActionFlag.ALLOW_ON_CONFIGURATION_CHANGED
+        # FIXME(sileht): MRGFY-561
+        # | actions.ActionFlag.ALWAYS_RUN
+    )
 
     async def run(
         self, ctxt: context.Context, rule: rules.EvaluatedRule

--- a/mergify_engine/actions/backport.py
+++ b/mergify_engine/actions/backport.py
@@ -16,6 +16,7 @@
 
 import typing
 
+from mergify_engine import actions
 from mergify_engine import check_api
 from mergify_engine import config
 from mergify_engine import context
@@ -26,7 +27,12 @@ from mergify_engine.actions import copy
 
 
 class BackportAction(copy.CopyAction):
-    is_command: bool = True
+    flags = (
+        actions.ActionFlag.ALLOW_AS_ACTION
+        | actions.ActionFlag.ALLOW_AS_COMMAND
+        | actions.ActionFlag.ALWAYS_SEND_REPORT
+        | actions.ActionFlag.ALLOW_ON_CONFIGURATION_CHANGED
+    )
 
     KIND: duplicate_pull.KindT = "backport"
     HOOK_EVENT_NAME: signals.EventName = "action.backport"

--- a/mergify_engine/actions/close.py
+++ b/mergify_engine/actions/close.py
@@ -29,7 +29,12 @@ MSG = "This pull request has been automatically closed by Mergify."
 
 
 class CloseAction(actions.Action):
-    only_once = True
+    flags = (
+        actions.ActionFlag.ALLOW_AS_ACTION
+        | actions.ActionFlag.ALWAYS_SEND_REPORT
+        | actions.ActionFlag.ALLOW_ON_CONFIGURATION_CHANGED
+        | actions.ActionFlag.DISALLOW_RERUN_ON_OTHER_RULES
+    )
     validator = {voluptuous.Required("message", default=MSG): types.Jinja2}
 
     async def run(

--- a/mergify_engine/actions/comment.py
+++ b/mergify_engine/actions/comment.py
@@ -31,12 +31,14 @@ from mergify_engine.rules import types
 
 
 class CommentAction(actions.Action):
+    flags = (
+        actions.ActionFlag.ALLOW_AS_ACTION
+        | actions.ActionFlag.ALLOW_ON_CONFIGURATION_CHANGED
+    )
     validator = {
         voluptuous.Required("message", default=None): types.Jinja2WithNone,
         voluptuous.Required("bot_account", default=None): types.Jinja2WithNone,
     }
-
-    silent_report = True
 
     async def run(
         self, ctxt: context.Context, rule: rules.EvaluatedRule

--- a/mergify_engine/actions/copy.py
+++ b/mergify_engine/actions/copy.py
@@ -61,7 +61,12 @@ def DuplicateTitleJinja2(v):
 
 
 class CopyAction(actions.Action):
-    is_command: bool = True
+    flags = (
+        actions.ActionFlag.ALLOW_AS_ACTION
+        | actions.ActionFlag.ALLOW_AS_COMMAND
+        | actions.ActionFlag.ALLOW_ON_CONFIGURATION_CHANGED
+        | actions.ActionFlag.ALWAYS_SEND_REPORT
+    )
 
     KIND: duplicate_pull.KindT = "copy"
     HOOK_EVENT_NAME: signals.EventName = "action.copy"

--- a/mergify_engine/actions/delete_head_branch.py
+++ b/mergify_engine/actions/delete_head_branch.py
@@ -27,7 +27,12 @@ from mergify_engine.clients import http
 
 
 class DeleteHeadBranchAction(actions.Action):
-    only_once = True
+    flags = (
+        actions.ActionFlag.ALLOW_AS_ACTION
+        | actions.ActionFlag.DISALLOW_RERUN_ON_OTHER_RULES
+        | actions.ActionFlag.ALLOW_ON_CONFIGURATION_CHANGED
+        | actions.ActionFlag.ALWAYS_SEND_REPORT
+    )
     validator = {voluptuous.Required("force", default=False): bool}
 
     async def run(

--- a/mergify_engine/actions/dismiss_reviews.py
+++ b/mergify_engine/actions/dismiss_reviews.py
@@ -26,6 +26,12 @@ from mergify_engine.rules import types
 
 
 class DismissReviewsAction(actions.Action):
+    flags = (
+        actions.ActionFlag.ALLOW_AS_ACTION
+        | actions.ActionFlag.ALLOW_ON_CONFIGURATION_CHANGED
+        | actions.ActionFlag.ALWAYS_RUN
+    )
+
     validator = {
         voluptuous.Required("approved", default=True): voluptuous.Any(
             True, False, [types.GitHubLogin]
@@ -37,10 +43,6 @@ class DismissReviewsAction(actions.Action):
             "message", default="Pull request has been modified."
         ): types.Jinja2,
     }
-
-    always_run = True
-
-    silent_report = True
 
     async def run(
         self, ctxt: context.Context, rule: rules.EvaluatedRule

--- a/mergify_engine/actions/label.py
+++ b/mergify_engine/actions/label.py
@@ -27,14 +27,17 @@ from mergify_engine.clients import http
 
 
 class LabelAction(actions.Action):
+    flags = (
+        actions.ActionFlag.ALLOW_AS_ACTION
+        | actions.ActionFlag.ALLOW_ON_CONFIGURATION_CHANGED
+        | actions.ActionFlag.ALWAYS_RUN
+    )
+
     validator = {
         voluptuous.Required("add", default=[]): [str],
         voluptuous.Required("remove", default=[]): [str],
         voluptuous.Required("remove_all", default=False): bool,
     }
-
-    silent_report = True
-    always_run = True
 
     async def run(
         self, ctxt: context.Context, rule: rules.EvaluatedRule

--- a/mergify_engine/actions/merge_base.py
+++ b/mergify_engine/actions/merge_base.py
@@ -169,8 +169,14 @@ async def get_rule_checks_status(
 
 
 class MergeBaseAction(actions.Action, abc.ABC):
-    only_once = True
-    can_be_used_on_configuration_change = False
+    flags = (
+        actions.ActionFlag.ALLOW_AS_ACTION
+        | actions.ActionFlag.ALWAYS_SEND_REPORT
+        | actions.ActionFlag.DISALLOW_RERUN_ON_OTHER_RULES
+        # FIXME(sileht): MRGFY-562
+        # | actions.ActionFlag.ALWAYS_RUN
+    )
+
     UNQUEUE_DOCUMENTATION = ""
     MESSAGE_ACTION_NAME = "Merge"
 

--- a/mergify_engine/actions/post_check.py
+++ b/mergify_engine/actions/post_check.py
@@ -39,6 +39,14 @@ def CheckRunJinja2(v):
 
 
 class PostCheckAction(actions.Action):
+
+    flags = (
+        actions.ActionFlag.ALLOW_AS_ACTION
+        | actions.ActionFlag.ALWAYS_RUN
+        | actions.ActionFlag.ALWAYS_SEND_REPORT
+        | actions.ActionFlag.ALLOW_ON_CONFIGURATION_CHANGED
+        | actions.ActionFlag.ALLOW_RETRIGGER_MERGIFY
+    )
     validator = {
         voluptuous.Required(
             "title",
@@ -48,9 +56,6 @@ class PostCheckAction(actions.Action):
             "summary", default="{{ check_conditions }}"
         ): CheckRunJinja2,
     }
-
-    always_run = True
-    allow_retrigger_mergify = True
 
     async def _post(
         self, ctxt: context.Context, rule: rules.EvaluatedRule

--- a/mergify_engine/actions/rebase.py
+++ b/mergify_engine/actions/rebase.py
@@ -30,12 +30,14 @@ from mergify_engine.rules import types
 
 
 class RebaseAction(actions.Action):
-    is_command = True
-
-    always_run = True
-
-    silent_report = True
-
+    flags = (
+        actions.ActionFlag.ALLOW_AS_ACTION
+        | actions.ActionFlag.ALLOW_AS_COMMAND
+        | actions.ActionFlag.ALWAYS_RUN
+        | actions.ActionFlag.ALLOW_ON_CONFIGURATION_CHANGED
+        # FIXME(sileht): it doesn't make sense to rebase code twice
+        # | actions.ActionFlag.DISALLOW_RERUN_ON_OTHER_RULES
+    )
     validator = {
         voluptuous.Required("bot_account", default=None): voluptuous.Any(
             None, types.Jinja2

--- a/mergify_engine/actions/refresh.py
+++ b/mergify_engine/actions/refresh.py
@@ -22,8 +22,11 @@ from mergify_engine import utils
 
 
 class RefreshAction(actions.Action):
-    is_command = True
-    is_action = False
+    flags = (
+        actions.ActionFlag.ALLOW_AS_COMMAND
+        | actions.ActionFlag.ALLOW_ON_CONFIGURATION_CHANGED
+    )
+
     validator: typing.ClassVar[typing.Dict[typing.Any, typing.Any]] = {}
 
     async def run(

--- a/mergify_engine/actions/request_reviews.py
+++ b/mergify_engine/actions/request_reviews.py
@@ -28,6 +28,11 @@ from mergify_engine.rules import types
 
 
 class RequestReviewsAction(actions.Action):
+    flags = (
+        actions.ActionFlag.ALLOW_AS_ACTION
+        | actions.ActionFlag.ALWAYS_RUN
+        | actions.ActionFlag.ALLOW_ON_CONFIGURATION_CHANGED
+    )
 
     # This is the maximum number of review you can request on a PR.
     # It's not documented in the API, but it is shown in GitHub UI.
@@ -56,10 +61,6 @@ class RequestReviewsAction(actions.Action):
             voluptuous.Range(1, GITHUB_MAXIMUM_REVIEW_REQUEST),
         ),
     }
-
-    silent_report = True
-
-    always_run = True
 
     def _get_random_reviewers(
         self, random_number: int, pr_author: str

--- a/mergify_engine/actions/review.py
+++ b/mergify_engine/actions/review.py
@@ -37,6 +37,12 @@ EVENT_STATE_MAP = {
 
 
 class ReviewAction(actions.Action):
+    flags = (
+        actions.ActionFlag.ALLOW_AS_ACTION
+        | actions.ActionFlag.ALLOW_ON_CONFIGURATION_CHANGED
+        # FIXME(sileht): MRGFY-565
+        # | actions.ActionFlag.ALWAYS_RUN
+    )
     validator = {
         voluptuous.Required("type", default="APPROVE"): voluptuous.Any(
             "APPROVE", "REQUEST_CHANGES", "COMMENT"
@@ -44,8 +50,6 @@ class ReviewAction(actions.Action):
         voluptuous.Required("message", default=None): types.Jinja2WithNone,
         voluptuous.Required("bot_account", default=None): types.Jinja2WithNone,
     }
-
-    silent_report = True
 
     async def run(
         self, ctxt: context.Context, rule: rules.EvaluatedRule

--- a/mergify_engine/actions/squash.py
+++ b/mergify_engine/actions/squash.py
@@ -31,10 +31,14 @@ from mergify_engine.rules import types
 
 
 class SquashAction(actions.Action):
-    is_command = True
-    always_run = True
-    silent_report = True
-
+    flags = (
+        actions.ActionFlag.ALLOW_AS_ACTION
+        | actions.ActionFlag.ALLOW_AS_COMMAND
+        | actions.ActionFlag.ALWAYS_RUN
+        | actions.ActionFlag.ALLOW_ON_CONFIGURATION_CHANGED
+        # FIXME(sileht): it doesn't make sense to squash the code twice
+        # | actions.ActionFlag.DISALLOW_RERUN_ON_OTHER_RULES
+    )
     validator = {
         voluptuous.Required("bot_account", default=None): voluptuous.Any(
             None, types.Jinja2

--- a/mergify_engine/actions/update.py
+++ b/mergify_engine/actions/update.py
@@ -24,9 +24,14 @@ from mergify_engine import signals
 
 
 class UpdateAction(actions.Action):
-    is_command = True
-    always_run = True
-    silent_report = True
+    flags = (
+        actions.ActionFlag.ALLOW_AS_ACTION
+        | actions.ActionFlag.ALLOW_AS_COMMAND
+        | actions.ActionFlag.ALWAYS_RUN
+        | actions.ActionFlag.ALLOW_ON_CONFIGURATION_CHANGED
+        # FIXME(sileht): it doesn't make sense to update the code twice
+        # | actions.ActionFlag.DISALLOW_RERUN_ON_OTHER_RULES
+    )
     validator: typing.ClassVar[typing.Dict[typing.Any, typing.Any]] = {}
 
     @staticmethod

--- a/mergify_engine/engine/actions_runner.py
+++ b/mergify_engine/engine/actions_runner.py
@@ -17,6 +17,7 @@ import typing
 from datadog import statsd
 import yaml
 
+from mergify_engine import actions
 from mergify_engine import check_api
 from mergify_engine import config
 from mergify_engine import constants
@@ -351,14 +352,18 @@ async def run_actions(
         for action, action_obj in rule.actions.items():
             check_name = f"Rule: {rule.name} ({action})"
 
-            done_by_another_action = action_obj.only_once and action in actions_ran
+            done_by_another_action = (
+                actions.ActionFlag.DISALLOW_RERUN_ON_OTHER_RULES in action_obj.flags
+                and action in actions_ran
+            )
 
             if (
                 not rule.conditions.match
                 or rule.disabled is not None
                 or (
                     ctxt.configuration_changed
-                    and not action_obj.can_be_used_on_configuration_change
+                    and actions.ActionFlag.ALLOW_ON_CONFIGURATION_CHANGED
+                    not in action_obj.flags
                 )
             ):
                 method_name = "cancel"
@@ -379,7 +384,7 @@ async def run_actions(
             )
 
             need_to_be_run = (
-                action_obj.always_run
+                actions.ActionFlag.ALWAYS_RUN in action_obj.flags
                 or admin_refresh_requested
                 or (
                     user_refresh_requested
@@ -427,7 +432,7 @@ async def run_actions(
                 statsd.increment("engine.actions.count", tags=[f"name:{action}"])
 
             if need_to_be_run and (
-                not action_obj.silent_report
+                actions.ActionFlag.ALWAYS_SEND_REPORT in action_obj.flags
                 or report.conclusion
                 not in (
                     check_api.Conclusion.SUCCESS,
@@ -437,7 +442,7 @@ async def run_actions(
             ):
                 external_id = (
                     check_api.USER_CREATED_CHECKS
-                    if action_obj.allow_retrigger_mergify
+                    if actions.ActionFlag.ALLOW_RETRIGGER_MERGIFY in action_obj.flags
                     else None
                 )
                 try:

--- a/mergify_engine/engine/commands_runner.py
+++ b/mergify_engine/engine/commands_runner.py
@@ -234,7 +234,8 @@ async def handle(
 
     if (
         ctxt.configuration_changed
-        and not command.action.can_be_used_on_configuration_change
+        and actions.ActionFlag.ALLOW_ON_CONFIGURATION_CHANGED
+        not in command.action.flags
     ):
         message = CONFIGURATION_CHANGE_MESSAGE
         log(message)


### PR DESCRIPTION
Relying on boolean shared with a baseclass is confusing, we don't really
known how the action behave.

This change uses enum.Flag instead of boolean to track the behavior of
an action in an explicit fashion.

Change-Id: Icc63fc95c4177349dfdd4c0e7e3211de816192ee