### PR TITLE
fix(approved-by): should not contains requested_reviews

### DIFF
--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -975,6 +975,10 @@ class Context(object):
             approvals: typing.Dict[
                 github_types.GitHubLogin, github_types.GitHubReview
             ] = {}
+
+            requested_reviewer_ids = [
+                rr["id"] for rr in self.pull["requested_reviewers"]
+            ]
             valid_user_ids = {
                 r["user"]["id"]
                 for r in await self.reviews
@@ -984,6 +988,7 @@ class Context(object):
                         r["user"]["type"] == "Bot"
                         or await self.repository.has_write_permission(r["user"])
                     )
+                    and r["user"]["id"] not in requested_reviewer_ids
                 )
             }
 


### PR DESCRIPTION
GitHub Reviews API still show as APPROVED pull request with
requested_reviews.

From GitHub UI and GitHub branch protection perspective, the pull
request is not approved anymore.

This change improved approved-by to done the same.

Fixes MRGFY-773

Change-Id: Id42991a441b53151eedeecc0c4c0dd9f291e582e