### PR TITLE
fix(queue/rules): handle correctly when we use negative check conditions

### DIFF
--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -1088,6 +1088,19 @@ class Context(object):
                 for ctext, state in (await self.checks).items()
                 if state == "stale"
             ]
+        elif name.startswith("potential-check"):
+            # NOTE(sileht): This include pending into all other checks
+            return list(
+                set(
+                    typing.cast(
+                        typing.List[str], await self._get_consolidated_data(name[6:])
+                    )
+                    + typing.cast(
+                        typing.List[str],
+                        await self._get_consolidated_data("check-pending"),
+                    )
+                )
+            )
         elif name == "depends-on":
             # TODO(sileht):  This is the list of merged pull requests that are
             # required by this pull request. An optimisation can be to look at
@@ -1607,16 +1620,16 @@ class PullRequest(BasePullRequest):
         "dismissed-reviews-by",
         "changes-requested-reviews-by",
         "commented-reviews-by",
-        "check-success",
         "check-success-or-neutral",
+        "check-success",
         "check-failure",
         "check-neutral",
-        "status-success",
-        "status-failure",
-        "status-neutral",
         "check-skipped",
         "check-pending",
         "check-stale",
+        "status-success",
+        "status-failure",
+        "status-neutral",
         "commits",
         "commits-behind",
         "commits-unverified",
@@ -1761,18 +1774,6 @@ class QueuePullRequest(BasePullRequest):
     # always the same within the same batch
     QUEUE_ATTRIBUTES = (
         "base",
-        "status-success",
-        "status-failure",
-        "status-neutral",
-        "check",
-        "check-success",
-        "check-success-or-neutral",
-        "check-success-or-neutral-or-pending",
-        "check-failure",
-        "check-neutral",
-        "check-skipped",
-        "check-pending",
-        "check-stale",
         "current-time",
         "current-day",
         "current-month",
@@ -1780,6 +1781,28 @@ class QueuePullRequest(BasePullRequest):
         "current-day-of-week",
         "current-timestamp",
         "schedule",
+        "status-success",
+        "status-failure",
+        "status-neutral",
+        "check",
+        "check-success-or-neutral",
+        "check-success-or-neutral-or-pending",
+        "check-success",
+        "check-failure",
+        "check-neutral",
+        "check-skipped",
+        "check-pending",
+        "check-stale",
+        # used only by get_rule_checks_status()
+        "potential-check",
+        "potential-check-success-or-neutral",
+        "potential-check-success-or-neutral-or-pending",
+        "potential-check-success",
+        "potential-check-failure",
+        "potential-check-neutral",
+        "potential-check-skipped",
+        "potential-check-pending",
+        "potential-check-stale",
     )
 
     async def __getattr__(self, name: str) -> ContextAttributeType:

--- a/mergify_engine/rules/conditions.py
+++ b/mergify_engine/rules/conditions.py
@@ -69,6 +69,15 @@ class RuleCondition:
                 error_message=str(e),
             )
 
+    def add_negate(self) -> None:
+        tree = typing.cast(filter.TreeT, self.partial_filter.tree)
+        if "-" not in tree:
+            self.update(typing.cast(FakeTreeT, {"-": tree}))
+
+    def drop_negate(self) -> None:
+        tree = typing.cast(filter.TreeT, self.partial_filter.tree)
+        self.update(typing.cast(FakeTreeT, tree.get("-", tree)))
+
     def update_attribute_name(self, new_name: str) -> None:
         tree = typing.cast(filter.TreeT, self.partial_filter.tree)
         negate = "-" in tree

--- a/mergify_engine/tests/unit/rules/test_rules.py
+++ b/mergify_engine/tests/unit/rules/test_rules.py
@@ -77,6 +77,19 @@ class FakeQueuePullRequest:
         fancy_name = name.replace("_", "-")
         return self.attrs[fancy_name]
 
+    def sync_checks(self) -> None:
+        self.attrs["check-success-or-neutral-or-pending"] = (
+            self.attrs.get("check-success", [])  # type: ignore
+            + self.attrs.get("check-neutral", [])  # type: ignore
+            + self.attrs.get("check-pending", [])  # type: ignore
+        )
+        self.attrs["check"] = (
+            self.attrs.get("check-success", [])  # type: ignore
+            + self.attrs.get("check-neutral", [])  # type: ignore
+            + self.attrs.get("check-pending", [])  # type: ignore
+            + self.attrs.get("check-failure", [])  # type: ignore
+        )
+
 
 @pytest.mark.asyncio
 async def test_multiple_pulls_to_match():
@@ -1919,12 +1932,12 @@ async def test_rules_conditions_update():
                 "head": "feature-1",
                 "label": ["foo", "bar"],
                 "check-success": ["tests"],
+                "check-pending": [],
                 "check-failure": ["jenkins/fake-tests"],
-                "check": ["tests", "jenkins/fake-tests"],
-                "check-success-or-neutral-or-pending": ["tests"],
             }
         ),
     ]
