### PR TITLE
fix(record): extend record timeout delay to avoid timeout on specific batch tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ setenv =
    MERGIFYENGINE_TEST_SETTINGS=test.env
    MERGIFYENGINE_STORAGE_URL=redis://localhost:6363?db=2
    MERGIFYENGINE_STREAM_URL=redis://localhost:6363?db=3
-   PYTEST_TIMEOUT=300
+   PYTEST_TIMEOUT=500
 whitelist_externals =
     git
 commands =


### PR DESCRIPTION
## Description of the change

Some tests (batch tests) timeout when getting recorded, we should extend the timeout delay to be able to record them fully.

## Related issues



## Checklists

### Development

- [X] All checks must pass (Semantic Pull Request, pep8, requirements, unit tests, functional tests, security checks, …)
- [X] The code changed/added as part of this pull request must be covered with tests
- [X] Hotfixes must have a link to Sentry issue and the ``hotfix`` label
- [x] Features must have a link to a Linear task

### Code Review

Code review policies are handled and automated by Mergify.

* When all tests pass, reviewers will be assigned automatically.
* When change is approved by at least one review and no pending review are
  remaining, pull request is retested against its base branch.
* The pull request is then merged automatically.
