### PR TITLE
fix(branch-protection): remove support for code-owners

### DIFF
--- a/mergify_engine/rules/conditions.py
+++ b/mergify_engine/rules/conditions.py
@@ -447,15 +447,6 @@ async def get_branch_protection_conditions(
                     ),
                 ]
             )
-            if protection["required_pull_request_reviews"][
-                "require_code_owner_reviews"
-            ]:
-                conditions.append(
-                    RuleCondition(
-                        "#review-requested=0",
-                        description="🛡 GitHub branch protection",
-                    )
-                )
     return conditions
 
 


### PR DESCRIPTION
`#review-requested=0` is not a perfect match for CODEOWNERS.

Users are more annoyed by the strict meaning of our version (pull
request not queued, because non CODEOWNERS review are requested) than
seeing the benefice of the issue we are trying to solve.

Change-Id: Ib9e9a61586d4d7683f7a7fe4f23722a274ae1fc9
