### PR TITLE
fix(commands): don't display empty details

### DIFF
--- a/mergify_engine/engine/commands_runner.py
+++ b/mergify_engine/engine/commands_runner.py
@@ -243,17 +243,18 @@ async def run_command(
         "command": command_full,
         "conclusion": result.conclusion.value,
     }
+    details = ""
+    if result.summary:
+        details = f"<details>\n\n{result.summary}\n\n</details>\n"
+
     return (
         result,
         f"""> {command_full}
 
 #### {result.conclusion.emoji} {result.title}
 
-<details>
+{details}
 
-{result.summary}
-
-</details>
 <!--
 DO NOT EDIT
 -*- Mergify Payload -*-


### PR DESCRIPTION
GitHub displays empty details, so we should avoid this.

MRGFY-666