### PR TITLE
fix(depends-on): make the order predictable

### DIFF
--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -972,18 +972,20 @@ class Context(object):
         re.MULTILINE | re.IGNORECASE,
     )
 
-    def get_depends_on(self) -> typing.Set[github_types.GitHubPullRequestNumber]:
+    def get_depends_on(self) -> typing.List[github_types.GitHubPullRequestNumber]:
         if self.pull["body"] is None:
-            return set()
-        return {
-            github_types.GitHubPullRequestNumber(int(pull))
-            for owner, repo, pull in self.DEPENDS_ON.findall(self.pull["body"])
-            if (owner == "" and repo == "")
-            or (
-                owner == self.pull["base"]["user"]["login"]
-                and repo == self.pull["base"]["repo"]["name"]
-            )
-        }
+            return []
+        return sorted(
+            {
+                github_types.GitHubPullRequestNumber(int(pull))
+                for owner, repo, pull in self.DEPENDS_ON.findall(self.pull["body"])
+                if (owner == "" and repo == "")
+                or (
+                    owner == self.pull["base"]["user"]["login"]
+                    and repo == self.pull["base"]["repo"]["name"]
+                )
+            }
+        )
 
     async def update_pull_check_runs(self, check: github_types.GitHubCheckRun) -> None:
         self._cache["pull_check_runs"] = [

--- a/mergify_engine/tests/functional/test_attributes.py
+++ b/mergify_engine/tests/functional/test_attributes.py
@@ -314,7 +314,7 @@ class TestAttributesWithSub(base.FunctionalTestBase):
         await self.run_engine()
 
         ctxt = await context.Context.create(self.repository_ctxt, pr)
-        assert ctxt.get_depends_on() == {pr1["number"], pr2["number"], 9999999}
+        assert ctxt.get_depends_on() == [pr1["number"], pr2["number"], 9999999]
         assert await ctxt._get_consolidated_data("depends-on") == [f"#{pr2['number']}"]
 
         repo_url = ctxt.pull["base"]["repo"]["html_url"]

--- a/mergify_engine/tests/unit/test_context.py
+++ b/mergify_engine/tests/unit/test_context.py
@@ -491,7 +491,7 @@ footer
     )
 
     ctxt = await context.Context.create(mock.Mock(), pull)
-    assert ctxt.get_depends_on() == {123, 456, 789, 42, 48}
+    assert ctxt.get_depends_on() == [42, 48, 123, 456, 789]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This was creating useless update of the summary just because the set was
not always have the same order.

Change-Id: I5a80a40d0396468975c999430154b4d4512b992a
