### PR TITLE
chore(github-events): remove useless cache

### DIFF
--- a/mergify_engine/migrations/cache/0002_remove_pull_request_sha_number_cache.redis
+++ b/mergify_engine/migrations/cache/0002_remove_pull_request_sha_number_cache.redis
@@ -1,0 +1,4 @@
+local keys = redis.call("KEYS", "sha~*~*~*")
+for idx, key in ipairs(keys) do
+    redis.call("DEL", key)
+end

--- a/mergify_engine/tests/unit/test_github_events.py
+++ b/mergify_engine/tests/unit/test_github_events.py
@@ -62,7 +62,6 @@ async def _do_test_event_to_pull_check_run(
     )
     pulls = await github_events.extract_pull_numbers_from_event(
         installation,
-        github_types.GitHubRepositoryName("Cytopia"),
         "check_run",
         data,
         [],

--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -727,7 +727,6 @@ class StreamProcessor:
         # multiple complete event
         pull_numbers = await github_events.extract_pull_numbers_from_event(
             installation,
-            repo_name,
             source["event_type"],
             source["data"],
             pulls,


### PR DESCRIPTION
Since we always get the list of open pull requests, storing
the mapping between sha and number is useless.

Change-Id: Ie004f4007cd37d665e08e7897b8b57dc0fde2d57
