### PR TITLE
fix(config): defaults must not be required

### DIFF
--- a/mergify_engine/engine/commands_runner.py
+++ b/mergify_engine/engine/commands_runner.py
@@ -96,10 +96,9 @@ def load_command(
         command_args = match[2].strip()
 
         action_config = {}
-        if defaults := mergify_config["raw"].get("defaults"):
-            if defaults_actions := defaults.get("actions"):
-                if default_action_config := defaults_actions.get(action_name):
-                    action_config = default_action_config
+        if defaults_actions := mergify_config["defaults"].get("actions"):
+            if default_action_config := defaults_actions.get(action_name):
+                action_config = default_action_config
 
         action_config.update(action_class.command_to_config(command_args))
         try:


### PR DESCRIPTION
We were checking defaults with partial_validation=True, but we
revalidated them with partial_validation=False.

This change removes the defaults from the dict before the second
validation step.

Change-Id: Ib05d4cf24dc6d3a9291c897e458cdf5736a7a8bc
