### PR TITLE
fix(queue): control is_behind one last time before merging a pull request

### DIFF
--- a/mergify_engine/actions/queue.py
+++ b/mergify_engine/actions/queue.py
@@ -306,7 +306,11 @@ Then, re-embark the pull request into the merge queue by posting the comment
         if not await q.is_first_pull(ctxt):
             return False
 
-        if not await ctxt.is_behind:
+        if await ctxt.is_behind:
+            car = typing.cast(merge_train.Train, q).get_car(ctxt)
+            if car and car.creation_state == "updated":
+                return False
+        else:
             # NOTE(sileht) check first if PR should be removed from the queue
             pull_rule_checks_status = await merge_base.get_rule_checks_status(
                 ctxt.log, ctxt.repository, [ctxt.pull_request], rule


### PR DESCRIPTION
After we rebase pull requests in-place if something gets merged manually
at a particular timing, the queue can be stuck has Mergify didn't check
one last time before merging the pull request that the pull request is
up-to-date, it blindly trusts the QUEUE_SUMMARY generated for the previous
base sha.

This change adds new control of is_behind, and the pull request will
be rebased one more time.

Fixes MRGFY-822