### PR TITLE
fix(queue/rules): use a Filter to found pending/final checks

### DIFF
--- a/mergify_engine/actions/merge_base.py
+++ b/mergify_engine/actions/merge_base.py
@@ -35,6 +35,7 @@ from mergify_engine.actions import utils as action_utils
 from mergify_engine.clients import http
 from mergify_engine.dashboard import subscription
 from mergify_engine.dashboard import user_tokens
+from mergify_engine.rules import filter
 
 
 LOG = daiquiri.getLogger(__name__)
@@ -85,28 +86,11 @@ async def get_rule_checks_status(
     if rule.conditions.match:
         return check_api.Conclusion.SUCCESS
 
-    conditions_initial = rule.conditions.copy()
     conditions_without_checks = rule.conditions.copy()
-    conditions_with_all_checks = rule.conditions.copy()
-    conditions_with_check_not_failing = rule.conditions.copy()
-    for (
-        condition_initial,
-        condition_without_check,
-        condition_with_all_check,
-        condition_with_check_not_failing,
-    ) in zip(
-        conditions_initial.walk(),
-        conditions_without_checks.walk(),
-        conditions_with_all_checks.walk(),
-        conditions_with_check_not_failing.walk(),
-    ):
-        attr = condition_initial.get_attribute_name()
+    for condition_without_check in conditions_without_checks.walk():
+        attr = condition_without_check.get_attribute_name()
         if attr.startswith("check-") or attr.startswith("status-"):
             condition_without_check.update("number>0")
-            condition_with_check_not_failing.update_attribute_name(
-                "check-success-or-neutral-or-pending"
-            )
-            condition_with_all_check.update_attribute_name("check")
 
     # NOTE(sileht): Something unrelated to checks unmatch?
     await conditions_without_checks(pulls)
@@ -120,22 +104,29 @@ async def get_rule_checks_status(
         else:
             return check_api.Conclusion.PENDING
 
-    # NOTE(sileht): Have all checks reported their status?
-    await conditions_with_all_checks(pulls)
-    log.debug(
-        "did check report their status? %s",
-        conditions_with_all_checks.get_summary(),
-    )
-    if not conditions_with_all_checks.match:
-        return check_api.Conclusion.PENDING
+    tree = rule.conditions.extract_raw_filter_tree()
+    results: typing.Dict[int, filter.IncompleteChecksResult] = {}
+    for pull in pulls:
+        f = filter.IncompleteChecksFilter(
+            tree,
+            pending_checks=await getattr(pull, "check-pending"),
+            all_checks=await pull.check,  # type: ignore[attr-defined]
+        )
+        ret = await f(pull)
+        if ret is filter.IncompleteCheck:
+            return check_api.Conclusion.PENDING
 
-    # NOTE(sileht): Are remaining unmatch checks success or pending?
-    await conditions_with_check_not_failing(pulls)
-    log.debug(
-        "did checks report success-or-neutral-or-pending? %s",
-        conditions_with_check_not_failing.get_summary(),
-    )
-    if conditions_with_check_not_failing.match:
+        pr_number = await pull.number  # type: ignore[attr-defined]
+        results[pr_number] = ret
+
+    if all(results.values()):
+        # This can't occur!, we should have returned SUCCESS earlier.
+        LOG.error(
+            "filter.IncompleteChecksFilter unexpectly returned true",
+            tree=tree,
+            results=results,
+        )
+        # So don't merge broken stuff
         return check_api.Conclusion.PENDING
     else:
         return check_api.Conclusion.FAILURE

--- a/mergify_engine/rules/conditions.py
+++ b/mergify_engine/rules/conditions.py
@@ -69,20 +69,6 @@ class RuleCondition:
                 error_message=str(e),
             )
 
-    def update_attribute_name(self, new_name: str) -> None:
-        tree = typing.cast(filter.TreeT, self.partial_filter.tree)
-        negate = "-" in tree
-        tree = tree.get("-", tree)
-        operator = list(tree.keys())[0]
-        name, value = list(tree.values())[0]
-        if name.startswith(filter.Filter.LENGTH_OPERATOR):
-            new_name = f"{filter.Filter.LENGTH_OPERATOR}{new_name}"
-
-        new_tree: FakeTreeT = {operator: (new_name, value)}
-        if negate:
-            new_tree = {"-": new_tree}
-        self.update(new_tree)
-
     def __str__(self) -> str:
         if isinstance(self.condition, str):
             return self.condition


### PR DESCRIPTION
Instead of the heuristic that looks only for `check-success=XXX`.

This creates a Filter that introduces a new possible result
`IncompleteCheck`.

The filter has a different meaning for or/and when boolean are combined
with IncompleteCheck:
* or cannot return false if at least one is IncompleteCheck
* and cannot return false if at least one is IncompleteCheck

To compute if a check conditions is final or not, this change adds an
hook in Filter before the evaluation of the condition to return IncompleteCheck
if need instead of the real evaluation outcome.

Fixes MRGFY-729
Fixes MRGFY-730
Fixes MRGFY-731
Fixes MRGFY-736

Change-Id: I1ce946161bc1acafbc23fbfa00fb88e5baf30875
