### PR TITLE
fix(ghes): make graphql call working

### DIFF
--- a/mergify_engine/clients/github.py
+++ b/mergify_engine/clients/github.py
@@ -162,7 +162,7 @@ class GithubAppInstallationAuth(httpx.Auth):
 
         return self.build_github_app_request(
             "POST",
-            f"{config.GITHUB_API_URL}/app/installations/{self._installation['id']}/access_tokens",
+            f"{config.GITHUB_REST_API_URL}/app/installations/{self._installation['id']}/access_tokens",
             force=force,
         )
 
@@ -216,7 +216,7 @@ async def get_installation_from_account_id(
             return typing.cast(
                 github_types.GitHubInstallation,
                 await client.item(
-                    f"{config.GITHUB_API_URL}/user/{account_id}/installation"
+                    f"{config.GITHUB_REST_API_URL}/user/{account_id}/installation"
                 ),
             )
         except http.HTTPNotFound as e:
@@ -236,7 +236,7 @@ async def get_installation_from_login(
             return typing.cast(
                 github_types.GitHubInstallation,
                 await client.item(
-                    f"{config.GITHUB_API_URL}/users/{login}/installation"
+                    f"{config.GITHUB_REST_API_URL}/users/{login}/installation"
                 ),
             )
         except http.HTTPNotFound as e:
@@ -303,7 +303,7 @@ class AsyncGithubClient(http.AsyncClient):
         ],
     ):
         super().__init__(
-            base_url=config.GITHUB_API_URL,
+            base_url=config.GITHUB_REST_API_URL,
             auth=auth,
             headers={"Accept": "application/vnd.github.machine-man-preview+json"},
         )
@@ -393,7 +393,7 @@ class AsyncGithubClient(http.AsyncClient):
         )
 
     async def graphql_post(self, query: str) -> typing.Any:
-        response = await self.post("/graphql", json={"query": query})
+        response = await self.post(config.GITHUB_GRAPHQL_API_URL, json={"query": query})
         data = response.json()
         if "data" not in data:
             raise GraphqlError(response.text)

--- a/mergify_engine/debug.py
+++ b/mergify_engine/debug.py
@@ -45,7 +45,7 @@ async def get_repositories_setuped(
     token: str, install_id: int
 ) -> typing.List[github_types.GitHubRepository]:  # pragma: no cover
     repositories = []
