### PR TITLE
fix(schedule): drop second and microsecond from date.Time()

### DIFF
--- a/mergify_engine/date.py
+++ b/mergify_engine/date.py
@@ -92,7 +92,13 @@ class Time:
         if isinstance(obj, datetime.datetime):
             return obj
         elif isinstance(obj, Time):
-            return ref.replace(minute=obj.minute, hour=obj.hour, tzinfo=obj.tzinfo)
+            return ref.replace(
+                minute=obj.minute,
+                hour=obj.hour,
+                second=0,
+                microsecond=0,
+                tzinfo=obj.tzinfo,
+            )
         else:
             raise ValueError(f"Unsupport comparaison type: {type(obj)}")
 


### PR DESCRIPTION
date.Time(8, 5) means today at 8:05:00.0, so we must set second
and microsecond to 0 otherwise we got those from utcnow() method.

Change-Id: Ib552a51ed12553330ccad71e94abba8c3dc9a17c
