### PR TITLE
feat(queue): add batch_max_wait_time

### DIFF
--- a/docs/source/actions/queue.rst
+++ b/docs/source/actions/queue.rst
@@ -363,6 +363,12 @@ A ``queue_rules`` takes the following parameter:
        between 1 and 20.
        See :ref:`speculative checks`.
 
+   * - ``batch_max_wait_time``
+     - :ref:`Duration <duration>`
+     - 0 s
+     - |premium plan tag| The time to wait before creating the speculative check temporary pull request.
+       See :ref:`speculative checks`.
+
    * - ``checks_timeout``
      - :ref:`Duration <duration>`
      -

--- a/mergify_engine/actions/merge.py
+++ b/mergify_engine/actions/merge.py
@@ -15,6 +15,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import datetime
 import enum
 import typing
 
@@ -147,6 +148,7 @@ class MergeAction(merge_base.MergeBaseAction):
                 "priority": 0,
                 "speculative_checks": 1,
                 "batch_size": 1,
+                "batch_max_wait_time": datetime.timedelta(seconds=0),
                 "allow_inplace_checks": True,
                 "allow_checks_interruption": True,
                 "checks_timeout": None,

--- a/mergify_engine/queue/naive.py
+++ b/mergify_engine/queue/naive.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import dataclasses
+import datetime
 import typing
 
 import daiquiri
@@ -80,6 +81,7 @@ class Queue(queue.QueueBase):
                         "priority": 0,
                         "speculative_checks": 1,
                         "batch_size": 1,
+                        "batch_max_wait_time": datetime.timedelta(seconds=0),
                         "allow_inplace_checks": True,
                         "allow_checks_interruption": True,
                         "checks_timeout": None,

--- a/mergify_engine/rules/__init__.py
+++ b/mergify_engine/rules/__init__.py
@@ -74,6 +74,7 @@ class QueueConfig(typing.TypedDict):
     priority: int
     speculative_checks: int
     batch_size: int
+    batch_max_wait_time: datetime.timedelta
     allow_inplace_checks: bool
     allow_checks_interruption: bool
     checks_timeout: typing.Optional[datetime.timedelta]
@@ -477,6 +478,13 @@ def get_pull_request_rules_schema(partial_validation: bool = False) -> voluptuou
     )
 
 
+def PositiveInterval(v: str) -> datetime.timedelta:
+    td = date.interval_from_string(v)
+    if td < datetime.timedelta(seconds=0):
+        raise voluptuous.Invalid("Interval must be positive")
+    return td
+
+
 def ChecksTimeout(v: str) -> datetime.timedelta:
     td = date.interval_from_string(v)
     if td < datetime.timedelta(seconds=60):
@@ -499,6 +507,9 @@ QueueRulesSchema = voluptuous.All(
                 voluptuous.Required("batch_size", default=1): voluptuous.All(
                     int, voluptuous.Range(min=1, max=20)
                 ),
+                voluptuous.Required(
+                    "batch_max_wait_time", default="0 s"
+                ): voluptuous.Coerce(PositiveInterval),
                 voluptuous.Required("allow_inplace_checks", default=True): bool,
                 voluptuous.Required("allow_checks_interruption", default=True): bool,
                 voluptuous.Required(

--- a/mergify_engine/tests/functional/actions/test_queue.py
+++ b/mergify_engine/tests/functional/actions/test_queue.py
@@ -13,6 +13,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+import datetime
 import itertools
 import operator
 import time
@@ -2203,6 +2204,7 @@ DO NOT EDIT
                                 "config": {
                                     "allow_inplace_checks": True,
                                     "allow_checks_interruption": True,
+                                    "batch_max_wait_time": 0.0,
                                     "batch_size": 1,
                                     "checks_timeout": None,
                                     "priority": 1,
@@ -2224,6 +2226,7 @@ DO NOT EDIT
                                 "config": {
                                     "allow_inplace_checks": True,
                                     "allow_checks_interruption": True,
+                                    "batch_max_wait_time": 0.0,
                                     "batch_size": 1,
                                     "checks_timeout": None,
                                     "priority": 0,
@@ -2243,6 +2246,7 @@ DO NOT EDIT
                                     "allow_inplace_checks": True,
                                     "allow_checks_interruption": True,
                                     "batch_size": 1,
+                                    "batch_max_wait_time": 0.0,
                                     "checks_timeout": None,
                                     "priority": 0,
                                     "speculative_checks": 5,
@@ -2914,6 +2918,7 @@ class TestTrainApiCalls(base.FunctionalTestBase):
             priority=0,
             speculative_checks=5,
             batch_size=1,
+            batch_max_wait_time=datetime.timedelta(seconds=0),
             allow_inplace_checks=True,
             allow_checks_interruption=True,
             checks_timeout=None,
@@ -2987,6 +2992,7 @@ class TestTrainApiCalls(base.FunctionalTestBase):
             priority=0,
             speculative_checks=5,
             batch_size=1,
+            batch_max_wait_time=datetime.timedelta(seconds=0),
             allow_inplace_checks=True,
             allow_checks_interruption=True,
             checks_timeout=None,

--- a/mergify_engine/web/api/queues.py
+++ b/mergify_engine/web/api/queues.py
@@ -149,6 +149,7 @@ class Queues:
                                             "config": {
                                                 "priority": 100,
                                                 "batch_size": 1,
+                                                "batch_max_wait_time": 0,
                                                 "speculative_checks": 2,
                                                 "allow_inplace_checks": True,
                                                 "allow_checks_interruption": True,
@@ -171,6 +172,7 @@ class Queues:
                                             "config": {
                                                 "priority": 100,
                                                 "batch_size": 1,
+                                                "batch_max_wait_time": 0,
                                                 "speculative_checks": 2,
                                                 "allow_inplace_checks": True,
                                                 "allow_checks_interruption": True,

--- a/releasenotes/notes/batch_max_wait_time-362c3db513f48cb2.yaml
+++ b/releasenotes/notes/batch_max_wait_time-362c3db513f48cb2.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The ``queue_rules`` section offers a new option ``batch_max_wait_time``.


### PR DESCRIPTION
This change introduces a new queue_rule option `batch_max_wait_time`.

If set, the construction of the temporary pull request is postponed.

This leverages the delayed-refresh mechanism to retrigger the engine
when we waited enought time to proceed the batch.

Fixes MRGFY-781

Change-Id: I58166215b417043096baea446366553ab497d255
