### PR TITLE
fix(queue/rules): use a Filter to found pending/final checks

### DIFF
--- a/mergify_engine/rules/conditions.py
+++ b/mergify_engine/rules/conditions.py
@@ -69,20 +69,6 @@ class RuleCondition:
                 error_message=str(e),
             )
 
-    def update_attribute_name(self, new_name: str) -> None:
-        tree = typing.cast(filter.TreeT, self.partial_filter.tree)
-        negate = "-" in tree
-        tree = tree.get("-", tree)
-        operator = list(tree.keys())[0]
-        name, value = list(tree.values())[0]
-        if name.startswith(filter.Filter.LENGTH_OPERATOR):
-            new_name = f"{filter.Filter.LENGTH_OPERATOR}{new_name}"
-
-        new_tree: FakeTreeT = {operator: (new_name, value)}
-        if negate:
-            new_tree = {"-": new_tree}
-        self.update(new_tree)
-
     def __str__(self) -> str:
         if isinstance(self.condition, str):
             return self.condition

--- a/mergify_engine/rules/filter.py
+++ b/mergify_engine/rules/filter.py
@@ -16,6 +16,7 @@
 from collections import abc
 import dataclasses
 import datetime
+import enum
 import inspect
 import operator
 import re
@@ -233,6 +234,20 @@ class Filter(typing.Generic[FilterResultT]):
             raise InvalidArguments(nodes)
         return self._handle_multiple_op(multiple_op, nodes)
 
+    def _eval_binary_op(
+        self,
+        op: BinaryOperatorT[FilterResultT],
+        attribute_name: str,
+        attribute_values: typing.List[typing.Any],
+        ref_values_expanded: typing.List[typing.Any],
+    ) -> FilterResultT:
+        binary_op, iterable_op, compile_fn = op
+        return iterable_op(
+            binary_op(attribute_value, ref_value)
+            for attribute_value in attribute_values
+            for ref_value in ref_values_expanded
+        )
+
     def _handle_binary_op(
         self,
         op: BinaryOperatorT[FilterResultT],
@@ -258,10 +273,8 @@ class Filter(typing.Generic[FilterResultT]):
                     typing.Awaitable[typing.Any], ref_values_expanded
                 )
 
-            return iterable_op(
-                binary_op(attribute_value, ref_value)
-                for attribute_value in attribute_values
-                for ref_value in ref_values_expanded
+            return self._eval_binary_op(
+                op, attribute_name, attribute_values, ref_values_expanded
             )
 
         return _op
@@ -491,3 +504,189 @@ def NearDatetimeFilter(
             "and": _minimal_datetime,
         },
     )
