### PR TITLE
fix(strict): the next version will be 3.0.0

### DIFF
--- a/mergify_engine/engine/actions_runner.py
+++ b/mergify_engine/engine/actions_runner.py
@@ -42,7 +42,7 @@ STRICT_MODE_DEPRECATION_GHES = """
 :bangbang: **Action Required** :bangbang:
 
 > **The configuration uses the deprecated `strict` mode of the merge action.**
-> This option will be removed on version 2.0.0.
+> This option will be removed on version 3.0.0.
 > For more information: https://blog.mergify.io/strict-mode-deprecation/
 
 """


### PR DESCRIPTION
We though the next version will be 1.6.0, but reno choice 2.0.0.
So the removal will be on 3.0.0.

Change-Id: If1832d8cf77020e8110796294c122dfa38b34ffd