### PR TITLE
chore(deps): cap mypy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ pep8 =
     flake8-rst-docstrings
     flake8-use-fstring
     isort
-    mypy>=0.901
+    mypy>=0.901,<0.920
     types-first
     types-freezegun
     types-pkg_resources


### PR DESCRIPTION
0.920 has been released, but pydantic.mypy plugin is not compatible

cap mypy until pydantic get updated.

https://github.com/samuelcolvin/pydantic/pull/3175

Change-Id: Idd714099c176a26db873ed4cfc0187f443ddfb2e