-    url = f"{config.GITHUB_API_URL}/user/installations/{install_id}/repositories"
+    url = f"{config.GITHUB_REST_API_URL}/user/installations/{install_id}/repositories"
     token = f"token {token}"
     async with http.AsyncClient(
         headers={

--- a/mergify_engine/github_events.py
+++ b/mergify_engine/github_events.py
@@ -514,7 +514,7 @@ async def extract_pull_numbers_from_event(
         data = typing.cast(github_types.GitHubEventCheckSuite, data)
         # NOTE(sileht): This list may contains Pull Request from another org/user fork...
         base_repo_url = (
-            f"{config.GITHUB_API_URL}/repos/{installation.owner_login}/{repo_name}"
+            f"{config.GITHUB_REST_API_URL}/repos/{installation.owner_login}/{repo_name}"
         )
         pulls = [
             p["number"]
@@ -531,7 +531,7 @@ async def extract_pull_numbers_from_event(
         data = typing.cast(github_types.GitHubEventCheckRun, data)
         # NOTE(sileht): This list may contains Pull Request from another org/user fork...
         base_repo_url = (
-            f"{config.GITHUB_API_URL}/repos/{installation.owner_login}/{repo_name}"
+            f"{config.GITHUB_REST_API_URL}/repos/{installation.owner_login}/{repo_name}"
         )
         pulls = [
             p["number"]

--- a/mergify_engine/logs.py
+++ b/mergify_engine/logs.py
@@ -91,6 +91,23 @@ def config_log() -> None:
     LOG.info("* PATH: %s", os.environ.get("PATH"))
     LOG.info("##########################################################")
 
+    legacy_api_url = os.getenv("MERGIFYENGINE_GITHUB_API_URL")
+    if legacy_api_url is not None:
+        if legacy_api_url[-1] == "/":
+            legacy_api_url = legacy_api_url[:-1]
+        if legacy_api_url.endswith("/api/v3"):
+            LOG.warning(
+                """
+MERGIFYENGINE_GITHUB_API_URL configuration environment is deprecated and must be replaced by:
+
+  MERGIFYENGINE_GITHUB_REST_API_URL=%s
+  MERGIFYENGINE_GITHUB_GRAPHQL_API_URL=%s
+
+  """,
+                legacy_api_url,
+                f"{legacy_api_url[:-3]}/graphql",
+            )
+
 
 def setup_logging(dump_config: bool = True) -> None:
     outputs = []

--- a/mergify_engine/tests/conftest.py
+++ b/mergify_engine/tests/conftest.py
@@ -73,7 +73,7 @@ async def redis_stream() -> typing.AsyncGenerator[utils.RedisStream, None]:
 async def github_server(
     httpserver: httpserver.HTTPServer, monkeypatch: pytest.MonkeyPatch
 ) -> typing.AsyncGenerator[httpserver.HTTPServer, None]:
-    monkeypatch.setattr(config, "GITHUB_API_URL", httpserver.url_for("/")[:-1])
+    monkeypatch.setattr(config, "GITHUB_REST_API_URL", httpserver.url_for("/")[:-1])
     monkeypatch.setattr(github.CachedToken, "STORAGE", {})
 
     httpserver.expect_request("/users/owner/installation").respond_with_json(

--- a/mergify_engine/tests/functional/test_count_seats.py
+++ b/mergify_engine/tests/functional/test_count_seats.py
@@ -39,12 +39,12 @@ class TestCountSeats(base.FunctionalTestBase):
 
         repos = (
             await self.client_admin.get(
-                url=f"{config.GITHUB_API_URL}/orgs/mergifyio-testing/repos"
+                url=f"{config.GITHUB_REST_API_URL}/orgs/mergifyio-testing/repos"
             )
         ).json()
         members = (
             await self.client_admin.get(
-                url=f"{config.GITHUB_API_URL}/orgs/mergifyio-testing/members"
+                url=f"{config.GITHUB_REST_API_URL}/orgs/mergifyio-testing/members"
             )
         ).json()
         write_users = {
@@ -109,7 +109,7 @@ class TestCountSeats(base.FunctionalTestBase):
         await self._prepare_repo()
         members = (
             await self.client_admin.get(
-                url=f"{config.GITHUB_API_URL}/orgs/mergifyio-testing/members"
+                url=f"{config.GITHUB_REST_API_URL}/orgs/mergifyio-testing/members"
             )
         ).json()
         seats_count = (await count_seats.Seats.get(self.redis_cache)).count()
@@ -143,7 +143,7 @@ class TestCountSeats(base.FunctionalTestBase):
 
                 repos = (
                     await self.client_admin.get(
-                        url=f"{config.GITHUB_API_URL}/orgs/mergifyio-testing/repos"
+                        url=f"{config.GITHUB_REST_API_URL}/orgs/mergifyio-testing/repos"
                     )
                 ).json()
                 expected_repositories = sorted(
@@ -156,7 +156,7 @@ class TestCountSeats(base.FunctionalTestBase):
 
                 members = (
                     await self.client_admin.get(
-                        url=f"{config.GITHUB_API_URL}/orgs/mergifyio-testing/members"
+                        url=f"{config.GITHUB_REST_API_URL}/orgs/mergifyio-testing/members"
                     )
                 ).json()
                 users_expected = {(member["id"], member["login"]) for member in members}

--- a/mergify_engine/tests/unit/test_clients.py
+++ b/mergify_engine/tests/unit/test_clients.py
@@ -36,7 +36,7 @@ async def test_client_installation_token_with_owner_id(
 ) -> None:
 
     with mock.patch(
-        "mergify_engine.config.GITHUB_API_URL",
+        "mergify_engine.config.GITHUB_REST_API_URL",
         httpserver.url_for("/")[:-1],
     ):
 
@@ -85,7 +85,7 @@ async def test_client_installation_token_with_owner_id(
 @pytest.mark.asyncio
 async def test_client_user_token(httpserver: httpserver.HTTPServer) -> None:
     with mock.patch(
-        "mergify_engine.config.GITHUB_API_URL",
+        "mergify_engine.config.GITHUB_REST_API_URL",
         httpserver.url_for("/")[:-1],
     ):
         httpserver.expect_request("/user/12345/installation").respond_with_json(
@@ -159,7 +159,7 @@ async def test_client_401_raise_ratelimit(httpserver: httpserver.HTTPServer) -> 
     )
 
     with mock.patch(
-        "mergify_engine.config.GITHUB_API_URL",
+        "mergify_engine.config.GITHUB_REST_API_URL",
         httpserver.url_for("/")[:-1],
     ):
         installation_json = await github.get_installation_from_account_id(owner_id)
@@ -295,7 +295,7 @@ async def test_client_access_token_HTTP_500(httpserver: httpserver.HTTPServer) -
     ).respond_with_data("This is an 5XX error", status=500)
 
     with mock.patch(
-        "mergify_engine.config.GITHUB_API_URL",
+        "mergify_engine.config.GITHUB_REST_API_URL",
         httpserver.url_for("/")[:-1],
     ):
         installation_json = await github.get_installation_from_account_id(
@@ -328,7 +328,7 @@ async def test_client_installation_HTTP_500(httpserver: httpserver.HTTPServer) -
     )
 
     with mock.patch(
-        "mergify_engine.config.GITHUB_API_URL",
+        "mergify_engine.config.GITHUB_REST_API_URL",
         httpserver.url_for("/")[:-1],
     ):
         with pytest.raises(http.HTTPServerSideError) as exc_info:
@@ -356,7 +356,7 @@ async def test_client_installation_HTTP_404(httpserver: httpserver.HTTPServer) -
         {"message": "Repository not found"}, status=404
     )
     with mock.patch(
-        "mergify_engine.config.GITHUB_API_URL",
+        "mergify_engine.config.GITHUB_REST_API_URL",
         httpserver.url_for("/")[:-1],
     ):
         with pytest.raises(exceptions.MergifyNotInstalled):
@@ -380,7 +380,7 @@ async def test_client_installation_HTTP_301(httpserver: httpserver.HTTPServer) -
         {"message": "Repository not found"}, status=404
     )
     with mock.patch(
-        "mergify_engine.config.GITHUB_API_URL",
+        "mergify_engine.config.GITHUB_REST_API_URL",
         httpserver.url_for("/")[:-1],
     ):
         with pytest.raises(exceptions.MergifyNotInstalled):
@@ -423,7 +423,7 @@ async def test_client_abuse_403_no_header(httpserver: httpserver.HTTPServer) -> 
     )
 
     with mock.patch(
-        "mergify_engine.config.GITHUB_API_URL",
+        "mergify_engine.config.GITHUB_REST_API_URL",
         httpserver.url_for("/")[:-1],
     ):
         installation_json = await github.get_installation_from_account_id(

--- a/mergify_engine/tests/unit/test_github_events.py
+++ b/mergify_engine/tests/unit/test_github_events.py
@@ -38,7 +38,7 @@ async def _do_test_event_to_pull_check_run(
         data = json.loads(
             f.read()
             .replace("https://github.com", config.GITHUB_URL)
-            .replace("https://api.github.com", config.GITHUB_API_URL)
+            .replace("https://api.github.com", config.GITHUB_REST_API_URL)
         )
 
     gh_owner = github_types.GitHubAccount(

--- a/mergify_engine/web/auth.py
+++ b/mergify_engine/web/auth.py
@@ -58,7 +58,7 @@ async def token(request: requests.Request) -> None:
         if authorization.startswith("token "):
             try:
                 async with http.AsyncClient(
-                    base_url=config.GITHUB_API_URL,
+                    base_url=config.GITHUB_REST_API_URL,
                     headers={"Authorization": authorization},
                 ) as client:
                     await client.get("/user")

--- a/releasenotes/notes/api-url-change-fccbdb37e6085a39.yaml
+++ b/releasenotes/notes/api-url-change-fccbdb37e6085a39.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    Environment variable ``MERGIFYENGINE_GITHUB_API_URL`` have been replaced by
+    ``MERGIFYENGINE_GITHUB_REST_API_URL`` and ``MERGIFYENGINE_GITHUB_GRAPHQL_API_URL``.


### PR DESCRIPTION
The graphql endpoint of GHES is /api/graphql instead of /graphql.

This introduce new environment variables to configure it.

Fixes MRGFY-788

Change-Id: I084cfe2631180fabd4609a26effe050c3fda5f4a
