### PR TITLE
fix(tests): typo in fork user login

### DIFF
--- a/mergify_engine/tests/functional/base.py
+++ b/mergify_engine/tests/functional/base.py
@@ -824,7 +824,7 @@ class FunctionalTestBase(unittest.IsolatedAsyncioTestCase):
 
         if base_repo == "fork":
             client = self.client_fork
-            login = github_types.GitHubLogin("mergifyi-test2")
+            login = github_types.GitHubLogin("mergify-test2")
         else:
             client = self.client_admin
             login = github_types.GitHubLogin("mergifyio-testing")


### PR DESCRIPTION
The typo breaks recording.

Change-Id: I8f4c2deac52fe0fdf7b2c82e2f584996839b9e28