### PR TITLE
refactor(tests): convert some fixture into pytest format

### DIFF
--- a/mergify_engine/tests/functional/test_fixtures.py
+++ b/mergify_engine/tests/functional/test_fixtures.py
@@ -1,0 +1,48 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright © 2021 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+import httpx
+import pytest
+
+from mergify_engine import config
+from mergify_engine.clients import github
+from mergify_engine.clients import github_app
+from mergify_engine.dashboard import subscription
+from mergify_engine.tests.functional import conftest as func_conftest
+
+
+@pytest.mark.asyncio
+async def test_fixture_mergify_web_client(
+    mergify_web_client: httpx.AsyncClient,
+) -> None:
+    r = await mergify_web_client.get("/foobar")
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.recorder
+async def test_fixture_recorder() -> None:
+    async with github.AsyncGithubClient(auth=github_app.GithubBearerAuth()) as client:
+        r = await client.get("/app")
+        assert r.status_code == 200
+        assert r.json()["owner"]["id"] == config.TESTING_ORGANIZATION_ID
+        assert r.json()["owner"]["login"] == config.TESTING_ORGANIZATION_NAME
+
+
+@pytest.mark.asyncio
+async def test_fixture_dashboard(dashboard: func_conftest.DashboardFixture) -> None:
+    assert dashboard.subscription.features == frozenset(
+        {subscription.Features.PUBLIC_REPOSITORY}
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -131,3 +131,9 @@ no_implicit_optional = true
 disallow_untyped_decorators = true
 show_error_codes = true
 disallow_untyped_calls = true
+
+[tool:pytest]
+addopts = --strict-markers
+markers =
+  recorder
+  subscription

--- a/tools/check-obsolete-fixtures.sh
+++ b/tools/check-obsolete-fixtures.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-TESTS="$(pytest --collect-only | sed -n -e '/TestCaseFunction/s/.* \([^ >]*\)>.*/\1/gp')"
+TESTS="$(pytest --collect-only | sed -n -e '/\(TestCaseFunction\|Function\)/s/.* \([^ >]*\)>.*/\1/gp')"
 ret=0
-for f in $(ls -d1 zfixtures/cassettes/*/* | awk -F/ '{print $4}' ); do
+for f in $(find zfixtures -name config.json | sed -n -e 's/.*\/\([^/]*\)\/config.json/\1/gp'); do
     used=$(echo -e "$TESTS" | grep "^$f\$")
     if [ ! "$used" ]; then
         if [ "$ret" -eq 0 ] ; then

--- a/zfixtures/cassettes/test_fixtures/test_fixture_recorder/config.json
+++ b/zfixtures/cassettes/test_fixtures/test_fixture_recorder/config.json
@@ -1,0 +1,1 @@
+{"organization_id": 40527191, "organization_name": "mergifyio-testing", "repository_id": 258840104, "repository_name": "functional-testing-repo", "branch_prefix": "20211027152313"}

--- a/zfixtures/cassettes/test_fixtures/test_fixture_recorder/http.json
+++ b/zfixtures/cassettes/test_fixtures/test_fixture_recorder/http.json
@@ -1,0 +1,25 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - application/vnd.github.machine-man-preview+json
+      host:
+      - api.github.com
+    method: GET
+    uri: https://api.github.com/app
+  response:
+    content: '{"id":11221,"slug":"mergify-test","node_id":"MDM6QXBwMTEyMjE=","owner":{"login":"mergifyio-testing","id":40527191,"node_id":"MDEyOk9yZ2FuaXphdGlvbjQwNTI3MTkx","avatar_url":"https://avatars.githubusercontent.com/u/40527191?v=4","gravatar_id":"","url":"https://api.github.com/users/mergifyio-testing","html_url":"https://github.com/mergifyio-testing","followers_url":"https://api.github.com/users/mergifyio-testing/followers","following_url":"https://api.github.com/users/mergifyio-testing/following{/other_user}","gists_url":"https://api.github.com/users/mergifyio-testing/gists{/gist_id}","starred_url":"https://api.github.com/users/mergifyio-testing/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/mergifyio-testing/subscriptions","organizations_url":"https://api.github.com/users/mergifyio-testing/orgs","repos_url":"https://api.github.com/users/mergifyio-testing/repos","events_url":"https://api.github.com/users/mergifyio-testing/events{/privacy}","received_events_url":"https://api.github.com/users/mergifyio-testing/received_events","type":"Organization","site_admin":false},"name":"Mergify-test","description":"Test
+      version of Mergify.","external_url":"https://mergify.io","html_url":"https://github.com/apps/mergify-test","created_at":"2018-04-18T13:55:11Z","updated_at":"2021-03-15T16:12:09Z","permissions":{"administration":"read","checks":"write","contents":"write","emails":"read","issues":"write","members":"read","metadata":"read","pages":"write","pull_requests":"write","statuses":"read","workflows":"write"},"events":["check_run","check_suite","issue_comment","merge_queue_entry","pull_request","pull_request_review","pull_request_review_comment","push","status"],"installations_count":1}'
+    headers:
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-GitHub-Media-Type:
+      - github.v3; param=machine-man-preview; format=json
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1


### PR DESCRIPTION
This will allow to use recorder via:

```
@pytest.mark.asyncio
@pytest.mark.recorder
async def test_code(mergify_api_client, dashboard):
    assert dashboard.subscription.features == ...
    assert dashboard.user_tokens.select_for_user(...) == ...
    resp = await mergify_api_client.get(...)
```
