### PR TITLE
ci(pep8): ensure mergify is importable

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -93,6 +93,7 @@ commands =
   mypy
   bandit -r mergify_engine mergify_engine_signals -x mergify_engine/tests
   yamllint .
+  mergify-import-check
   bash tools/check-obsolete-fixtures.sh
 
 [testenv:docs]


### PR DESCRIPTION
We ensure mergify_engine is importable before collecting the list of
tests to avoid weird errors that list that all zfixtures need to be
deleted.

Change-Id: Idd9a63540196cefab69c652b0e2ef3f697e570b6