### PR TITLE
ci(semantic-pr): don't run it on merge queue

### DIFF
--- a/.github/workflows/semantic-pull-request.yaml
+++ b/.github/workflows/semantic-pull-request.yaml
@@ -4,7 +4,7 @@ permissions: read-all
 on:
   pull_request_target:
     branches-ignore:
-      - mergify/merge-queue/**
+      - mergify/merge-queue/main/**
     types:
       - opened
       - edited


### PR DESCRIPTION
`**` in branches-ignore does not catch `/`, so we add the merge-queue
target branch to only catch pull requests numbers.

Change-Id: I81ba671d81f6380888c6871540e8c4adffdcbad6