### PR TITLE
fix(queue): use hash to store trains

### DIFF
--- a/mergify_engine/tests/unit/test_worker.py
+++ b/mergify_engine/tests/unit/test_worker.py
@@ -1190,3 +1190,47 @@ async def test_worker_stuck_shutdown(
         {"payload": "whatever"},
     )
     await run_worker(test_timeout=2, shutdown_timeout=1)
+
+
+@pytest.mark.asyncio
+@mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
+@mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
+@mock.patch("mergify_engine.worker.run_engine")
+async def test_worker_migrate_train(
+    run_engine,
+    get_installation_from_account_id,
+    _,
+    redis_stream,
+    redis_cache,
+    logger_checker,
+):
+    get_installation_from_account_id.side_effect = fake_get_installation_from_account_id
+
+    assert not await redis_cache.exists("MERGE_TRAIN_MIGRATION_DONE")
+    expected_trains = {}
+    for owner_id in (123456, 424242, 789789):
+        expected_trains.setdefault(owner_id, {})
+        for i in range(1, 3):
+            for ref in ("main", "stable"):
+                repo_id = owner_id + i
+                expected_trains[owner_id][f"{repo_id}~{ref}"] = "some-data"
+                await redis_cache.set(
+                    f"merge-train~{owner_id}~{repo_id}~{ref}", "some-data"
+                )
+
+    await run_worker()
+
+    assert await redis_cache.exists("MERGE_TRAIN_MIGRATION_DONE")
+
+    old_trains = sorted(await redis_cache.keys("merge-train~*"))
+    assert old_trains == []
+    trains = sorted(await redis_cache.keys("merge-trains~*"))
+    assert trains == [
+        "merge-trains~123456",
+        "merge-trains~424242",
+        "merge-trains~789789",
+    ]
+
+    for train in trains:
+        owner_id = int(train[13:])
+        assert await redis_cache.hgetall(train) == expected_trains[owner_id]

--- a/mergify_engine/web/api/queues.py
+++ b/mergify_engine/web/api/queues.py
@@ -213,8 +213,6 @@ async def repository_queues(
         queues = Queues()
 
         async for train in merge_train.Train.iter_trains(installation, repository_ctxt):
-            await train.load()
-
             queue_rules = await train.get_queue_rules()
             if queue_rules is None:
                 # The train is going the be deleted, so skip it.

--- a/releasenotes/notes/queue-storage-change-4f8d1b26eaf9e266.yaml
+++ b/releasenotes/notes/queue-storage-change-4f8d1b26eaf9e266.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    The merge-queue data format stored in redis has changed. The migration is
+    done automatically on first startup of version 3.X and must be done before
+    updating to 4.X.


### PR DESCRIPTION
Instead of having one key per trains, this change uses a hash per
organization and then one key per repo_id/ref.

Since we use iter_trains() more often than before this should load train
faster that before.

Also compared to SCAN, HSCAN also load values, so we also remove one
round-trip to retrieve the data.

Fixes MRGFY-714
