### PR TITLE
fix(timezone): compute correct the current-time with TZ

### DIFF
--- a/mergify_engine/date.py
+++ b/mergify_engine/date.py
@@ -187,12 +187,11 @@ class Time:
         if isinstance(obj, datetime.datetime):
             return obj
         elif isinstance(obj, Time):
-            return ref.replace(
+            return ref.astimezone(obj.tzinfo).replace(
                 minute=obj.minute,
                 hour=obj.hour,
                 second=0,
                 microsecond=0,
-                tzinfo=obj.tzinfo,
             )
         else:
             raise ValueError(f"Unsupport comparaison type: {type(obj)}")

--- a/mergify_engine/tests/unit/test_date.py
+++ b/mergify_engine/tests/unit/test_date.py
@@ -111,6 +111,7 @@ def test_time_compare():
         assert date.Time(13, 15, utc) < date.Time(15, 15, utc)
         assert date.Time(15, 0, utc) > date.Time(5, 0, utc)
 
+        # TZ that endup the same day
         zone = zoneinfo.ZoneInfo("Europe/Paris")
         assert date.Time(10, 0, zone) < date.utcnow()
         assert date.Time(18, 45, zone) > date.utcnow()
@@ -118,6 +119,18 @@ def test_time_compare():
         assert date.utcnow() > date.Time(10, 0, zone)
         assert date.utcnow() < date.Time(18, 45, zone)
         assert date.utcnow() == date.Time(13, 15, zone)
+        assert date.Time(13, 15, zone) == date.Time(13, 15, zone)
+        assert date.Time(13, 15, zone) < date.Time(15, 15, zone)
+        assert date.Time(15, 0, zone) > date.Time(5, 0, zone)
+
+        # TZ that endup the next day GMT + 13
+        zone = zoneinfo.ZoneInfo("Pacific/Auckland")
+        assert date.Time(0, 2, zone) < date.utcnow()
+        assert date.Time(2, 9, zone) > date.utcnow()
+        assert date.Time(1, 15, zone) == date.utcnow()
+        assert date.utcnow() > date.Time(0, 2, zone)
+        assert date.utcnow() < date.Time(2, 9, zone)
+        assert date.utcnow() == date.Time(1, 15, zone)
         assert date.Time(13, 15, zone) == date.Time(13, 15, zone)
         assert date.Time(13, 15, zone) < date.Time(15, 15, zone)
         assert date.Time(15, 0, zone) > date.Time(5, 0, zone)


### PR DESCRIPTION
The current code doesn't prepare date with correct offset.
It was only working if the offset endup the same day, not if it
resulting date should be the next day.

Fixes MRGFY-869

Change-Id: I916c6cc353f11d0f524ee67569db7f294f3dd21d