+
+
+# NOTE(sileht): Sentinel object (eg: `marker = object()`) can't be expressed
+# with typing yet use the proposed workaround instead:
+#   https://github.com/python/typing/issues/689
+#   https://www.python.org/dev/peps/pep-0661/
+class _IncompleteMarker(enum.Enum):
+    _MARKER = 0
+
+
+IncompleteCheck: typing.Final = _IncompleteMarker._MARKER
+
+
+IncompleteChecksResult = typing.Union[bool, _IncompleteMarker]
+
+
+def IncompleteChecksAll(
+    values: typing.Iterable[object],
+) -> IncompleteChecksResult:
+    values = typing.cast(typing.Iterable[IncompleteChecksResult], values)
+    found_unknown = False
+    for v in values:
+        if v is False:
+            return False
+        elif v is IncompleteCheck:
+            found_unknown = True
+    if found_unknown:
+        return IncompleteCheck
+    return True
+
+
+def IncompleteChecksAny(
+    values: typing.Iterable[object],
+) -> IncompleteChecksResult:
+    values = typing.cast(typing.Iterable[IncompleteChecksResult], values)
+    found_true = False
+    for v in values:
+        if v is IncompleteCheck:
+            return IncompleteCheck
+        elif v:
+            found_true = True
+    return found_true
+
+
+def IncompleteChecksNegate(value: IncompleteChecksResult) -> IncompleteChecksResult:
+    if value is IncompleteCheck:
+        return IncompleteCheck
+    else:
+        return not value
+
+
+def cast_ret_to_incomplete_check_result(
+    op: typing.Callable[[typing.Any, typing.Any], bool]
+) -> typing.Callable[[typing.Any, typing.Any], IncompleteChecksResult]:
+    return typing.cast(
+        typing.Callable[[typing.Any, typing.Any], IncompleteChecksResult], op
+    )
+
+
+@dataclasses.dataclass(repr=False)
+class IncompleteChecksFilter(Filter[IncompleteChecksResult]):
+    tree: typing.Union[TreeT, CompiledTreeT[GetAttrObject, bool]]
+    unary_operators: typing.Dict[
+        str, UnaryOperatorT[IncompleteChecksResult]
+    ] = dataclasses.field(default_factory=lambda: {"-": IncompleteChecksNegate})
+    binary_operators: typing.Dict[
+        str, BinaryOperatorT[IncompleteChecksResult]
+    ] = dataclasses.field(
+        default_factory=lambda: {
+            "=": (
+                cast_ret_to_incomplete_check_result(operator.eq),
+                IncompleteChecksAny,
+                _identity,
+            ),
+            "<": (
+                cast_ret_to_incomplete_check_result(operator.lt),
+                IncompleteChecksAny,
+                _identity,
+            ),
+            ">": (
+                cast_ret_to_incomplete_check_result(operator.gt),
+                IncompleteChecksAny,
+                _identity,
+            ),
+            "<=": (
+                cast_ret_to_incomplete_check_result(operator.le),
+                IncompleteChecksAny,
+                _identity,
+            ),
+            ">=": (
+                cast_ret_to_incomplete_check_result(operator.ge),
+                IncompleteChecksAny,
+                _identity,
+            ),
+            "!=": (
+                cast_ret_to_incomplete_check_result(operator.ne),
+                IncompleteChecksAll,
+                _identity,
+            ),
+            "~=": (
+                cast_ret_to_incomplete_check_result(
+                    lambda a, b: a is not None and b.search(a)
+                ),
+                IncompleteChecksAny,
+                re.compile,
+            ),
+        }
+    )
+    multiple_operators: typing.Dict[
+        str, MultipleOperatorT[IncompleteChecksResult]
+    ] = dataclasses.field(
+        default_factory=lambda: {
+            "or": IncompleteChecksAny,
+            "and": IncompleteChecksAll,
+        }
+    )
+    pending_checks: typing.List[str] = dataclasses.field(default_factory=list)
+    all_checks: typing.List[str] = dataclasses.field(default_factory=list)
+
+    def _eval_binary_op(
+        self,
+        op: BinaryOperatorT[IncompleteChecksResult],
+        attribute_name: str,
+        attribute_values: typing.List[typing.Any],
+        ref_values_expanded: typing.List[typing.Any],
+    ) -> IncompleteChecksResult:
+        if not self.is_complete(op, attribute_name, ref_values_expanded):
+            return IncompleteCheck
+
+        binary_op, iterable_op, _ = op
+        return super()._eval_binary_op(
+            op, attribute_name, attribute_values, ref_values_expanded
+        )
+
+    def is_complete(
+        self,
+        op: BinaryOperatorT[FilterResultT],
+        attribute_name: str,
+        ref_values: typing.List[typing.Any],
+    ) -> bool:
+        binary_op, iterable_op, _ = op
+
+        if attribute_name.startswith(Filter.LENGTH_OPERATOR):
+            real_attr_name = attribute_name[1:]
+        else:
+            real_attr_name = attribute_name
+
+        if real_attr_name.startswith("check-") or real_attr_name.startswith("status-"):
+            if attribute_name.startswith(Filter.LENGTH_OPERATOR):
+                if len(self.pending_checks) != 0:
+                    return False
+            else:
+                if real_attr_name in (
+                    "check-pending",
+                    "check-success-or-neutral-or-pending",
+                ):
+                    return not bool(self.pending_checks)
+
+                final_checks = set(self.all_checks) - set(self.pending_checks)
+                final_check = iterable_op(
+                    binary_op(check, ref_value)
+                    for check in final_checks
+                    for ref_value in ref_values
+                )
+                if final_check:
+                    return True
+
+                # Ensure the check we are waiting for is somewhere
+                at_least_one_check = any(
+                    binary_op(check, ref_value)
+                    for check in self.all_checks
+                    for ref_value in ref_values
+                )
+                if not at_least_one_check:
+                    return False
+
+                if self.pending_checks:
+                    # Ensure the check we are waiting for is not in pending list
+                    pending_result = iterable_op(
+                        binary_op(check, ref_value)
+                        for check in self.pending_checks
+                        for ref_value in ref_values
+                    )
+                    if pending_result:
+                        return False
+        return True

