### PR TITLE
ci(pep8): cap flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,26 @@ test =
     pytest-timeout
     pytest-github-actions-annotate-failures
     vcrpy>=4.1.1
+pep8 =
+    bandit
+    flake8<4
+    flake8-black
+    flake8-blind-except
+    flake8-bugbear
+    flake8-builtins
+    flake8-comprehensions
+    flake8-docstrings
+    flake8-logging-format
+    flake8-rst-docstrings
+    flake8-use-fstring
+    isort
+    mypy>=0.901
+    types-first
+    types-freezegun
+    types-pkg_resources
+    types-PyYAML
+    yamllint
+
 docs =
     sphinx
     sphinxcontrib-spelling

--- a/tox.ini
+++ b/tox.ini
@@ -83,25 +83,9 @@ commands =
   black .
 
 [testenv:pep8]
-deps = flake8
-       flake8-black
-       flake8-blind-except
-       flake8-builtins
-       flake8-bugbear
-       flake8-use-fstring
-       flake8-docstrings
-       flake8-rst-docstrings
-       flake8-logging-format
-       flake8-comprehensions
-       isort
-       mypy>=0.901
-       pytest
-       bandit
-       yamllint
-       types-PyYAML
-       types-first
-       types-freezegun
-       types-pkg_resources
+extras =
+  pep8
+  test
 whitelist_externals =
   bash
 commands =


### PR DESCRIPTION
flake8 4.0.0 is out and break the world, since all our plugins are not
compatible yet, pip tries to download all previous released of all
plugins to see if a very very old is maybe compatible with the just
release lib...

Change-Id: Idbc5e83935c75b333fef9ea21b9fc76f5978a167
