### PR TITLE
fix(http): use same timeout everywhere

### DIFF
--- a/mergify_engine/clients/github.py
+++ b/mergify_engine/clients/github.py
@@ -347,7 +347,7 @@ class AsyncGithubClient(http.AsyncClient):
         super().__init__(
             base_url=config.GITHUB_API_URL,
             auth=auth,
-            **http.DEFAULT_CLIENT_OPTIONS,  # type: ignore
+            headers={"Accept": "application/vnd.github.machine-man-preview+json"},
         )
 
     def __repr__(self):

--- a/mergify_engine/debug.py
+++ b/mergify_engine/debug.py
@@ -47,7 +47,6 @@ async def get_repositories_setuped(
         headers={
             "Authorization": token,
             "Accept": "application/vnd.github.machine-man-preview+json",
-            "User-Agent": "PyGithub/Python",
         },
     ) as session:
         while True:

--- a/mergify_engine/web/auth.py
+++ b/mergify_engine/web/auth.py
@@ -57,10 +57,9 @@ async def token(request: requests.Request) -> None:
     if authorization:
         if authorization.startswith("token "):
             try:
-                options = http.DEFAULT_CLIENT_OPTIONS.copy()
-                options["headers"]["Authorization"] = authorization  # type: ignore
                 async with http.AsyncClient(
-                    base_url=config.GITHUB_API_URL, **options  # type: ignore
+                    base_url=config.GITHUB_API_URL,
+                    headers={"Authorization": authorization},
                 ) as client:
                     await client.get("/user")
                     return


### PR DESCRIPTION
The dashboard HTTP client uses the default httpx timeout (5 sec) instead
of our custom timeout settings (5 sec for connect and 10 sec for read).

This change moves the default headers/timeout into our AsyncClient base
class so any instantiation will have the correct values.

Fixes MRGFY-589

Change-Id: I5effc27a982fc6d23eea3a4ce34980ab34dae798