### PR TITLE
fix(timezone): comparison of current-time

### DIFF
--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -926,10 +926,8 @@ class Context(object):
                 if ctxt.pull["merged"]:
                     depends_on.append(f"#{pull_request_number}")
             return depends_on
-        elif name == "current-timestamp":
+        elif name in ("current-timestamp", "current-time"):
             return date.utcnow()
-        elif name == "current-time":
-            return date.utcnow().timetz()
         elif name == "current-day":
             return date.Day(date.utcnow().day)
         elif name == "current-month":

--- a/mergify_engine/rules/filter.py
+++ b/mergify_engine/rules/filter.py
@@ -346,12 +346,13 @@ def _as_datetime(value: typing.Any) -> datetime.datetime:
             return dt.replace(year=value.value, month=1, day=1)
         else:
             return date.DT_MAX
-    elif isinstance(value, datetime.time):
+    elif isinstance(value, date.Time):
         return date.utcnow().replace(
             hour=value.hour,
             minute=value.minute,
-            second=value.second,
-            microsecond=value.microsecond,
+            second=0,
+            microsecond=0,
+            tzinfo=value.tzinfo,
         )
     else:
         return date.DT_MAX
@@ -419,7 +420,7 @@ def _dt_op(
                 else:
                     return _dt_in_future(dt_ref)
             else:
-                if isinstance(ref, datetime.time):
+                if isinstance(ref, date.Time):
                     # Condition will change next day at 00:00:00
                     dt_ref = dt_ref + datetime.timedelta(days=1)
                 elif isinstance(value, date.DayOfWeek):

--- a/mergify_engine/rules/parser.py
+++ b/mergify_engine/rules/parser.py
@@ -56,7 +56,7 @@ _match_time = (
     )
     + _timezone
 ).setParseAction(
-    lambda toks: datetime.time(hour=int(toks[0]), minute=int(toks[2]), tzinfo=toks[3])
+    lambda toks: date.Time(hour=int(toks[0]), minute=int(toks[2]), tzinfo=toks[3])
 )
 
 _day = (
@@ -174,7 +174,7 @@ def _parse_time_range(toks: typing.List[pyparsing.Token]) -> typing.Any:
     # NOTE(sileht): In case of the format is `10:00-18:00[Europe/Paris]`,
     # we assume the first time is also [Europe/Paris]
     if time1.tzinfo != time2.tzinfo and time2.tzinfo != datetime.timezone.utc:
-        time1 = time1.replace(tzinfo=time2.tzinfo)
+        time1.tzinfo = time2.tzinfo
 
     return {
         "and": (

--- a/mergify_engine/tests/unit/rules/test_parser.py
+++ b/mergify_engine/tests/unit/rules/test_parser.py
@@ -59,7 +59,7 @@ now = datetime.datetime.fromisoformat("2012-01-14T20:32:00+00:00")
                                         {
                                             ">=": (
                                                 "current-time",
-                                                datetime.time(
+                                                date.Time(
                                                     12,
                                                     0,
                                                     tzinfo=zoneinfo.ZoneInfo(
@@ -71,7 +71,7 @@ now = datetime.datetime.fromisoformat("2012-01-14T20:32:00+00:00")
                                         {
                                             "<=": (
                                                 "current-time",
-                                                datetime.time(
+                                                date.Time(
                                                     23,
                                                     59,
                                                     tzinfo=zoneinfo.ZoneInfo(
@@ -117,7 +117,7 @@ now = datetime.datetime.fromisoformat("2012-01-14T20:32:00+00:00")
                                         {
                                             ">=": (
                                                 "current-time",
-                                                datetime.time(
+                                                date.Time(
                                                     12, 0, tzinfo=datetime.timezone.utc
                                                 ),
                                             )
@@ -125,7 +125,7 @@ now = datetime.datetime.fromisoformat("2012-01-14T20:32:00+00:00")
                                         {
                                             "<=": (
                                                 "current-time",
-                                                datetime.time(
+                                                date.Time(
                                                     23, 59, tzinfo=datetime.timezone.utc
                                                 ),
                                             )
@@ -150,7 +150,7 @@ now = datetime.datetime.fromisoformat("2012-01-14T20:32:00+00:00")
             {
                 ">=": (
                     "current-time",
-                    datetime.time(10, 0, tzinfo=zoneinfo.ZoneInfo("PST8PDT")),
+                    date.Time(10, 0, tzinfo=zoneinfo.ZoneInfo("PST8PDT")),
                 )
             },
         ),
@@ -159,7 +159,7 @@ now = datetime.datetime.fromisoformat("2012-01-14T20:32:00+00:00")
             {
                 ">=": (
                     "current-time",
-                    datetime.time(10, 0, tzinfo=datetime.timezone.utc),
+                    date.Time(10, 0, tzinfo=datetime.timezone.utc),
                 )
             },
         ),
@@ -191,7 +191,7 @@ now = datetime.datetime.fromisoformat("2012-01-14T20:32:00+00:00")
                                     {
                                         ">=": (
                                             "current-time",
-                                            datetime.time(
+                                            date.Time(
                                                 10, 2, tzinfo=datetime.timezone.utc
                                             ),
                                         )
@@ -199,7 +199,7 @@ now = datetime.datetime.fromisoformat("2012-01-14T20:32:00+00:00")
                                     {
                                         "<=": (
                                             "current-time",
-                                            datetime.time(
+                                            date.Time(
                                                 22, 35, tzinfo=datetime.timezone.utc
                                             ),
                                         )
@@ -235,13 +235,13 @@ now = datetime.datetime.fromisoformat("2012-01-14T20:32:00+00:00")
                             {
                                 ">=": (
                                     "current-time",
-                                    datetime.time(10, 2, tzinfo=datetime.timezone.utc),
+                                    date.Time(10, 2, tzinfo=datetime.timezone.utc),
                                 )
                             },
                             {
                                 "<=": (
                                     "current-time",
-                                    datetime.time(22, 35, tzinfo=datetime.timezone.utc),
+                                    date.Time(22, 35, tzinfo=datetime.timezone.utc),
                                 )
                             },
                         )


### PR DESCRIPTION
datetime.time can't be compared if the tzinfo differ.

This patch creates a intermediate representation to build a
datetime.datetime for the comparison.

Fixes MERGIFY-ENGINE-2AE

Change-Id: I5f32c42d2a0b203577f0c934cdc7c308385dd97c
