### PR TITLE
fix(delete_head_branch): don't catch 422

### DIFF
--- a/mergify_engine/actions/delete_head_branch.py
+++ b/mergify_engine/actions/delete_head_branch.py
@@ -75,7 +75,7 @@ class DeleteHeadBranchAction(actions.Action):
         try:
             await ctxt.client.delete(f"{ctxt.base_url}/git/refs/heads/{ref_to_delete}")
         except http.HTTPClientSideError as e:
-            if e.status_code in [422, 404]:
+            if e.status_code == 404:
                 return check_api.Result(
                     check_api.Conclusion.SUCCESS,
                     f"Branch `{ctxt.pull['head']['ref']}` does not exists",


### PR DESCRIPTION
I remember some 422 are like 404, but not all. Since we didn't put the
detail, return an error in case of 422.

For example, protected branch may return a 422, and this should be
reported to the used.