### PR TITLE
chore(github): get rid of some attributes

### DIFF
--- a/mergify_engine/clients/http.py
+++ b/mergify_engine/clients/http.py
@@ -122,15 +122,15 @@ class wait_retry_after_header(tenacity.wait.wait_base):
         return max(0, (d - date.utcnow()).total_seconds())
 
 
-def extract_github_extra(client):
-    if client.auth and hasattr(client.auth, "owner_login"):
-        return client.auth.owner_login
+def extract_organization_login(client):
+    if client.auth and hasattr(client.auth, "_owner_login"):
+        return client.auth._owner_login
 
 
 def before_log(retry_state):
     client = retry_state.args[0]
     method = retry_state.args[1]
-    gh_owner = extract_github_extra(client)
+    gh_owner = extract_organization_login(client)
     url = retry_state.args[2]
     LOG.debug(
         "http request starts",
@@ -145,7 +145,7 @@ def after_log(retry_state):
     client = retry_state.args[0]
     method = retry_state.args[1]
     url = retry_state.args[2]
-    gh_owner = extract_github_extra(client)
+    gh_owner = extract_organization_login(client)
     error_message = None
     response = None
     exc_info = None

--- a/mergify_engine/tests/functional/actions/test_squash.py
+++ b/mergify_engine/tests/functional/actions/test_squash.py
@@ -52,16 +52,13 @@ class TestActionSquash(base.FunctionalTestBase):
 
         await self.git("push", "--quiet", repo_name, branch_name)
 
-        client = self.client_fork
-        owner_login = self.client_fork.auth.owner_login
-
         # create a PR with several commits to squash
         pr = (
-            await client.post(
+            await self.client_fork.post(
                 f"{self.url_origin}/pulls",
                 json={
                     "base": self.main_branch_name,
-                    "head": f"{owner_login}:{branch_name}",
+                    "head": f"mergify-test2:{branch_name}",
                     "title": "squash the PR",
                     "body": """This is a squash_test
 
@@ -85,7 +82,7 @@ Awesome body
         await self.wait_for("pull_request", {"action": "synchronize"})
 
         # get the PR
-        pr = await client.item(f"{self.url_origin}/pulls/{pr['number']}")
+        pr = await self.client_fork.item(f"{self.url_origin}/pulls/{pr['number']}")
         assert pr["commits"] == 1
 
         ctxt = await context.Context.create(self.repository_ctxt, pr, [])

--- a/mergify_engine/tests/functional/base.py
+++ b/mergify_engine/tests/functional/base.py
@@ -471,19 +471,11 @@ class FunctionalTestBase(unittest.IsolatedAsyncioTestCase):
         self.client_admin = github.AsyncGithubInstallationClient(
             auth=github.GithubTokenAuth(
                 token=config.ORG_ADMIN_PERSONAL_TOKEN,
-                owner_id=github_types.GitHubAccountIdType(
-                    config.TESTING_MERGIFY_TEST_1_ID
-                ),
-                owner_login=github_types.GitHubLogin("mergify-test1"),
             )
         )
         self.client_fork = github.AsyncGithubInstallationClient(
             auth=github.GithubTokenAuth(
                 token=self.FORK_PERSONAL_TOKEN,
-                owner_id=github_types.GitHubAccountIdType(
-                    config.TESTING_MERGIFY_TEST_2_ID
-                ),
-                owner_login=github_types.GitHubLogin("mergify-test2"),
             )
         )
         self.addAsyncCleanup(self.client_integration.aclose)
@@ -492,17 +484,15 @@ class FunctionalTestBase(unittest.IsolatedAsyncioTestCase):
 
         await self.client_admin.item("/user")
         await self.client_fork.item("/user")
-        assert self.client_admin.auth.owner_login == "mergify-test1"
-        assert self.client_fork.auth.owner_login == "mergify-test2"
-        assert self.client_admin.auth.owner_id == config.TESTING_MERGIFY_TEST_1_ID
-        assert self.client_fork.auth.owner_id == config.TESTING_MERGIFY_TEST_2_ID
 
         self.url_origin = (
             f"/repos/mergifyio-testing/{self.RECORD_CONFIG['repository_name']}"
         )
-        self.url_fork = f"/repos/{self.client_fork.auth.owner_login}/{self.RECORD_CONFIG['repository_name']}"
+        self.url_fork = f"/repos/mergify-test2/{self.RECORD_CONFIG['repository_name']}"
         self.git_origin = f"{config.GITHUB_URL}/mergifyio-testing/{self.RECORD_CONFIG['repository_name']}"
-        self.git_fork = f"{config.GITHUB_URL}/{self.client_fork.auth.owner_login}/{self.RECORD_CONFIG['repository_name']}"
+        self.git_fork = (
+            f"{config.GITHUB_URL}/mergify-test2/{self.RECORD_CONFIG['repository_name']}"
+        )
 
         self.installation_ctxt = context.Installation(
             config.TESTING_ORGANIZATION_ID,
@@ -689,7 +679,7 @@ class FunctionalTestBase(unittest.IsolatedAsyncioTestCase):
         await self.git.add_cred(
             self.FORK_PERSONAL_TOKEN,
             "",
-            f"{self.client_fork.auth.owner_login}/{self.RECORD_CONFIG['repository_name']}",
+            f"mergify-test2/{self.RECORD_CONFIG['repository_name']}",
         )
         await self.git("config", "user.name", f"{config.CONTEXT}-tester")
         await self.git("remote", "add", "origin", self.git_origin)
@@ -834,7 +824,7 @@ class FunctionalTestBase(unittest.IsolatedAsyncioTestCase):
 
         if base_repo == "fork":
             client = self.client_fork
-            login = self.client_fork.auth.owner_login
+            login = github_types.GitHubLogin("mergifyi-test2")
         else:
             client = self.client_admin
             login = github_types.GitHubLogin("mergifyio-testing")

--- a/mergify_engine/tests/functional/commands/test_squash.py
+++ b/mergify_engine/tests/functional/commands/test_squash.py
@@ -39,16 +39,13 @@ class TestCommandSquash(base.FunctionalTestBase):
 
         await self.git("push", "--quiet", repo_name, branch_name)
 
-        client = self.client_fork
-        owner_login = self.client_fork.auth.owner_login
-
         # create a PR with several commits to squash
         pr = (
-            await client.post(
+            await self.client_fork.post(
                 f"{self.url_origin}/pulls",
                 json={
                     "base": self.main_branch_name,
-                    "head": f"{owner_login}:{branch_name}",
+                    "head": f"mergify-test2:{branch_name}",
                     "title": "squash the PR",
                     "body": "This is a squash_test",
                     "draft": False,
@@ -69,7 +66,7 @@ class TestCommandSquash(base.FunctionalTestBase):
         await self.wait_for("pull_request", {"action": "synchronize"})
 
         # get the PR
-        pr = await client.item(f"{self.url_origin}/pulls/{pr['number']}")
+        pr = await self.client_fork.item(f"{self.url_origin}/pulls/{pr['number']}")
         assert pr["commits"] == 1
 
     async def test_squash_several_commits_with_one_merge_commit_and_custom_message(
@@ -110,14 +107,11 @@ class TestCommandSquash(base.FunctionalTestBase):
 
         await self.git("push", "--quiet", repo_name, branch_name2)
 
-        client = self.client_fork
-        owner_login = self.client_fork.auth.owner_login
-
         # create a merge between this 2 branches
-        await client.post(
+        await self.client_fork.post(
             f"{self.url_fork}/merges",
             json={
-                "owner": owner_login,
+                "owner": "mergify-test2",
                 "repo": self.RECORD_CONFIG["repository_name"],
                 "base": branch_name1,
                 "head": branch_name2,
@@ -126,11 +120,11 @@ class TestCommandSquash(base.FunctionalTestBase):
 
         # create a new PR between main & fork
         pr = (
-            await client.post(
+            await self.client_fork.post(
                 f"{self.url_origin}/pulls",
                 json={
                     "base": self.main_branch_name,
-                    "head": f"{owner_login}:{branch_name1}",
+                    "head": f"mergify-test2:{branch_name1}",
                     "title": "squash the PR",
                     "body": """This is a squash_test
 
@@ -157,7 +151,7 @@ Awesome body
         # wait after the update & get the PR
         await self.wait_for("pull_request", {"action": "synchronize"})
 
-        pr = await client.item(f"{self.url_origin}/pulls/{pr['number']}")
+        pr = await self.client_fork.item(f"{self.url_origin}/pulls/{pr['number']}")
         assert pr["commits"] == 1
 
         ctxt = await context.Context.create(self.repository_ctxt, pr, [])
@@ -202,14 +196,11 @@ Awesome body
 
         await self.git("push", "--quiet", repo_name, branch_name2)
 
-        client = self.client_fork
-        owner_login = self.client_fork.auth.owner_login
-
         # create a merge between this 2 branches
-        await client.post(
+        await self.client_fork.post(
             f"{self.url_fork}/merges",
             json={
-                "owner": owner_login,
+                "owner": "mergify-test2",
                 "repo": self.RECORD_CONFIG["repository_name"],
                 "base": branch_name1,
                 "head": branch_name2,
@@ -233,10 +224,10 @@ Awesome body
         await self.git("push", "--quiet", repo_name, branch_name3)
 
         # create a PR between this branche n3 & n1
-        await client.post(
+        await self.client_fork.post(
             f"{self.url_fork}/merges",
             json={
-                "owner": owner_login,
+                "owner": "mergify-test2",
                 "repo": self.RECORD_CONFIG["repository_name"],
                 "base": branch_name1,
                 "head": branch_name3,
@@ -245,11 +236,11 @@ Awesome body
 
         # create a new PR between main & fork
         pr = (
-            await client.post(
+            await self.client_fork.post(
                 f"{self.url_origin}/pulls",
                 json={
                     "base": self.main_branch_name,
-                    "head": f"{owner_login}:{branch_name1}",
+                    "head": f"mergify-test2:{branch_name1}",
                     "title": "squash the PR",
                     "body": "This is a squash_test",
                     "draft": False,
@@ -270,5 +261,5 @@ Awesome body
         # wait after the update & get the PR
         await self.wait_for("pull_request", {"action": "synchronize"})
 
-        pr = await client.item(f"{self.url_origin}/pulls/{pr['number']}")
+        pr = await self.client_fork.item(f"{self.url_origin}/pulls/{pr['number']}")
         assert pr["commits"] == 1

--- a/mergify_engine/tests/functional/test_count_seats.py
+++ b/mergify_engine/tests/functional/test_count_seats.py
@@ -95,20 +95,14 @@ class TestCountSeats(base.FunctionalTestBase):
             )
         ]
 
-        if self.client_admin.auth.owner_id is None:
-            raise RuntimeError("client_admin owner_id is None")
-        if self.client_fork.auth.owner_id is None:
-            raise RuntimeError("client_fork owner_id is None")
-        if self.client_admin.auth.owner_login is None:
-            raise RuntimeError("client_admin owner is None")
-        if self.client_fork.auth.owner_login is None:
-            raise RuntimeError("client_fork owner is None")
         repository["active_users"] = {
             count_seats.ActiveUser(
-                self.client_admin.auth.owner_id, self.client_admin.auth.owner_login
+                github_types.GitHubAccountIdType(config.TESTING_MERGIFY_TEST_1_ID),
+                github_types.GitHubLogin("mergify-test1"),
             ),
             count_seats.ActiveUser(
-                self.client_fork.auth.owner_id, self.client_fork.auth.owner_login
+                github_types.GitHubAccountIdType(config.TESTING_MERGIFY_TEST_2_ID),
+                github_types.GitHubLogin("mergify-test2"),
             ),
         }
         return count_seats.Seats(collaborators)
@@ -163,12 +157,6 @@ class TestCountSeats(base.FunctionalTestBase):
         user_admin, timestamp_admin = active_users[0]
         user_fork, timestamp_fork = active_users[1]
         assert timestamp_admin <= now and timestamp_admin > now - 60
-        assert (
-            user_admin
-            == f"{self.client_admin.auth.owner_id}~{self.client_admin.auth.owner}"
-        )
+        assert user_admin == f"{config.TESTING_MERGIFY_TEST_1_ID}~mergify-test1"
         assert timestamp_fork <= now and timestamp_fork > now - 60
-        assert (
-            user_fork
-            == f"{self.client_fork.auth.owner_id}~{self.client_fork.auth.owner}"
-        )
+        assert user_fork == f"{config.TESTING_MERGIFY_TEST_2_ID}~mergify-test2"

--- a/mergify_engine/tests/unit/rules/test_rules.py
+++ b/mergify_engine/tests/unit/rules/test_rules.py
@@ -552,7 +552,6 @@ async def test_get_mergify_config_location_from_cache(
     redis_cache: utils.RedisCache,
 ) -> None:
     client = mock.AsyncMock()
-    client.auth.owner = "foo"
     client.item.side_effect = [
         http.HTTPNotFound("Not Found", request=mock.Mock(), response=mock.Mock()),
         http.HTTPNotFound("Not Found", request=mock.Mock(), response=mock.Mock()),

--- a/mergify_engine/tests/unit/test_clients.py
+++ b/mergify_engine/tests/unit/test_clients.py
@@ -71,8 +71,9 @@ async def test_client_installation_token_with_owner_id(
         ) as client:
             ret = await client.get(httpserver.url_for("/"))
             assert ret.json()["work"]
-            assert client.auth.owner_login == "testing"
-            assert client.auth.owner_id == 12345
+            assert client.auth.installation is not None
+            assert client.auth.installation["account"]["login"] == "testing"
+            assert client.auth.installation["account"]["id"] == 12345
 
     assert len(httpserver.log) == 3
 

--- a/mergify_engine/web/root.py
+++ b/mergify_engine/web/root.py
@@ -330,9 +330,7 @@ async def queues(
     token = request.headers.get("Authorization")
     if token:
         token = token[6:]  # Drop 'token '
-        installation_json = await github.get_installation_from_account_id(owner_id)
-        owner_login = installation_json["account"]["login"]
-        auth = github.GithubTokenAuth(token, owner_id, owner_login)
+        auth = github.GithubTokenAuth(token)
         async with github.AsyncGithubInstallationClient(auth=auth) as client:
             # Check this token as access to this organization
             try:

--- a/mergify_engine/web/simulator.py
+++ b/mergify_engine/web/simulator.py
@@ -117,7 +117,7 @@ async def _simulator(
         installation_json = await github.get_installation_from_login(owner_login)
         owner_id = installation_json["account"]["id"]
         if token:
-            auth = github.GithubTokenAuth(token, owner_id, owner_login)
+            auth = github.GithubTokenAuth(token)
         else:
             auth = github.GithubAppInstallationAuth(installation_json)
 


### PR DESCRIPTION
owner_id/owner_login are confused depending on the used auth, it could
be the organization an used acts on behalf or the owner of the
oauth token.

This change removes them, all code that requires it get the value from
another source.

Change-Id: I3c61eca90f7966c406163a6e7c15fbf83d60dcc7