### PR TITLE
fix(redis): load redis script on startup

### DIFF
--- a/mergify_engine/migrations/__init__.py
+++ b/mergify_engine/migrations/__init__.py
@@ -58,6 +58,7 @@ async def _run_scripts(
 
         raw = pkg_resources.resource_string(__name__, f"{dirname}/{script}").decode()
         redis_script = redis_utils.register_script(raw)
+        await redis_utils.load_script(redis, redis_script)
         await redis_utils.run_script(redis, redis_script, ())
         current_version = version
         await redis.set(MIGRATION_STAMPS_KEY, current_version)

--- a/mergify_engine/tests/conftest.py
+++ b/mergify_engine/tests/conftest.py
@@ -8,6 +8,7 @@ from pytest_httpserver import httpserver
 
 from mergify_engine import config
 from mergify_engine import logs
+from mergify_engine import redis_utils
 from mergify_engine import utils
 from mergify_engine.clients import github
 
@@ -61,6 +62,7 @@ async def redis_cache() -> typing.AsyncGenerator[utils.RedisCache, None]:
 async def redis_stream() -> typing.AsyncGenerator[utils.RedisStream, None]:
     with utils.yaaredis_for_stream() as client:
         await client.flushdb()
+        await redis_utils.load_scripts(client)
         try:
             yield client
         finally:

--- a/mergify_engine/web/redis.py
+++ b/mergify_engine/web/redis.py
@@ -17,6 +17,7 @@
 import daiquiri
 
 from mergify_engine import config
+from mergify_engine import redis_utils
 from mergify_engine import utils
 
 
@@ -34,6 +35,7 @@ async def startup() -> None:
     _AREDIS_CACHE = utils.create_yaaredis_for_cache(
         max_connections=config.REDIS_CACHE_WEB_MAX_CONNECTIONS
     )
+    await redis_utils.load_scripts(_AREDIS_STREAM)
 
 
 async def shutdown() -> None:

--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -71,6 +71,7 @@ from mergify_engine import github_events
 from mergify_engine import github_types
 from mergify_engine import logs
 from mergify_engine import migrations
+from mergify_engine import redis_utils
 from mergify_engine import service
 from mergify_engine import signals
 from mergify_engine import utils
@@ -1088,6 +1089,7 @@ class Worker:
         self._redis_stream = utils.create_yaaredis_for_stream()
         self._redis_cache = utils.create_yaaredis_for_cache()
 
+        await redis_utils.load_scripts(self._redis_stream)
         await migrations.run(self._redis_cache)
 
         if "stream" in self.enabled_services:


### PR DESCRIPTION
Since we use pipeline with redis script, if script loading may fail as
the ScriptError is not raise when we use evalsha(), but a generic error
is raise during the pipeline execution.

Instead, this change loads script on startup.

Depends-On: #3821

Change-Id: Id47d234cbb0447d94b4d54c3fc6268122dfae1f9