+    pulls[0].sync_checks()
     schema = voluptuous.Schema(
         voluptuous.All(
             [voluptuous.Coerce(rules.RuleConditionSchema)],
@@ -1955,6 +1968,252 @@ async def test_rules_conditions_update():
         mock.Mock(), pulls, mock.Mock(conditions=c)
     )
     assert state == check_api.Conclusion.FAILURE
+
+
+async def assert_queue_rule_checks_status(conds, pull, expected_state):
+    schema = voluptuous.Schema(
+        voluptuous.All(
+            [voluptuous.Coerce(rules.RuleConditionSchema)],
+            voluptuous.Coerce(conditions.QueueRuleConditions),
+        )
+    )
+
+    c = schema(conds)
+
+    await c([pull])
+    state = await merge_base.get_rule_checks_status(
+        mock.Mock(),
+        [pull],
+        mock.Mock(conditions=c),
+        unmatched_conditions_return_failure=False,
+    )
+    assert state == expected_state
+
+
+@pytest.mark.xfail(True, reason="not yet supported", strict=True)
+@pytest.mark.asyncio
+async def test_rules_checks_status_with_negative_conditions():
+    pull = FakeQueuePullRequest(
+        {
+            "number": 1,
+            "current-year": date.Year(2018),
+            "author": "me",
+            "base": "main",
+            "head": "feature-1",
+            "check-success": [],
+            "check-failure": [],
+            "check-pending": [],
+            "check": [],
+            "check-success-or-neutral-or-pending": [],
+        }
+    )
+    conds = [
+        "check-success=test-starter",
+        "-check-pending=foo",
+        "-check-failure=foo",
+    ]
+
+    # Nothing reported
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Pending reported
+    pull.attrs["check-pending"] = ["foo"]
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["test-starter"]
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Failure reported
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = ["foo"]
+    pull.attrs["check-success"] = ["test-starter"]
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
+
+    # Success reported
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["test-starter", "foo"]
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
+
+    # half reported, sorry..., UNDEFINED BEHAVIOR
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["test-starter"]
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
+
+
+@pytest.mark.asyncio
+async def test_rules_checks_status_with_or_conditions():
+    pull = FakeQueuePullRequest(
+        {
+            "number": 1,
+            "current-year": date.Year(2018),
+            "author": "me",
+            "base": "main",
+            "head": "feature-1",
+            "check-success": [],
+            "check-failure": [],
+            "check-pending": [],
+            "check": [],
+            "check-success-or-neutral-or-pending": [],
+        }
+    )
+    conds = [
+        {
+            "or": ["check-success=ci-1", "check-success=ci-2"],
+        }
+    ]
+
+    # Nothing reported
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Pending reported
+    pull.attrs["check-pending"] = ["ci-1"]
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["ci-2"]
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
+
+    # Pending reported
+    pull.attrs["check-pending"] = ["ci-1"]
+    pull.attrs["check-failure"] = ["ci-2"]
+    pull.attrs["check-success"] = []
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Failure reported
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = ["ci-1"]
+    pull.attrs["check-success"] = ["ci-2"]
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
+
+    # Success reported
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["ci-1", "ci-2"]
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
+
+    # half reported success
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-success"] = ["ci-1"]
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
+
+    # half reported failure, UNDEFINED BEHAVIOR
+    # FIXME(sileht): Why are we failing instead of waiting ci-2 ? (MRGFY-729)
+    pull.attrs["check-failure"] = ["ci-1"]
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-success"] = []
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
+
+
+@pytest.mark.asyncio
+async def test_rules_checks_status_expected_failure():
+    pull = FakeQueuePullRequest(
+        {
+            "number": 1,
+            "current-year": date.Year(2018),
+            "author": "me",
+            "base": "main",
+            "head": "feature-1",
+            "check-success": [],
+            "check-failure": [],
+            "check-pending": [],
+            "check": [],
+            "check-success-or-neutral-or-pending": [],
+        }
+    )
+    conds = ["check-failure=ci-1"]
+
+    # Nothing reported
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Pending reported
+    pull.attrs["check-pending"] = ["ci-1"]
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = []
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Failure reported
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = ["ci-1"]
+    pull.attrs["check-success"] = []
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
+
+    # Success reported
+    # FIXME(sileht): we should fail! (MRGFY-730)
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["ci-1"]
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+
+@pytest.mark.asyncio
+async def test_rules_checks_status_regular():
+    pull = FakeQueuePullRequest(
+        {
+            "number": 1,
+            "current-year": date.Year(2018),
+            "author": "me",
+            "base": "main",
+            "head": "feature-1",
+            "check-success": [],
+            "check-failure": [],
+            "check-pending": [],
+            "check": [],
+            "check-success-or-neutral-or-pending": [],
+        }
+    )
+    conds = ["check-success=ci-1", "check-success=ci-2"]
+
+    # Nothing reported
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Pending reported
+    pull.attrs["check-pending"] = ["ci-1"]
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["ci-2"]
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Failure reported
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = ["ci-1"]
+    pull.attrs["check-success"] = ["ci-2"]
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
+
+    # Success reported
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["ci-1", "ci-2"]
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
+
+    # half reported success
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-success"] = ["ci-1"]
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # half reported failure, UNDEFINED BEHAVIOR
+    # FIXME(sileht): Why are we waiting for ci-2 ? we can fail earlier (MRGFY-731)
+    pull.attrs["check-failure"] = ["ci-1"]
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-success"] = []
+    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
If pending/failure checks have a negative conditions, the current code
doesn't works, as we explicit replace any `check-XXX` by `check` to
known if all required checks has reported they values.

This change remove the "-" from the conditions and look that required
checks are not pending.

This will to write rules like:

- check-success=seatbelt
- -check-pending=foo
- -check-failure=foo

Fixes MRGFY-730

Change-Id: I1ce946161bc1acafbc23fbfa00fb88e5baf30875

Depends-On: #3643