### PR TITLE
fix(dictionnary): adding all words not recognized by fedora 34

### DIFF
--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -29,3 +29,12 @@ templating
 wasn
 th
 queueing
+workflow
+workflows
+checkbox
+username
+logins
+Timestamp
+timestamp
+Timestamps
+startup


### PR DESCRIPTION
Aspell and Hunspell have some conflicts regarding some words spelling. It causes different versions of Os to find new words being 'misspelled'.

Fixes MRGFY-667

### Development

- [X] All checks must pass (Semantic Pull Request, pep8, requirements, unit tests, functional tests, security checks, …)
- [ ] The code changed/added as part of this pull request must be covered with tests
- [X] Hotfixes must have a link to Sentry issue and the ``hotfix`` label
- [X] Features must have a link to a Linear task

### Code Review

Code review policies are handled and automated by Mergify.

* When all tests pass, reviewers will be assigned automatically.
* When change is approved by at least one review and no pending review are
  remaining, pull request is retested against its base branch.
* The pull request is then merged automatically.
