### PR TITLE
fix(depends-on): support when body has CRLF instead LF eol

### DIFF
--- a/mergify_engine/queue/merge_train.py
+++ b/mergify_engine/queue/merge_train.py
@@ -601,7 +601,7 @@ You don't need to do anything. Mergify will close this pull request automaticall
                     show_queue=False,
                 )
 
-                if tmp_pull_ctxt.pull["body"] != body:
+                if tmp_pull_ctxt.body != body:
                     await tmp_pull_ctxt.client.patch(
                         f"{tmp_pull_ctxt.base_url}/pulls/{self.queue_pull_request_number}",
                         json={"body": body},
@@ -793,7 +793,7 @@ You don't need to do anything. Mergify will close this pull request automaticall
                 show_queue=show_queue,
             )
 
-            if tmp_pull_ctxt.pull["body"] != body:
+            if tmp_pull_ctxt.body != body:
                 await tmp_pull_ctxt.client.patch(
                     f"{tmp_pull_ctxt.base_url}/pulls/{self.queue_pull_request_number}",
                     json={"body": body},

--- a/mergify_engine/tests/unit/test_context.py
+++ b/mergify_engine/tests/unit/test_context.py
@@ -581,9 +581,11 @@ depends-on: {config.GITHUB_URL}/foo/bar/999
 depends-on: azertyuiopqsdfghjklmwxcvbn
 depends-on: https://somewhereelse.com/foo/bar/999
 Depends-oN: {config.GITHUB_URL}/user/repo/pull/456
+Depends-oN: {config.GITHUB_URL}/user/repo/pull/457\r
 Depends-oN: {config.GITHUB_URL}/user/repo/pull/789
  DEPENDS-ON: #42
 Depends-On:  #48
+Depends-On:  #50\r
 Depends-On:  #999 with crap
 DePeNdS-oN: {config.GITHUB_URL}/user/repo/pull/999 with crap
 
@@ -591,7 +593,7 @@ footer
 """
 
     ctxt = await context.Context.create(mock.Mock(), a_pull_request)
-    assert ctxt.get_depends_on() == [42, 48, 123, 456, 789]
+    assert ctxt.get_depends_on() == [42, 48, 50, 123, 456, 457, 789]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
GitHub has changed the eol character in the UI, yes you correctly read it!

Body edited with UI has \r\n. Via API it have exactly was you sent.

Looks at body on old PR #3237, then on new PR #3821.

Since this breaks our multiline regex assumptions, this change replaces
all \r\n to \n.

Change-Id: I0b8bbc4d2acbb215626cc03d58fdf19deaa3554c
