### PR TITLE
fix(action-runner): retry event on redis OOM

### DIFF
--- a/mergify_engine/exceptions.py
+++ b/mergify_engine/exceptions.py
@@ -106,7 +106,12 @@ def need_retry(
         elif exception.response.status_code == 403:
             return datetime.timedelta(minutes=3)
 
+    elif isinstance(exception, yaaredis.exceptions.ResponseError):
+        # Redis script bug or OOM
+        return datetime.timedelta(minutes=1)
+
     elif isinstance(exception, yaaredis.exceptions.ConnectionError):
+        # Redis down
         return datetime.timedelta(minutes=1)
 
     return None


### PR DESCRIPTION
yaaredis.exceptions.ResponseError was reported as failure in some
actions instead of been retried.

For queue action, this has marked the merge as failure, but because of
the OOM, the train was not updated...

This change will be retried like when Redis is down, to not report false
status on actions.
