### PR TITLE
ci(record): add job test fixture generation

### DIFF
--- a/.github/workflows/ci-record-fixtures.yaml
+++ b/.github/workflows/ci-record-fixtures.yaml
@@ -1,0 +1,29 @@
+name: Continuous Integration, fixtures re-recording
+
+on:
+  workflow_dispatch:
+
+jobs:
+  record:
+    timeout-minutes: 10
+    runs-on: ubuntu-20.04
+    services:
+      redis:
+        image: redis:latest
+        ports:
+          - 6363:6379
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.4
+
+      - name: Setup Python 🔧
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: 3.9.6
+
+      - name: Build 🔧 & Test 🔍
+        run: |
+          cat ${{ secrets.ENGINE_RECORD_TEST_ENV }} > test.env
+          sudo apt install -y redis-server
+          pip install tox
+          tox -e record


### PR DESCRIPTION
Don't yet run it every day, just add a manual trigger for now.

Change-Id: Icf3514a00820532b4433d76e41afeb6f48d60c2e