### PR TITLE
feat(api): put version in API url

### DIFF
--- a/mergify_engine/tests/functional/actions/test_queue.py
+++ b/mergify_engine/tests/functional/actions/test_queue.py
@@ -2139,7 +2139,7 @@ DO NOT EDIT
 
         # Queue API with token
         r = await self.app.get(
-            f"/api/repos/{config.TESTING_ORGANIZATION_NAME}/{config.TESTING_REPOSITORY_NAME}/queues",
+            f"/v1/repos/{config.TESTING_ORGANIZATION_NAME}/{config.TESTING_REPOSITORY_NAME}/queues",
             headers={
                 "Authorization": f"bearer {self.api_key_admin}",
                 "Content-type": "application/json",

--- a/mergify_engine/tests/functional/api/test_auth.py
+++ b/mergify_engine/tests/functional/api/test_auth.py
@@ -60,7 +60,7 @@ async def test_api_auth_unknown_path(
     mergify_web_client: httpx.AsyncClient,
 ) -> None:
     # Default
-    r = await mergify_web_client.get("/api/foobar")
+    r = await mergify_web_client.get("/v1/foobar")
     assert r.status_code == 404
     assert r.json() == {"detail": "Not Found"}
 
@@ -72,14 +72,14 @@ async def test_api_auth(
     dashboard: func_conftest.DashboardFixture,
 ) -> None:
     r = await mergify_web_client.get(
-        "/api/testing-endpoint-with-default-dep",
+        "/v1/testing-endpoint-with-default-dep",
         headers={"Authorization": f"bearer {dashboard.api_key_admin}"},
     )
     assert r.status_code == 200, r.json()
     assert r.json()["user_login"] == "foobar"
 
     r = await mergify_web_client.get(
-        "/api/testing-endpoint-with-explicit-dep",
+        "/v1/testing-endpoint-with-explicit-dep",
         headers={"Authorization": f"bearer {dashboard.api_key_admin}"},
     )
     assert r.status_code == 200, r.json()
@@ -94,13 +94,13 @@ async def test_api_auth_invalid_token(
 ) -> None:
     # invalid header
     r = await mergify_web_client.get(
-        "/api/testing-endpoint-with-default-dep",
+        "/v1/testing-endpoint-with-default-dep",
         headers={"Authorization": "whatever"},
     )
     assert r.status_code == 403
     assert r.json() == {"detail": "Not authenticated"}
     r = await mergify_web_client.get(
-        "/api/testing-endpoint-with-explicit-dep",
+        "/v1/testing-endpoint-with-explicit-dep",
         headers={"Authorization": "whatever"},
     )
     assert r.status_code == 403
@@ -108,13 +108,13 @@ async def test_api_auth_invalid_token(
 
     # invalid token too short
     r = await mergify_web_client.get(
-        "/api/testing-endpoint-with-default-dep",
+        "/v1/testing-endpoint-with-default-dep",
         headers={"Authorization": "bearer whatever"},
     )
     assert r.status_code == 403
     assert r.json() == {"detail": "Forbidden"}
     r = await mergify_web_client.get(
-        "/api/testing-endpoint-with-explicit-dep",
+        "/v1/testing-endpoint-with-explicit-dep",
         headers={"Authorization": "bearer whatever"},
     )
     assert r.status_code == 403
@@ -123,18 +123,18 @@ async def test_api_auth_invalid_token(
     # invalid token good size
     invalid_token = "6" * 64
     r = await mergify_web_client.get(
-        "/api/foobar/", headers={"Authorization": f"bearer {invalid_token}"}
+        "/v1/foobar/", headers={"Authorization": f"bearer {invalid_token}"}
     )
     assert r.status_code == 404
     assert r.json() == {"detail": "Not Found"}
     r = await mergify_web_client.get(
-        "/api/testing-endpoint-with-default-dep",
+        "/v1/testing-endpoint-with-default-dep",
         headers={"Authorization": f"bearer {invalid_token}"},
     )
     assert r.status_code == 403
     assert r.json() == {"detail": "Forbidden"}
     r = await mergify_web_client.get(
-        "/api/testing-endpoint-with-explicit-dep",
+        "/v1/testing-endpoint-with-explicit-dep",
         headers={"Authorization": f"bearer {invalid_token}"},
     )
     assert r.status_code == 403
@@ -146,9 +146,9 @@ async def test_api_auth_no_token(
     mergify_web_client: httpx.AsyncClient,
     dashboard: func_conftest.DashboardFixture,
 ) -> None:
-    r = await mergify_web_client.get("/api/testing-endpoint-with-default-dep")
+    r = await mergify_web_client.get("/v1/testing-endpoint-with-default-dep")
     assert r.status_code == 403
     assert r.json() == {"detail": "Not authenticated"}
-    r = await mergify_web_client.get("/api/testing-endpoint-with-explicit-dep")
+    r = await mergify_web_client.get("/v1/testing-endpoint-with-explicit-dep")
     assert r.status_code == 403
     assert r.json() == {"detail": "Not authenticated"}

--- a/mergify_engine/web/api/root.py
+++ b/mergify_engine/web/api/root.py
@@ -48,7 +48,7 @@ def api_enabled() -> None:
 app = fastapi.FastAPI(
     title="Mergify API",
     description="Faster & safer code merge",
-    vesion="1.0",
+    version="v1",
     terms_of_service="https://mergify.io/tos",
     contact={
         "name": "Mergify",
@@ -64,7 +64,7 @@ app = fastapi.FastAPI(
             "description": "Operations with queues.",
         },
     ],
-    servers=[{"url": "https://api.mergify.com/api", "description": "default"}],
+    servers=[{"url": "https://api.mergify.com/v1", "description": "default"}],
     # NOTE(sileht): Ensure endpoints requires a valid token even if they don't
     # use the GitHub API
     dependencies=[

--- a/mergify_engine/web/root.py
+++ b/mergify_engine/web/root.py
@@ -52,7 +52,7 @@ app = fastapi.FastAPI()
 app.mount("/simulator", simulator.app)
 app.mount("/validate", config_validator.app)
 app.mount("/badges", badges.app)
-app.mount("/api", root.app)
+app.mount("/v1", root.app)
 
 # Set the maximum timeout to 5 seconds: GitHub is not going to wait for
 # more than 10 seconds for us to accept an event, so if we're unable to


### PR DESCRIPTION
The final url looks better.
We don't need to rewrite url, just the domain.
It's good practice to have major api version in the url path.