### PR TITLE
feat(context): cache user/teams permissions

### DIFF
--- a/mergify_engine/actions/utils.py
+++ b/mergify_engine/actions/utils.py
@@ -88,7 +88,9 @@ async def render_bot_account(
     if required_permissions:
         try:
             user = await ctxt.repository.installation.get_user(bot_account)
-            permission = await ctxt.repository.get_user_permission(user)
+            permission = await ctxt.repository.get_user_permission(
+                user["id"], user["login"]
+            )
         except http.HTTPNotFound:
             raise RenderBotAccountFailure(
                 check_api.Conclusion.ACTION_REQUIRED,

--- a/mergify_engine/tests/unit/test_context.py
+++ b/mergify_engine/tests/unit/test_context.py
@@ -127,6 +127,11 @@ async def test_user_permission_cache(redis_cache: utils.RedisCache) -> None:
     assert client.called == 1
     assert not await repository.has_write_permission(user_2)
     assert client.called == 2
+    # From local cache
+    assert not await repository.has_write_permission(user_2)
+    assert client.called == 2
+    # From redis
+    repository.get_user_permission.cache_clear()
     assert not await repository.has_write_permission(user_2)
     assert client.called == 2
     assert not await repository.has_write_permission(user_3)
@@ -152,27 +157,41 @@ async def test_user_permission_cache(redis_cache: utils.RedisCache) -> None:
     assert client.called == 0
     assert await repository.has_write_permission(user_2)
     assert client.called == 1
+    # From local cache
     assert await repository.has_write_permission(user_2)
     assert client.called == 1
+    # From redis
+    repository.get_user_permission.cache_clear()
+    assert await repository.has_write_permission(user_2)
+    assert client.called == 1
+
     assert not await repository.has_write_permission(user_1)
     assert client.called == 2
     await context.Repository.clear_user_permission_cache_for_repo(
         redis_cache, gh_owner, gh_repo
     )
+    repository.get_user_permission.cache_clear()
     assert not await repository.has_write_permission(user_1)
     assert client.called == 3
     assert not await repository.has_write_permission(user_3)
     assert client.called == 4
     await context.Repository.clear_user_permission_cache_for_org(redis_cache, gh_owner)
+    repository.get_user_permission.cache_clear()
     assert not await repository.has_write_permission(user_3)
     assert client.called == 5
     assert await repository.has_write_permission(user_2)
     assert client.called == 6
+    # From local cache
+    assert await repository.has_write_permission(user_2)
+    assert client.called == 6
+    # From redis
+    repository.get_user_permission.cache_clear()
     assert await repository.has_write_permission(user_2)
     assert client.called == 6
     await context.Repository.clear_user_permission_cache_for_user(
         redis_cache, gh_owner, gh_repo, user_2
     )
+    repository.get_user_permission.cache_clear()
     assert await repository.has_write_permission(user_2)
     assert client.called == 7
 
@@ -233,30 +252,68 @@ async def test_team_members_cache(redis_cache: utils.RedisCache) -> None:
     assert client.called == 1
     assert (await installation.get_team_members(team_slug2)) == ["member3", "member4"]
     assert client.called == 2
+    # From local cache
     assert (await installation.get_team_members(team_slug2)) == ["member3", "member4"]
     assert client.called == 2
+    # From redis
+    installation.get_team_members.cache_clear()
+    assert (await installation.get_team_members(team_slug2)) == ["member3", "member4"]
+    assert client.called == 2
+
     assert (await installation.get_team_members(team_slug3)) == []
     assert client.called == 3
+    # From local cache
     assert (await installation.get_team_members(team_slug3)) == []
     assert client.called == 3
+    # From redis
+    installation.get_team_members.cache_clear()
+    assert (await installation.get_team_members(team_slug3)) == []
+    assert client.called == 3
+
     await installation.clear_team_members_cache_for_team(
         redis_cache, gh_owner, github_types.GitHubTeamSlug(team_slug2)
     )
+    installation.get_team_members.cache_clear()
+
     assert (await installation.get_team_members(team_slug2)) == ["member3", "member4"]
     assert client.called == 4
+    # From local cache
     assert (await installation.get_team_members(team_slug2)) == ["member3", "member4"]
     assert client.called == 4
+    # From redis
+    installation.get_team_members.cache_clear()
+    assert (await installation.get_team_members(team_slug2)) == ["member3", "member4"]
+    assert client.called == 4
+
     await installation.clear_team_members_cache_for_org(redis_cache, gh_owner)
+    installation.get_team_members.cache_clear()
+
     assert (await installation.get_team_members(team_slug1)) == ["member1", "member2"]
     assert client.called == 5
+    # From local cache
     assert (await installation.get_team_members(team_slug1)) == ["member1", "member2"]
     assert client.called == 5
+    # From redis
+    installation.get_team_members.cache_clear()
+    assert (await installation.get_team_members(team_slug1)) == ["member1", "member2"]
+    assert client.called == 5
+
     assert (await installation.get_team_members(team_slug2)) == ["member3", "member4"]
     assert client.called == 6
+    # From local cache
+    assert (await installation.get_team_members(team_slug2)) == ["member3", "member4"]
+    assert client.called == 6
+    # From redis
+    installation.get_team_members.cache_clear()
     assert (await installation.get_team_members(team_slug2)) == ["member3", "member4"]
     assert client.called == 6
     assert (await installation.get_team_members(team_slug3)) == []
     assert client.called == 7
+    # From local cache
+    assert (await installation.get_team_members(team_slug3)) == []
+    assert client.called == 7
+    # From redis
+    installation.get_team_members.cache_clear()
     assert (await installation.get_team_members(team_slug3)) == []
     assert client.called == 7
 
@@ -369,6 +426,11 @@ async def test_team_permission_cache(redis_cache: utils.RedisCache) -> None:
     assert client.called == 0
     assert not await repository.team_has_read_permission(team_slug2)
     assert client.called == 1
+    # From local cache
+    assert not await repository.team_has_read_permission(team_slug2)
+    assert client.called == 1
+    # From redis
+    repository.team_has_read_permission.cache_clear()
     assert not await repository.team_has_read_permission(team_slug2)
     assert client.called == 1
     assert await repository.team_has_read_permission(team_slug1)
@@ -376,20 +438,29 @@ async def test_team_permission_cache(redis_cache: utils.RedisCache) -> None:
     await context.Repository.clear_team_permission_cache_for_repo(
         redis_cache, gh_owner, gh_repo
     )
+    repository.team_has_read_permission.cache_clear()
     assert await repository.team_has_read_permission(team_slug1)
     assert client.called == 3
     assert not await repository.team_has_read_permission(team_slug3)
     assert client.called == 4
     await context.Repository.clear_team_permission_cache_for_org(redis_cache, gh_owner)
+    repository.team_has_read_permission.cache_clear()
     assert not await repository.team_has_read_permission(team_slug3)
     assert client.called == 5
     assert not await repository.team_has_read_permission(team_slug2)
     assert client.called == 6
+    # From local cache
     assert not await repository.team_has_read_permission(team_slug2)
     assert client.called == 6
+    # From redis
+    repository.team_has_read_permission.cache_clear()
+    assert not await repository.team_has_read_permission(team_slug2)
+    assert client.called == 6
+    repository.team_has_read_permission.cache_clear()
     await context.Repository.clear_team_permission_cache_for_team(
         redis_cache, gh_owner, team_slug2
     )
+    repository.team_has_read_permission.cache_clear()
     assert not await repository.team_has_read_permission(team_slug2)
     assert client.called == 7
 

--- a/mergify_engine/tests/unit/test_utils.py
+++ b/mergify_engine/tests/unit/test_utils.py
@@ -12,6 +12,8 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+import dataclasses
+
 import msgpack
 import pytest
 
@@ -202,3 +204,34 @@ async def test_refresh_with_pull_request_number(
     assert event["action"] == "admin"
     assert event["ref"] == "master"
     assert event["pull_request_number"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_cache() -> None:
+    @dataclasses.dataclass(unsafe_hash=True)
+    class Me:
+        id: int
+        name: str = dataclasses.field(hash=False)
+
+        @utils.async_cache
+        async def who(self, prefix: str) -> str:
+            return f"{prefix} {self.name}"
+
+    m = Me(1, "sileht")
+    assert await m.who("hello") == "hello sileht"
+    assert await m.who("hello") == "hello sileht"
+    assert await m.who("bye") == "bye sileht"
+    assert await m.who("bye") == "bye sileht"
+
+    # changing the name unused by hashing function, should return cached data
+    m.name = "ghost"
+    assert await m.who("hello") == "hello sileht"
+    assert await m.who("bye") == "bye sileht"
+
+    assert await m.who("goodmorning") == "goodmorning ghost"
+
+    # changing the id used by hashing function, should return fresh data
+    m.id = 2
+    assert await m.who("hello") == "hello ghost"
+    assert await m.who("bye") == "bye ghost"
+    assert await m.who("goodmorning") == "goodmorning ghost"


### PR DESCRIPTION
This data is not going to change often we can keep it for the life time
of a context (maximum 30s).

Fixes MRGFY-750

Change-Id: Id3dabe978c4a826d1eb8fc7e6589ecc4b9a2cfba
