### PR TITLE
chore(deps): mark react-scripts has direct deps only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,8 @@ updates:
       timezone: Europe/Paris
     open-pull-requests-limit: 10
     allow:
-      - dependency-type: "production"
+      - dependency-name: "react-scripts"
+        dependency-type: "direct"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
production type does not work for some reason, so try direct mode.

Change-Id: I81881a76399da11f52e53569f75de3aa91d8e9d0