### PR TITLE
chore(deps): drop eslint-plugin-import-order-alphabetical

### DIFF
--- a/installer/package-lock.json
+++ b/installer/package-lock.json
@@ -24,7 +24,6 @@
         "eslint": "^8.7.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-plugin-import": "^2.25.4",
-        "eslint-plugin-import-order-alphabetical": "^1.0.1",
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-react": "^7.28.0",
         "eslint-plugin-react-hooks": "^4.3.0"
@@ -6341,20 +6340,6 @@
       },
       "peerDependencies": {
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
-      }
-    },
-    "node_modules/eslint-plugin-import-order-alphabetical": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import-order-alphabetical/-/eslint-plugin-import-order-alphabetical-1.0.1.tgz",
-      "integrity": "sha512-fCCIMtD7gkgziKEydRUqviVpEpY7Payg7U8erirqf8rEFpN2GshBuS9A1ClueTQ0VvXEATWTxJC6ihAIHGHDHQ==",
-      "dev": true,
-      "dependencies": {
-        "eslint-module-utils": "^2.2.0",
-        "lodash": "^4.17.4",
-        "resolve": "^1.6.0"
-      },
-      "peerDependencies": {
-        "eslint": "2 - 7"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
@@ -19280,17 +19265,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
-      }
-    },
-    "eslint-plugin-import-order-alphabetical": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import-order-alphabetical/-/eslint-plugin-import-order-alphabetical-1.0.1.tgz",
-      "integrity": "sha512-fCCIMtD7gkgziKEydRUqviVpEpY7Payg7U8erirqf8rEFpN2GshBuS9A1ClueTQ0VvXEATWTxJC6ihAIHGHDHQ==",
-      "dev": true,
-      "requires": {
-        "eslint-module-utils": "^2.2.0",
-        "lodash": "^4.17.4",
-        "resolve": "^1.6.0"
       }
     },
     "eslint-plugin-jest": {

--- a/installer/package.json
+++ b/installer/package.json
@@ -28,20 +28,20 @@
     },
     "extends": [
       "airbnb",
+      "plugin:import/recommended",
       "plugin:import/errors",
       "plugin:import/warnings"
-    ],
-    "plugins": [
-      "eslint-plugin-import-order-alphabetical"
     ],
     "rules": {
       "import/order": [
         "error",
         {
-          "newlines-between": "always-and-inside-groups"
+          "newlines-between": "always-and-inside-groups",
+          "alphabetize": {
+            "order": "asc"
+          }
         }
       ],
-      "import-order-alphabetical/order": "error",
       "jsx-a11y/click-events-have-key-events": "off",
       "jsx-a11y/no-static-element-interactions": "off",
       "jsx-a11y/no-autofocus": "off",
@@ -66,7 +66,6 @@
     "eslint": "^8.7.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-plugin-import": "^2.25.4",
-    "eslint-plugin-import-order-alphabetical": "^1.0.1",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0"


### PR DESCRIPTION
It's deprecated, use eslint-plugin-import order rule instead.

Fixes MRGFY-852

Change-Id: I7fab956f15346d3b6918119ad07f688735444227