### PR TITLE
fix(http): follow redirect

### DIFF
--- a/mergify_engine/clients/http.py
+++ b/mergify_engine/clients/http.py
@@ -223,6 +223,7 @@ class AsyncClient(httpx.AsyncClient):
             base_url=base_url,
             headers=final_headers,
             timeout=timeout,
+            follow_redirects=True,
         )
 
     @connectivity_issue_retry

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     cryptography
     aredis
     hiredis
-    httpx[http2]>=0.14.0
+    httpx[http2]>=0.20.0
     pyyaml
     voluptuous
     sentry-sdk


### PR DESCRIPTION
Since httpx 0.20.0, following redirect is not the default anymore.

This changes enables it for us.

Fixes MERGIFY-ENGINE-2CT

Change-Id: I7a482635d9600ce3c84258e68d0b39c105218f85