--- a/mergify_engine/tests/unit/rules/test_get_rule_checks_status.py
+++ b/mergify_engine/tests/unit/rules/test_get_rule_checks_status.py
@@ -48,7 +48,12 @@ class FakeQueuePullRequest:
             + self.attrs.get("check-neutral", [])  # type: ignore
             + self.attrs.get("check-pending", [])  # type: ignore
             + self.attrs.get("check-failure", [])  # type: ignore
+            + self.attrs.get("check-skipped", [])  # type: ignore
         )
+
+        for key, value in list(self.attrs.items()):
+            if key.startswith("check"):
+                self.attrs[f"potential-{key}"] = value + self.attrs.get("check-pending", [])  # type: ignore
 
 
 @pytest.mark.asyncio
@@ -102,6 +107,7 @@ async def test_rules_conditions_update():
 
 
 async def assert_queue_rule_checks_status(conds, pull, expected_state):
+    pull.sync_checks()
     schema = voluptuous.Schema(
         voluptuous.All(
             [voluptuous.Coerce(rules.RuleConditionSchema)],
@@ -121,9 +127,181 @@ async def assert_queue_rule_checks_status(conds, pull, expected_state):
     assert state == expected_state
 
 
-@pytest.mark.xfail(True, reason="not yet supported", strict=True)
 @pytest.mark.asyncio
-async def test_rules_checks_status_with_negative_conditions():
+async def test_rules_checks_basic(logger_checker):
+    pull = FakeQueuePullRequest(
+        {
+            "number": 1,
+            "current-year": date.Year(2018),
+            "author": "me",
+            "base": "main",
+            "head": "feature-1",
+            "label": [],
+            "check-success": [],
+            "check-failure": [],
+            "check-pending": [],
+            "check": [],
+            "check-success-or-neutral-or-pending": [],
+        }
+    )
+    conds = ["check-success=fake-ci", "label=foobar"]
+
+    # Label missing and nothing reported
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Label missing and success
+    pull.attrs["check-success"] = ["fake-ci"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # label ok and nothing reported
+    pull.attrs["label"] = ["foobar"]
+    pull.attrs["check-success"] = []
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Pending reported
+    pull.attrs["check-pending"] = ["fake-ci"]
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["test-starter"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Failure reported
+    pull.attrs["check-pending"] = ["whatever"]
+    pull.attrs["check-failure"] = ["foo", "fake-ci"]
+    pull.attrs["check-success"] = ["test-starter"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
+
+    # Success reported
+    pull.attrs["check-pending"] = ["whatever"]
+    pull.attrs["check-failure"] = ["foo"]
+    pull.attrs["check-success"] = ["fake-ci", "test-starter"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
+
+
+@pytest.mark.asyncio
+async def test_rules_checks_with_and_or(logger_checker):
+    pull = FakeQueuePullRequest(
+        {
+            "number": 1,
+            "current-year": date.Year(2018),
+            "author": "me",
+            "base": "main",
+            "head": "feature-1",
+            "label": [],
+            "check-success": [],
+            "check-failure": [],
+            "check-pending": [],
+            "check": [],
+            "check-success-or-neutral-or-pending": [],
+        }
+    )
+    conds = [
+        {"or": ["check-success=fake-ci", "label=skip-tests"]},
+        "check-success=other-ci",
+    ]
+
+    # Label missing and nothing reported
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Label missing and half success
+    pull.attrs["check-success"] = ["fake-ci"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Label missing and half success and half pending
+    pull.attrs["check-success"] = ["fake-ci"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Label missing and all success
+    pull.attrs["check-success"] = ["fake-ci", "other-ci"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
+
+    # Label missing and half failure
+    pull.attrs["check-success"] = ["fake-ci"]
+    pull.attrs["check-failure"] = ["other-ci"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
+
+    # Label missing and half failure bus
+    pull.attrs["check-success"] = ["other-ci"]
+    pull.attrs["check-failure"] = ["fake-ci"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
+
+    # label ok and nothing reported
+    pull.attrs["label"] = ["skip-tests"]
+    pull.attrs["check-success"] = []
+    pull.attrs["check-failure"] = []
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # label ok and failure
+    pull.attrs["label"] = ["skip-tests"]
+    pull.attrs["check-success"] = []
+    pull.attrs["check-failure"] = ["other-ci"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
+
+    # label ok and failure
+    pull.attrs["label"] = ["skip-tests"]
+    pull.attrs["check-success"] = []
+    pull.attrs["check-failure"] = ["fake-ci"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # label ok and success
+    pull.attrs["label"] = ["skip-tests"]
+    pull.attrs["check-pending"] = ["fake-ci"]
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["other-ci"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
+
+
+@pytest.mark.asyncio
+async def test_rules_checks_status_with_negative_conditions1(logger_checker):
+    pull = FakeQueuePullRequest(
+        {
+            "number": 1,
+            "current-year": date.Year(2018),
+            "author": "me",
+            "base": "main",
+            "head": "feature-1",
+            "check-success": [],
+            "check-failure": [],
+            "check-pending": [],
+            "check": [],
+            "check-success-or-neutral-or-pending": [],
+        }
+    )
+    conds = [
+        "check-success=test-starter",
+        "check-pending!=foo",
+        "check-failure!=foo",
+    ]
+
+    # Nothing reported
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Pending reported
+    pull.attrs["check-pending"] = ["foo"]
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["test-starter"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Failure reported
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = ["foo"]
+    pull.attrs["check-success"] = ["test-starter"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
+
+    # Success reported
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["test-starter", "foo"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
+
+    # half reported, sorry..., UNDEFINED BEHAVIOR
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["test-starter"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
+
+
+@pytest.mark.asyncio
+async def test_rules_checks_status_with_negative_conditions2():
     pull = FakeQueuePullRequest(
         {
             "number": 1,
@@ -151,28 +329,74 @@ async def test_rules_checks_status_with_negative_conditions():
     pull.attrs["check-pending"] = ["foo"]
     pull.attrs["check-failure"] = []
     pull.attrs["check-success"] = ["test-starter"]
-    pull.sync_checks()
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
 
     # Failure reported
     pull.attrs["check-pending"] = []
     pull.attrs["check-failure"] = ["foo"]
     pull.attrs["check-success"] = ["test-starter"]
-    pull.sync_checks()
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
 
     # Success reported
     pull.attrs["check-pending"] = []
     pull.attrs["check-failure"] = []
     pull.attrs["check-success"] = ["test-starter", "foo"]
-    pull.sync_checks()
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
 
     # half reported, sorry..., UNDEFINED BEHAVIOR
     pull.attrs["check-pending"] = []
     pull.attrs["check-failure"] = []
     pull.attrs["check-success"] = ["test-starter"]
-    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
+
+
+@pytest.mark.asyncio
+async def test_rules_checks_status_with_negative_conditions3(logger_checker):
+    pull = FakeQueuePullRequest(
+        {
+            "number": 1,
+            "current-year": date.Year(2018),
+            "author": "me",
+            "base": "main",
+            "head": "feature-1",
+            "check-success": [],
+            "check-failure": [],
+            "check-pending": [],
+            "check": [],
+            "check-success-or-neutral-or-pending": [],
+        }
+    )
+    conds = [
+        "check-success=test-starter",
+        "#check-pending=0",
+        "#check-failure=0",
+    ]
+
+    # Nothing reported
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Pending reported
+    pull.attrs["check-pending"] = ["foo"]
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["test-starter"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Failure reported
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = ["foo"]
+    pull.attrs["check-success"] = ["test-starter"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
+
+    # Success reported
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["test-starter", "foo"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
+
+    # half reported, sorry..., UNDEFINED BEHAVIOR
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["test-starter"]
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
 
 
@@ -205,44 +429,37 @@ async def test_rules_checks_status_with_or_conditions():
     pull.attrs["check-pending"] = ["ci-1"]
     pull.attrs["check-failure"] = []
     pull.attrs["check-success"] = ["ci-2"]
-    pull.sync_checks()
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
 
     # Pending reported
     pull.attrs["check-pending"] = ["ci-1"]
     pull.attrs["check-failure"] = ["ci-2"]
     pull.attrs["check-success"] = []
-    pull.sync_checks()
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
 
     # Failure reported
     pull.attrs["check-pending"] = []
     pull.attrs["check-failure"] = ["ci-1"]
     pull.attrs["check-success"] = ["ci-2"]
-    pull.sync_checks()
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
 
     # Success reported
     pull.attrs["check-pending"] = []
     pull.attrs["check-failure"] = []
     pull.attrs["check-success"] = ["ci-1", "ci-2"]
-    pull.sync_checks()
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
 
     # half reported success
     pull.attrs["check-failure"] = []
     pull.attrs["check-pending"] = []
     pull.attrs["check-success"] = ["ci-1"]
-    pull.sync_checks()
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
 
-    # half reported failure, UNDEFINED BEHAVIOR
-    # FIXME(sileht): Why are we failing instead of waiting ci-2 ? (MRGFY-729)
+    # half reported failure, wait for ci-2 to finish
     pull.attrs["check-failure"] = ["ci-1"]
     pull.attrs["check-pending"] = []
     pull.attrs["check-success"] = []
-    pull.sync_checks()
-    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
 
 
 @pytest.mark.asyncio
@@ -270,23 +487,19 @@ async def test_rules_checks_status_expected_failure():
     pull.attrs["check-pending"] = ["ci-1"]
     pull.attrs["check-failure"] = []
     pull.attrs["check-success"] = []
-    pull.sync_checks()
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
 
     # Failure reported
     pull.attrs["check-pending"] = []
     pull.attrs["check-failure"] = ["ci-1"]
     pull.attrs["check-success"] = []
-    pull.sync_checks()
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
 
-    # Success reported
-    # FIXME(sileht): we should fail! (MRGFY-730)
+    # Success reported, no way!
     pull.attrs["check-pending"] = []
     pull.attrs["check-failure"] = []
     pull.attrs["check-success"] = ["ci-1"]
-    pull.sync_checks()
-    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
 
 
 @pytest.mark.asyncio
@@ -314,37 +527,83 @@ async def test_rules_checks_status_regular():
     pull.attrs["check-pending"] = ["ci-1"]
     pull.attrs["check-failure"] = []
     pull.attrs["check-success"] = ["ci-2"]
-    pull.sync_checks()
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
 
     # Failure reported
     pull.attrs["check-pending"] = []
     pull.attrs["check-failure"] = ["ci-1"]
     pull.attrs["check-success"] = ["ci-2"]
-    pull.sync_checks()
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
 
     # Success reported
     pull.attrs["check-pending"] = []
     pull.attrs["check-failure"] = []
     pull.attrs["check-success"] = ["ci-1", "ci-2"]
-    pull.sync_checks()
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
 
     # half reported success
     pull.attrs["check-failure"] = []
     pull.attrs["check-pending"] = []
     pull.attrs["check-success"] = ["ci-1"]
-    pull.sync_checks()
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
 
-    # half reported failure, UNDEFINED BEHAVIOR
-    # FIXME(sileht): Why are we waiting for ci-2 ? we can fail earlier (MRGFY-731)
+    # half reported failure, fail early
     pull.attrs["check-failure"] = ["ci-1"]
     pull.attrs["check-pending"] = []
     pull.attrs["check-success"] = []
-    pull.sync_checks()
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
+
+
+@pytest.mark.asyncio
+async def test_rules_checks_status_regex():
+    pull = FakeQueuePullRequest(
+        {
+            "number": 1,
+            "current-year": date.Year(2018),
+            "author": "me",
+            "base": "main",
+            "head": "feature-1",
+            "check-success": [],
+            "check-failure": [],
+            "check-pending": [],
+            "check": [],
+            "check-success-or-neutral-or-pending": [],
+        }
+    )
+    conds = ["check-success~=^ci-1$", "check-success~=^ci-2$"]
+
+    # Nothing reported
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Pending reported
+    pull.attrs["check-pending"] = ["ci-1"]
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["ci-2"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Failure reported
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = ["ci-1"]
+    pull.attrs["check-success"] = ["ci-2"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
+
+    # Success reported
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["ci-1", "ci-2"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
+
+    # half reported success
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-success"] = ["ci-1"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # half reported failure, fail early
+    pull.attrs["check-failure"] = ["ci-1"]
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-success"] = []
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
 
 
 @pytest.mark.asyncio
@@ -391,3 +650,110 @@ async def test_rules_conditions_schedule():
 - [ ] `schedule=SAT-SUN 07:00-12:00`
 """
     )
+
+
+@pytest.mark.asyncio
+async def test_rules_checks_status_depop(logger_checker):
+    pull = FakeQueuePullRequest(
+        {
+            "number": 1,
+            "current-year": date.Year(2018),
+            "author": "me",
+            "base": "main",
+            "head": "feature-1",
+            "check-success": [],
+            "check-failure": [],
+            "check-pending": [],
+            "check-neutral": [],
+            "check-skipped": [],
+            "check": [],
+            "check-success-or-neutral-or-pending": [],
+            "approved-reviews-by": ["me"],
+            "changes-requested-reviews-by": [],
+            "label": ["mergeit"],
+        }
+    )
+    conds = [
+        "check-success=Summary",
+        "check-success=c-ci/status",
+        "check-success=c-ci/s-c-t",
+        "check-success=c-ci/c-p-validate",
+        "#approved-reviews-by>=1",
+        "approved-reviews-by=me",
+        "-label=flag:wait",
+        {
+            "or": [
+                "check-success=c-ci/status",
+                "check-neutral=c-ci/status",
+                "check-skipped=c-ci/status",
+            ]
+        },
+        {
+            "or": [
+                "check-success=c-ci/s-c-t",
+                "check-neutral=c-ci/s-c-t",
+                "check-skipped=c-ci/s-c-t",
+            ]
+        },
+        {
+            "or": [
+                "check-success=c-ci/c-p-validate",
+                "check-neutral=c-ci/c-p-validate",
+                "check-skipped=c-ci/c-p-validate",
+            ]
+        },
+        "#approved-reviews-by>=1",
+        "#changes-requested-reviews-by=0",
+    ]
+    # Nothing reported
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Pending reported
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = ["Summary", "continuous-integration/jenkins/pr-head"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Pending reported
+    pull.attrs["check-pending"] = ["c-ci/status"]
+    pull.attrs["check-failure"] = []
+    pull.attrs["check-success"] = [
+        "Summary",
+        "continuous-integration/jenkins/pr-head",
+        "c-ci/s-c-t",
+    ]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Pending reported
+    pull.attrs["check-pending"] = [
+        "c-ci/status",
+        "c-ci/s-c-t",
+        "c-ci/c-p-validate",
+    ]
+    pull.attrs["check-failure"] = ["c-ci/g-validate"]
+    pull.attrs["check-success"] = ["Summary"]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
+
+    # Failure reported
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = [
+        "c-ci/s-c-t",
+        "c-ci/g-validate",
+    ]
+    pull.attrs["check-success"] = [
+        "Summary",
+        "c-ci/status",
+        "c-ci/c-p-validate",
+    ]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
+
+    # Success reported
+    pull.attrs["check-pending"] = []
+    pull.attrs["check-failure"] = ["c-ci/g-validate"]
+    pull.attrs["check-success"] = [
+        "Summary",
+        "c-ci/status",
+        "c-ci/s-c-t",
+        "c-ci/c-p-validate",
+    ]
+    await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)


### PR DESCRIPTION
Instead of the heuristic that looks only for `check-success=XXX`.

This creates a Filter that introduces a new possible result
`IncompleteCheck`.

The filter has a different meaning for or/and when boolean are combined
with IncompleteCheck:
* or cannot return false if at least one is IncompleteCheck
* and cannot return false if at least one is IncompleteCheck

To compute if a check conditions is final or not, this change adds an
hook in Filter before the evaluation of the condition to return IncompleteCheck
if need instead of the real evaluation outcome.

Fixes MRGFY-729
Fixes MRGFY-730
Fixes MRGFY-731
Fixes MRGFY-736
Fixes MRGFY-752

Change-Id: Ib99d93348934d91c556f14756a8da85e81e19160
