### PR TITLE
chore(pytest): set asyncio mode to auto

### DIFF
--- a/mergify_engine/tests/functional/api/test_application.py
+++ b/mergify_engine/tests/functional/api/test_application.py
@@ -22,7 +22,6 @@ from mergify_engine import config
 from mergify_engine.tests.functional import conftest as func_conftest
 
 
-@pytest.mark.asyncio
 @pytest.mark.recorder
 async def test_api_application(
     mergify_web_client: httpx.AsyncClient,

--- a/mergify_engine/tests/functional/api/test_auth.py
+++ b/mergify_engine/tests/functional/api/test_auth.py
@@ -49,7 +49,6 @@ def create_testing_router() -> None:
     api_root.app.include_router(router)
 
 
-@pytest.mark.asyncio
 async def test_api_auth_unknown_path(
     mergify_web_client: httpx.AsyncClient,
 ) -> None:
@@ -59,7 +58,6 @@ async def test_api_auth_unknown_path(
     assert r.json() == {"detail": "Not Found"}
 
 
-@pytest.mark.asyncio
 @pytest.mark.recorder
 async def test_api_auth(
     mergify_web_client: httpx.AsyncClient,
@@ -73,7 +71,6 @@ async def test_api_auth(
     assert r.json()["user_login"] == config.TESTING_ORGANIZATION_NAME
 
 
-@pytest.mark.asyncio
 @pytest.mark.recorder
 async def test_api_auth_invalid_token(
     mergify_web_client: httpx.AsyncClient,
@@ -110,7 +107,6 @@ async def test_api_auth_invalid_token(
     assert r.json() == {"detail": "Forbidden"}
 
 
-@pytest.mark.asyncio
 async def test_api_auth_no_token(
     mergify_web_client: httpx.AsyncClient,
     dashboard: func_conftest.DashboardFixture,

--- a/mergify_engine/tests/functional/test_admin_cli.py
+++ b/mergify_engine/tests/functional/test_admin_cli.py
@@ -19,7 +19,6 @@ from mergify_engine import admin
 from mergify_engine import config
 
 
-@pytest.mark.asyncio
 @pytest.mark.recorder
 async def test_suspended() -> None:
     await admin.suspended("PUT", config.TESTING_ORGANIZATION_NAME)

--- a/mergify_engine/tests/functional/test_fixtures.py
+++ b/mergify_engine/tests/functional/test_fixtures.py
@@ -23,7 +23,6 @@ from mergify_engine.dashboard import subscription
 from mergify_engine.tests.functional import conftest as func_conftest
 
 
-@pytest.mark.asyncio
 async def test_fixture_mergify_web_client(
     mergify_web_client: httpx.AsyncClient,
 ) -> None:
@@ -31,7 +30,6 @@ async def test_fixture_mergify_web_client(
     assert r.status_code == 404
 
 
-@pytest.mark.asyncio
 @pytest.mark.recorder
 async def test_fixture_recorder() -> None:
     async with github.AsyncGithubClient(auth=github_app.GithubBearerAuth()) as client:
@@ -41,7 +39,6 @@ async def test_fixture_recorder() -> None:
         assert r.json()["owner"]["login"] == config.TESTING_ORGANIZATION_NAME
 
 
-@pytest.mark.asyncio
 async def test_fixture_dashboard(dashboard: func_conftest.DashboardFixture) -> None:
     assert dashboard.subscription.features == frozenset(
         {subscription.Features.PUBLIC_REPOSITORY}

--- a/mergify_engine/tests/unit/actions/test_merge.py
+++ b/mergify_engine/tests/unit/actions/test_merge.py
@@ -113,7 +113,6 @@ my title
         ("Here's my message", "My PR title (#43)", "Here's my message", "title+body"),
     ],
 )
-@pytest.mark.asyncio
 async def test_merge_commit_message(body, title, message, mode, context_getter):
     ctxt = await context_getter(
         github_types.GitHubPullRequestNumber(43), body=body, title="My PR title"
@@ -162,7 +161,6 @@ on two lines"""
         ),
     ],
 )
-@pytest.mark.asyncio
 async def test_merge_commit_message_undefined(
     body: str, context_getter: conftest.ContextGetterFixture
 ) -> None:
@@ -189,7 +187,6 @@ here is my message {{ and broken template
         ),
     ],
 )
-@pytest.mark.asyncio
 async def test_merge_commit_message_syntax_error(
     body: str, error: str, context_getter: conftest.ContextGetterFixture
 ) -> None:

--- a/mergify_engine/tests/unit/actions/test_queue.py
+++ b/mergify_engine/tests/unit/actions/test_queue.py
@@ -254,7 +254,6 @@ def fake_client() -> mock.Mock:
         ),
     ),
 )
-@pytest.mark.asyncio
 async def test_get_rule_checks_status(
     conditions: typing.Any,
     conclusion: check_api.Conclusion,

--- a/mergify_engine/tests/unit/actions/test_request_reviews.py
+++ b/mergify_engine/tests/unit/actions/test_request_reviews.py
@@ -152,7 +152,6 @@ def test_get_reviewers() -> None:
     assert reviewers == ({"jd"}, {"foobar"})
 
 
-@pytest.mark.asyncio
 async def test_disabled(context_getter: conftest.ContextGetterFixture) -> None:
     action = request_reviews.RequestReviewsAction.get_schema()(
         {
@@ -177,7 +176,6 @@ async def test_disabled(context_getter: conftest.ContextGetterFixture) -> None:
     )
 
 
-@pytest.mark.asyncio
 @pytest.mark.subscription
 async def test_team_permissions_missing(
     context_getter: conftest.ContextGetterFixture,
@@ -213,7 +211,6 @@ async def test_team_permissions_missing(
         assert error in result.summary
 
 
-@pytest.mark.asyncio
 @pytest.mark.subscription
 async def test_team_permissions_ok(
     context_getter: conftest.ContextGetterFixture,

--- a/mergify_engine/tests/unit/engine/test_action_runner.py
+++ b/mergify_engine/tests/unit/engine/test_action_runner.py
@@ -16,8 +16,6 @@
 
 from unittest import mock
 
-import pytest
-
 from mergify_engine import check_api
 from mergify_engine import config
 from mergify_engine import github_types
@@ -26,7 +24,6 @@ from mergify_engine.queue import merge_train
 from mergify_engine.tests.unit import conftest
 
 
-@pytest.mark.asyncio
 async def test_cleanup_pending_actions_with_no_associated_rules(
     context_getter: conftest.ContextGetterFixture,
 ) -> None:

--- a/mergify_engine/tests/unit/engine/test_actions_runner.py
+++ b/mergify_engine/tests/unit/engine/test_actions_runner.py
@@ -74,7 +74,6 @@ pull_request_rules:
         ),
     ],
 )
-@pytest.mark.asyncio
 async def test_get_already_merged_summary(
     merged_by: str,
     raw_config: str,

--- a/mergify_engine/tests/unit/rules/test_filter.py
+++ b/mergify_engine/tests/unit/rules/test_filter.py
@@ -25,8 +25,6 @@ from mergify_engine.rules import filter
 from mergify_engine.rules import parser
 
 
-pytestmark = pytest.mark.asyncio
-
 UTC = datetime.timezone.utc
 
 

--- a/mergify_engine/tests/unit/rules/test_get_rule_checks_status.py
+++ b/mergify_engine/tests/unit/rules/test_get_rule_checks_status.py
@@ -18,7 +18,6 @@ import typing
 from unittest import mock
 
 from freezegun import freeze_time
-import pytest
 import voluptuous
 
 from mergify_engine import check_api
@@ -66,7 +65,6 @@ class FakeQueuePullRequest:
         self.attrs["status-failure"] = self.attrs.get("check-failure", [])  # type: ignore
 
 
-@pytest.mark.asyncio
 async def test_rules_conditions_update():
     pulls = [
         FakeQueuePullRequest(
@@ -141,7 +139,6 @@ async def assert_queue_rule_checks_status(conds, pull, expected_state):
     assert state == expected_state
 
 
-@pytest.mark.asyncio
 async def test_rules_checks_basic(logger_checker):
     pull = FakeQueuePullRequest(
         {
@@ -192,7 +189,6 @@ async def test_rules_checks_basic(logger_checker):
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
 
 
-@pytest.mark.asyncio
 async def test_rules_checks_with_and_or(logger_checker):
     pull = FakeQueuePullRequest(
         {
@@ -266,7 +262,6 @@ async def test_rules_checks_with_and_or(logger_checker):
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
 
 
-@pytest.mark.asyncio
 async def test_rules_checks_status_with_negative_conditions1(logger_checker):
     pull = FakeQueuePullRequest(
         {
@@ -317,7 +312,6 @@ async def test_rules_checks_status_with_negative_conditions1(logger_checker):
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
 
 
-@pytest.mark.asyncio
 async def test_rules_checks_status_with_negative_conditions2():
     pull = FakeQueuePullRequest(
         {
@@ -368,7 +362,6 @@ async def test_rules_checks_status_with_negative_conditions2():
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
 
 
-@pytest.mark.asyncio
 async def test_rules_checks_status_with_negative_conditions3(logger_checker):
     pull = FakeQueuePullRequest(
         {
@@ -419,7 +412,6 @@ async def test_rules_checks_status_with_negative_conditions3(logger_checker):
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
 
 
-@pytest.mark.asyncio
 async def test_rules_checks_status_with_or_conditions():
     pull = FakeQueuePullRequest(
         {
@@ -482,7 +474,6 @@ async def test_rules_checks_status_with_or_conditions():
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.PENDING)
 
 
-@pytest.mark.asyncio
 async def test_rules_checks_status_expected_failure():
     pull = FakeQueuePullRequest(
         {
@@ -523,7 +514,6 @@ async def test_rules_checks_status_expected_failure():
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
 
 
-@pytest.mark.asyncio
 async def test_rules_checks_status_regular():
     pull = FakeQueuePullRequest(
         {
@@ -576,7 +566,6 @@ async def test_rules_checks_status_regular():
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
 
 
-@pytest.mark.asyncio
 async def test_rules_checks_status_regex():
     pull = FakeQueuePullRequest(
         {
@@ -629,7 +618,6 @@ async def test_rules_checks_status_regex():
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.FAILURE)
 
 
-@pytest.mark.asyncio
 @freeze_time("2021-09-22T08:00:05", tz_offset=0)
 async def test_rules_conditions_schedule():
     pulls = [
@@ -675,7 +663,6 @@ async def test_rules_conditions_schedule():
     )
 
 
-@pytest.mark.asyncio
 async def test_rules_checks_status_depop(logger_checker):
     pull = FakeQueuePullRequest(
         {
@@ -781,7 +768,6 @@ async def test_rules_checks_status_depop(logger_checker):
     await assert_queue_rule_checks_status(conds, pull, check_api.Conclusion.SUCCESS)
 
 
-@pytest.mark.asyncio
 async def test_rules_checks_status_ceph(logger_checker):
     pull = FakeQueuePullRequest(
         {

--- a/mergify_engine/tests/unit/rules/test_rules.py
+++ b/mergify_engine/tests/unit/rules/test_rules.py
@@ -49,7 +49,6 @@ def fake_expander(v: str) -> typing.List[str]:
     return ["foo", "bar"]
 
 
-@pytest.mark.asyncio
 async def test_expanders():
     rc = conditions.RuleCondition("author=@team")
     rc.partial_filter.value_expanders["author"] = fake_expander
@@ -75,7 +74,6 @@ class FakeQueuePullRequest:
         return self.attrs[fancy_name]
 
 
-@pytest.mark.asyncio
 async def test_multiple_pulls_to_match():
     c = conditions.QueueRuleConditions(
         [
@@ -418,7 +416,6 @@ def test_jinja_with_wrong_syntax():
         ),
     ),
 )
-@pytest.mark.asyncio
 async def test_get_mergify_config(
     valid: str, fake_repository: context.Repository
 ) -> None:
@@ -445,7 +442,6 @@ async def test_get_mergify_config(
     assert "pull_request_rules" in schema
 
 
-@pytest.mark.asyncio
 async def test_get_mergify_config_with_defaults(
     fake_repository: context.Repository,
 ) -> None:
@@ -529,7 +525,6 @@ pull_request_rules:
     assert comment == {"message": "I really love Mergify", "bot_account": "AutoBot"}
 
 
-@pytest.mark.asyncio
 async def test_get_mergify_config_location_from_cache(
     fake_repository: context.Repository,
 ) -> None:
@@ -608,7 +603,6 @@ async def test_get_mergify_config_location_from_cache(
         ),
     ),
 )
-@pytest.mark.asyncio
 async def test_get_mergify_config_invalid(
     invalid: str, fake_repository: context.Repository
 ) -> None:
@@ -829,7 +823,6 @@ def test_pull_request_rule_schema_invalid(invalid, match):
         pull_request_rule_from_list([invalid])
 
 
-@pytest.mark.asyncio
 async def test_get_pull_request_rule(
     context_getter: conftest.ContextGetterFixture,
 ) -> None:
@@ -1543,7 +1536,6 @@ Invalid GitHub login
     )
 
 
-@pytest.mark.asyncio
 async def test_queue_rules_summary():
     schema = voluptuous.Schema(
         voluptuous.All(
@@ -1673,7 +1665,6 @@ async def test_queue_rules_summary():
     )
 
 
-@pytest.mark.asyncio
 @freeze_time("2021-09-22T08:00:05", tz_offset=0)
 async def test_rules_conditions_schedule():
     pulls = [

--- a/mergify_engine/tests/unit/test_applications.py
+++ b/mergify_engine/tests/unit/test_applications.py
@@ -8,7 +8,6 @@ from mergify_engine.clients import http
 from mergify_engine.dashboard import application
 
 
-@pytest.mark.asyncio
 async def test_init(redis_cache):
     application.Application(
         redis_cache,
@@ -32,7 +31,6 @@ async def test_init(redis_cache):
     )
 
 
-@pytest.mark.asyncio
 async def test_save_apikey_scoped(redis_cache):
     api_access_key = "a" * 32
     api_secret_key = "s" * 32
@@ -70,7 +68,6 @@ async def test_save_apikey_scoped(redis_cache):
     assert app is None
 
 
-@pytest.mark.asyncio
 async def test_save_apikey_unscoped(redis_cache):
     api_access_key = "a" * 32
     api_secret_key = "s" * 32
@@ -97,7 +94,6 @@ async def test_save_apikey_unscoped(redis_cache):
     assert app is None
 
 
-@pytest.mark.asyncio
 async def test_update_apikey(redis_cache):
     api_access_key = "a" * 32
     api_secret_key = "s" * 32
@@ -151,7 +147,6 @@ async def test_update_apikey(redis_cache):
     assert expected_app == rapp
 
 
-@pytest.mark.asyncio
 @mock.patch.object(application.Application, "_retrieve_from_db")
 async def test_application_db_unavailable(retrieve_from_db_mock, redis_cache):
     api_access_key = "a" * 32
@@ -220,7 +215,6 @@ async def test_application_db_unavailable(retrieve_from_db_mock, redis_cache):
     retrieve_from_db_mock.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_unknown_app(redis_cache):
     app = await application.Application._retrieve_from_cache(
         redis_cache, "whatever", "secret", None
@@ -228,7 +222,6 @@ async def test_unknown_app(redis_cache):
     assert app is None
 
 
-@pytest.mark.asyncio
 async def test_application_tokens_via_env(monkeypatch, redis_cache):
     api_access_key1 = "1" * 32
     api_secret_key1 = "1" * 32

--- a/mergify_engine/tests/unit/test_behind.py
+++ b/mergify_engine/tests/unit/test_behind.py
@@ -77,7 +77,6 @@ def commits_tree_generator(request):
     return behind, commits
 
 
-@pytest.mark.asyncio
 async def test_pull_behind(
     commits_tree_generator: typing.Any, context_getter: conftest.ContextGetterFixture
 ) -> None:

--- a/mergify_engine/tests/unit/test_clients.py
+++ b/mergify_engine/tests/unit/test_clients.py
@@ -30,7 +30,6 @@ from mergify_engine.clients import http
 
 
 @mock.patch.object(github.CachedToken, "STORAGE", {})
-@pytest.mark.asyncio
 async def test_client_installation_token_with_owner_id(
     httpserver: httpserver.HTTPServer,
 ) -> None:
@@ -82,7 +81,6 @@ async def test_client_installation_token_with_owner_id(
 
 
 @mock.patch.object(github.CachedToken, "STORAGE", {})
-@pytest.mark.asyncio
 async def test_client_user_token(httpserver: httpserver.HTTPServer) -> None:
     with mock.patch(
         "mergify_engine.config.GITHUB_REST_API_URL",
@@ -127,7 +125,6 @@ async def test_client_user_token(httpserver: httpserver.HTTPServer) -> None:
 
 
 @mock.patch.object(github.CachedToken, "STORAGE", {})
-@pytest.mark.asyncio
 async def test_client_401_raise_ratelimit(httpserver: httpserver.HTTPServer) -> None:
     owner_id = github_types.GitHubAccountIdType(12345)
     owner_login = github_types.GitHubLogin("owner")
@@ -170,7 +167,6 @@ async def test_client_401_raise_ratelimit(httpserver: httpserver.HTTPServer) -> 
     httpserver.check_assertions()  # type: ignore [no-untyped-call]
 
 
-@pytest.mark.asyncio
 async def test_client_HTTP_400(httpserver: httpserver.HTTPServer) -> None:
     httpserver.expect_oneshot_request("/").respond_with_json(
         {"message": "This is an 4XX error"}, status=400
@@ -188,7 +184,6 @@ async def test_client_HTTP_400(httpserver: httpserver.HTTPServer) -> None:
     httpserver.check_assertions()  # type: ignore [no-untyped-call]
 
 
-@pytest.mark.asyncio
 async def test_client_HTTP_500(httpserver: httpserver.HTTPServer) -> None:
     httpserver.expect_request("/").respond_with_data("This is an 5XX error", status=500)
 
@@ -207,7 +202,6 @@ async def test_client_HTTP_500(httpserver: httpserver.HTTPServer) -> None:
     httpserver.check_assertions()  # type: ignore [no-untyped-call]
 
 
-@pytest.mark.asyncio
 async def test_client_temporary_HTTP_500(httpserver: httpserver.HTTPServer) -> None:
     httpserver.expect_oneshot_request("/").respond_with_data(
         "This is an 5XX error", status=500
@@ -229,7 +223,6 @@ async def test_client_temporary_HTTP_500(httpserver: httpserver.HTTPServer) -> N
     httpserver.check_assertions()  # type: ignore [no-untyped-call]
 
 
-@pytest.mark.asyncio
 async def test_client_connection_error() -> None:
     async with http.AsyncClient() as client:
         with pytest.raises(http.RequestError):
@@ -260,14 +253,12 @@ async def _do_test_client_retry_429(
     httpserver.check_assertions()  # type: ignore [no-untyped-call]
 
 
-@pytest.mark.asyncio
 async def test_client_retry_429_retry_after_as_seconds(
     httpserver: httpserver.HTTPServer,
 ) -> None:
     await _do_test_client_retry_429(httpserver, "3", 3)
 
 
-@pytest.mark.asyncio
 async def test_client_retry_429_retry_after_as_absolute_date(
     httpserver: httpserver.HTTPServer,
 ) -> None:
@@ -276,7 +267,6 @@ async def test_client_retry_429_retry_after_as_absolute_date(
 
 
 @mock.patch.object(github.CachedToken, "STORAGE", {})
-@pytest.mark.asyncio
 async def test_client_access_token_HTTP_500(httpserver: httpserver.HTTPServer) -> None:
     httpserver.expect_request("/user/12345/installation").respond_with_json(
         {
@@ -321,7 +311,6 @@ async def test_client_access_token_HTTP_500(httpserver: httpserver.HTTPServer) -
 
 
 @mock.patch.object(github.CachedToken, "STORAGE", {})
-@pytest.mark.asyncio
 async def test_client_installation_HTTP_500(httpserver: httpserver.HTTPServer) -> None:
     httpserver.expect_request("/user/12345/installation").respond_with_data(
         "This is an 5XX error", status=500
@@ -350,7 +339,6 @@ async def test_client_installation_HTTP_500(httpserver: httpserver.HTTPServer) -
 
 
 @mock.patch.object(github.CachedToken, "STORAGE", {})
-@pytest.mark.asyncio
 async def test_client_installation_HTTP_404(httpserver: httpserver.HTTPServer) -> None:
     httpserver.expect_request("/user/12345/installation").respond_with_json(
         {"message": "Repository not found"}, status=404
@@ -370,7 +358,6 @@ async def test_client_installation_HTTP_404(httpserver: httpserver.HTTPServer) -
 
 
 @mock.patch.object(github.CachedToken, "STORAGE", {})
-@pytest.mark.asyncio
 async def test_client_installation_HTTP_301(httpserver: httpserver.HTTPServer) -> None:
     httpserver.expect_request("/user/12345/installation").respond_with_data(
         status=301,
@@ -394,7 +381,6 @@ async def test_client_installation_HTTP_301(httpserver: httpserver.HTTPServer) -
 
 
 @mock.patch.object(github.CachedToken, "STORAGE", {})
-@pytest.mark.asyncio
 async def test_client_abuse_403_no_header(httpserver: httpserver.HTTPServer) -> None:
 
     abuse_message = (

--- a/mergify_engine/tests/unit/test_command.py
+++ b/mergify_engine/tests/unit/test_command.py
@@ -115,7 +115,6 @@ defaults:
     }
 
 
-@pytest.mark.asyncio
 async def test_run_command_without_rerun_and_without_user(
     context_getter: conftest.ContextGetterFixture,
 ) -> None:
@@ -132,7 +131,6 @@ async def test_run_command_without_rerun_and_without_user(
     assert "user must be set if rerun is false" in str(error_msg.value)
 
 
-@pytest.mark.asyncio
 async def test_run_command_with_rerun_and_without_user(
     context_getter: conftest.ContextGetterFixture,
 ) -> None:
@@ -192,7 +190,6 @@ async def test_run_command_with_rerun_and_without_user(
         ),
     ],
 )
-@pytest.mark.asyncio
 async def test_run_command_with_user(
     user_id: int,
     permission: str,
@@ -240,7 +237,6 @@ async def test_run_command_with_user(
     assert result in client.post.call_args_list[0][1]["json"]["body"]
 
 
-@pytest.mark.asyncio
 async def test_run_command_with_wrong_arg(
     context_getter: conftest.ContextGetterFixture,
 ) -> None:

--- a/mergify_engine/tests/unit/test_context.py
+++ b/mergify_engine/tests/unit/test_context.py
@@ -27,7 +27,6 @@ from mergify_engine.clients import http
 from mergify_engine.dashboard import subscription
 
 
-@pytest.mark.asyncio
 async def test_user_permission_cache(redis_cache: utils.RedisCache) -> None:
     class FakeClient(github.AsyncGithubInstallationClient):
         called: int
@@ -196,7 +195,6 @@ async def test_user_permission_cache(redis_cache: utils.RedisCache) -> None:
     assert client.called == 7
 
 
-@pytest.mark.asyncio
 async def test_team_members_cache(redis_cache: utils.RedisCache) -> None:
     class FakeClient(github.AsyncGithubInstallationClient):
         called: int
@@ -318,7 +316,6 @@ async def test_team_members_cache(redis_cache: utils.RedisCache) -> None:
     assert client.called == 7
 
 
-@pytest.mark.asyncio
 async def test_team_permission_cache(redis_cache: utils.RedisCache) -> None:
     class FakeClient(github.AsyncGithubInstallationClient):
         called: int
@@ -569,7 +566,6 @@ def a_pull_request() -> github_types.GitHubPullRequest:
     )
 
 
-@pytest.mark.asyncio
 async def test_context_depends_on(a_pull_request):
     a_pull_request[
         "body"
@@ -596,14 +592,12 @@ footer
     assert ctxt.get_depends_on() == [42, 48, 50, 123, 456, 457, 789]
 
 
-@pytest.mark.asyncio
 async def test_context_body_null(a_pull_request):
     a_pull_request["body"] = None
     ctxt = await context.Context.create(mock.Mock(), a_pull_request)
     assert await ctxt._get_consolidated_data("body") == ""
 
 
-@pytest.mark.asyncio
 async def test_context_body_html(a_pull_request):
     a_pull_request["title"] = "chore(deps-dev): update flake8 requirement from <4 to <5"
     a_pull_request[
@@ -711,7 +705,6 @@ You can trigger Dependabot actions by commenting on this PR:
     ) == (expected_title, expected_body)
 
 
-@pytest.mark.asyncio
 async def test_context_body_section(a_pull_request):
     a_pull_request[
         "title"
@@ -757,7 +750,6 @@ Fixes MRGFY-XXX"""
     )
 
 
-@pytest.mark.asyncio
 async def test_context_unexisting_section(a_pull_request):
     ctxt = await context.Context.create(mock.Mock(), a_pull_request)
     assert (
@@ -769,7 +761,6 @@ async def test_context_unexisting_section(a_pull_request):
     )
 
 
-@pytest.mark.asyncio
 async def test_context_unexisting_section_with_templated_default(a_pull_request):
     ctxt = await context.Context.create(mock.Mock(), a_pull_request)
     assert (
@@ -781,7 +772,6 @@ async def test_context_unexisting_section_with_templated_default(a_pull_request)
     )
 
 
-@pytest.mark.asyncio
 async def test_context_body_section_with_template(a_pull_request):
     a_pull_request[
         "body"

--- a/mergify_engine/tests/unit/test_count_seats.py
+++ b/mergify_engine/tests/unit/test_count_seats.py
@@ -75,7 +75,6 @@ def test_seats_renamed_account_repo() -> None:
     assert repos == {repo1, repo2}
 
 
-@pytest.mark.asyncio
 async def test_send_seats(httpserver: httpserver.HTTPServer) -> None:
     httpserver.expect_request(
         "/on-premise/report",
@@ -102,7 +101,6 @@ for filename in os.listdir(_EVENT_DIR):
 
 
 @freeze_time("2011-11-11")
-@pytest.mark.asyncio
 @pytest.mark.parametrize("event_type, event", list(GITHUB_SAMPLE_EVENTS.values()))
 async def test_store_active_users(event_type, event, redis_cache):
     await count_seats.store_active_users(redis_cache, event_type, event)
@@ -138,7 +136,6 @@ async def test_store_active_users(event_type, event, redis_cache):
 
 
 @freeze_time("2011-11-11")
-@pytest.mark.asyncio
 @pytest.mark.parametrize("event_type, event", list(GITHUB_SAMPLE_EVENTS.values()))
 async def test_get_usage(event_type, event, redis_cache):
     await (count_seats.store_active_users(redis_cache, event_type, event))

--- a/mergify_engine/tests/unit/test_duplicate.py
+++ b/mergify_engine/tests/unit/test_duplicate.py
@@ -16,8 +16,6 @@
 import typing
 from unittest import mock
 
-import pytest
-
 from mergify_engine import duplicate_pull
 from mergify_engine import github_types
 from mergify_engine.tests.unit import conftest
@@ -56,7 +54,6 @@ async def fake_get_github_pulls_from_sha(url, api_version=None):
     "mergify_engine.context.Context.commits",
     new_callable=mock.PropertyMock,
 )
-@pytest.mark.asyncio
 async def test_get_commits_to_cherry_pick_rebase(
     commits: mock.PropertyMock,
     context_getter: conftest.ContextGetterFixture,
@@ -125,7 +122,6 @@ async def test_get_commits_to_cherry_pick_rebase(
     "mergify_engine.context.Context.commits",
     new_callable=mock.PropertyMock,
 )
-@pytest.mark.asyncio
 async def test_get_commits_to_cherry_pick_merge(
     commits: mock.PropertyMock,
     context_getter: conftest.ContextGetterFixture,

--- a/mergify_engine/tests/unit/test_engine.py
+++ b/mergify_engine/tests/unit/test_engine.py
@@ -16,7 +16,6 @@
 
 import base64
 
-import pytest
 from pytest_httpserver import httpserver
 
 from mergify_engine import context
@@ -170,7 +169,6 @@ CHECK_RUN = github_types.GitHubCheckRun(
 BASE_URL = f"/repos/{GH_OWNER['login']}/{GH_REPO['name']}"
 
 
-@pytest.mark.asyncio
 async def test_configuration_changed(
     github_server: httpserver.HTTPServer,
     redis_cache: utils.RedisCache,
@@ -259,7 +257,6 @@ async def test_configuration_changed(
     github_server.check_assertions()  # type: ignore [no-untyped-call]
 
 
-@pytest.mark.asyncio
 async def test_configuration_duplicated(
     github_server: httpserver.HTTPServer,
     redis_cache: utils.RedisCache,
@@ -370,7 +367,6 @@ async def test_configuration_duplicated(
     github_server.check_assertions()  # type: ignore [no-untyped-call]
 
 
-@pytest.mark.asyncio
 async def test_configuration_not_changed(
     github_server: httpserver.HTTPServer,
     redis_cache: utils.RedisCache,
@@ -470,7 +466,6 @@ async def test_configuration_not_changed(
     github_server.check_assertions()  # type: ignore [no-untyped-call]
 
 
-@pytest.mark.asyncio
 async def test_configuration_initial(
     github_server: httpserver.HTTPServer,
     redis_cache: utils.RedisCache,

--- a/mergify_engine/tests/unit/test_github_events.py
+++ b/mergify_engine/tests/unit/test_github_events.py
@@ -69,7 +69,6 @@ async def _do_test_event_to_pull_check_run(
     assert pulls == expected_pulls
 
 
-@pytest.mark.asyncio
 async def test_event_to_pull_check_run_forked_repo(
     redis_cache: utils.RedisCache,
 ) -> None:
@@ -78,7 +77,6 @@ async def test_event_to_pull_check_run_forked_repo(
     )
 
 
-@pytest.mark.asyncio
 async def test_event_to_pull_check_run_same_repo(redis_cache: utils.RedisCache) -> None:
     await _do_test_event_to_pull_check_run(
         redis_cache, "check_run.event_from_same_repo.json", [409]
@@ -95,7 +93,6 @@ for filename in os.listdir(_EVENT_DIR):
 
 @pytest.mark.parametrize("event_type, event", list(GITHUB_SAMPLE_EVENTS.values()))
 @mock.patch("mergify_engine.worker.push")
-@pytest.mark.asyncio
 async def test_filter_and_dispatch(
     worker_push: mock.Mock,
     event_type: github_types.GitHubEventType,

--- a/mergify_engine/tests/unit/test_gitter.py
+++ b/mergify_engine/tests/unit/test_gitter.py
@@ -22,7 +22,6 @@ import pytest
 from mergify_engine import gitter
 
 
-@pytest.mark.asyncio
 async def test_gitter(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANG", "C")
     git = gitter.Gitter(mock.Mock())

--- a/mergify_engine/tests/unit/test_migrations.py
+++ b/mergify_engine/tests/unit/test_migrations.py
@@ -15,13 +15,10 @@
 import typing
 from unittest import mock
 
-import pytest
-
 from mergify_engine import migrations
 from mergify_engine import utils
 
 
-@pytest.mark.asyncio
 async def test_0001_merge_train_hash(
     redis_cache: utils.RedisCache,
 ) -> None:
@@ -55,7 +52,6 @@ async def test_0001_merge_train_hash(
         assert await redis_cache.hgetall(train) == expected_trains[owner_id]
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.migrations._run_scripts")
 async def test_legacy_stamps(
     _: mock.Mock,
@@ -67,7 +63,6 @@ async def test_legacy_stamps(
     assert await redis_cache.get("migration-stamps") == "1"
 
 
-@pytest.mark.asyncio
 async def test_0002_pull_request_sha_number(
     redis_cache: utils.RedisCache,
 ) -> None:
@@ -91,7 +86,6 @@ async def test_0002_pull_request_sha_number(
         assert key == "migration-stamps" or key.startswith("summary-sha~")
 
 
-@pytest.mark.asyncio
 async def test_0003_attempts(
     redis_cache: utils.RedisCache,
 ) -> None:

--- a/mergify_engine/tests/unit/test_signals.py
+++ b/mergify_engine/tests/unit/test_signals.py
@@ -14,14 +14,11 @@
 
 from unittest import mock
 
-import pytest
-
 from mergify_engine import github_types
 from mergify_engine import signals
 from mergify_engine.tests.unit import conftest
 
 
-@pytest.mark.asyncio
 async def test_signals(context_getter: conftest.ContextGetterFixture) -> None:
     assert len(signals.SIGNALS) == 0
     signals.setup()

--- a/mergify_engine/tests/unit/test_subscription.py
+++ b/mergify_engine/tests/unit/test_subscription.py
@@ -9,7 +9,6 @@ from mergify_engine.clients import http
 from mergify_engine.dashboard import subscription
 
 
-@pytest.mark.asyncio
 async def test_init(redis_cache):
     subscription.Subscription(
         redis_cache,
@@ -19,7 +18,6 @@ async def test_init(redis_cache):
     )
 
 
-@pytest.mark.asyncio
 async def test_dict(redis_cache):
     owner_id = 1234
     sub = subscription.Subscription(
@@ -44,7 +42,6 @@ async def test_dict(redis_cache):
         },
     ),
 )
-@pytest.mark.asyncio
 async def test_save_sub(features, redis_cache):
     owner_id = 1234
     sub = subscription.Subscription(
@@ -61,7 +58,6 @@ async def test_save_sub(features, redis_cache):
     assert rsub == sub
 
 
-@pytest.mark.asyncio
 @mock.patch.object(subscription.Subscription, "_retrieve_subscription_from_db")
 async def test_subscription_db_unavailable(
     retrieve_subscription_from_db_mock, redis_cache
@@ -117,7 +113,6 @@ async def test_subscription_db_unavailable(
     retrieve_subscription_from_db_mock.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_unknown_sub(redis_cache):
     sub = await subscription.Subscription._retrieve_subscription_from_cache(
         redis_cache, 98732189
@@ -125,7 +120,6 @@ async def test_unknown_sub(redis_cache):
     assert sub is None
 
 
-@pytest.mark.asyncio
 async def test_from_dict_unknown_features(redis_cache):
     assert subscription.Subscription.from_dict(
         redis_cache,
@@ -143,7 +137,6 @@ async def test_from_dict_unknown_features(redis_cache):
     )
 
 
-@pytest.mark.asyncio
 async def test_active_feature(redis_cache):
     sub = subscription.Subscription(
         redis_cache,
@@ -173,7 +166,6 @@ async def test_active_feature(redis_cache):
     assert sub.has_feature(subscription.Features.PRIORITY_QUEUES) is False
 
 
-@pytest.mark.asyncio
 async def test_subscription_on_premise_valid(
     redis_cache: utils.RedisCache,
     httpserver: httpserver.HTTPServer,
@@ -207,7 +199,6 @@ async def test_subscription_on_premise_valid(
     httpserver.check_assertions()  # type: ignore [no-untyped-call]
 
 
-@pytest.mark.asyncio
 async def test_subscription_on_premise_wrong_token(
     redis_cache: utils.RedisCache,
     httpserver: httpserver.HTTPServer,
@@ -230,7 +221,6 @@ async def test_subscription_on_premise_wrong_token(
     httpserver.check_assertions()  # type: ignore [no-untyped-call]
 
 
-@pytest.mark.asyncio
 async def test_subscription_on_premise_invalid_sub(
     redis_cache: utils.RedisCache,
     httpserver: httpserver.HTTPServer,

--- a/mergify_engine/tests/unit/test_synchronize.py
+++ b/mergify_engine/tests/unit/test_synchronize.py
@@ -16,14 +16,11 @@
 
 from unittest import mock
 
-import pytest
-
 from mergify_engine import check_api
 from mergify_engine import github_types
 from mergify_engine.tests.unit import conftest
 
 
-@pytest.mark.asyncio
 async def test_summary_synchronization_cache(
     context_getter: conftest.ContextGetterFixture,
 ) -> None:

--- a/mergify_engine/tests/unit/test_train.py
+++ b/mergify_engine/tests/unit/test_train.py
@@ -203,7 +203,6 @@ def get_config(queue_name: str, priority: int = 100) -> queue.PullQueueConfig:
     )
 
 
-@pytest.mark.asyncio
 async def test_train_add_pull(
     context_getter: conftest.ContextGetterFixture,
     repository: context.Repository,
@@ -238,7 +237,6 @@ async def test_train_add_pull(
     assert [[1], [1, 3]] == get_cars_content(t)
 
 
-@pytest.mark.asyncio
 async def test_train_remove_middle_merged(
     repository: context.Repository, context_getter: conftest.ContextGetterFixture
 ) -> None:
@@ -259,7 +257,6 @@ async def test_train_remove_middle_merged(
     assert [[1], [1, 3]] == get_cars_content(t)
 
 
-@pytest.mark.asyncio
 async def test_train_remove_middle_not_merged(
     repository: context.Repository, context_getter: conftest.ContextGetterFixture
 ) -> None:
@@ -278,7 +275,6 @@ async def test_train_remove_middle_not_merged(
     assert [[1], [1, 3]] == get_cars_content(t)
 
 
-@pytest.mark.asyncio
 async def test_train_remove_head_not_merged(
     repository: context.Repository, context_getter: conftest.ContextGetterFixture
 ) -> None:
@@ -298,7 +294,6 @@ async def test_train_remove_head_not_merged(
     assert [[2], [2, 3]] == get_cars_content(t)
 
 
-@pytest.mark.asyncio
 async def test_train_remove_head_merged(
     repository: context.Repository, context_getter: conftest.ContextGetterFixture
 ) -> None:
@@ -320,7 +315,6 @@ async def test_train_remove_head_merged(
     assert [[1, 2], [1, 2, 3]] == get_cars_content(t)
 
 
-@pytest.mark.asyncio
 async def test_train_add_remove_pull_idempotant(
     repository: context.Repository, context_getter: conftest.ContextGetterFixture
 ) -> None:
@@ -358,7 +352,6 @@ async def test_train_add_remove_pull_idempotant(
     assert [[1], [1, 3]] == get_cars_content(t)
 
 
-@pytest.mark.asyncio
 async def test_train_mutiple_queue(
     repository: context.Repository, context_getter: conftest.ContextGetterFixture
 ) -> None:
@@ -418,7 +411,6 @@ async def test_train_mutiple_queue(
     assert [9] == get_waiting_content(t)
 
 
-@pytest.mark.asyncio
 async def test_train_remove_duplicates(
     repository: context.Repository, context_getter: conftest.ContextGetterFixture
 ) -> None:
@@ -455,7 +447,6 @@ async def test_train_remove_duplicates(
     assert [3, 4] == get_waiting_content(t)
 
 
-@pytest.mark.asyncio
 async def test_train_remove_end_wp(
     repository: context.Repository, context_getter: conftest.ContextGetterFixture
 ) -> None:
@@ -476,7 +467,6 @@ async def test_train_remove_end_wp(
     assert [2] == get_waiting_content(t)
 
 
-@pytest.mark.asyncio
 async def test_train_remove_first_wp(
     repository: context.Repository, context_getter: conftest.ContextGetterFixture
 ) -> None:
@@ -497,7 +487,6 @@ async def test_train_remove_first_wp(
     assert [3] == get_waiting_content(t)
 
 
-@pytest.mark.asyncio
 async def test_train_remove_last_cars(
     repository: context.Repository, context_getter: conftest.ContextGetterFixture
 ) -> None:
@@ -518,7 +507,6 @@ async def test_train_remove_last_cars(
     assert [3] == get_waiting_content(t)
 
 
-@pytest.mark.asyncio
 async def test_train_with_speculative_checks_decreased(
     repository: context.Repository, context_getter: conftest.ContextGetterFixture
 ) -> None:
@@ -561,7 +549,6 @@ queue_rules:
     assert [4, 5] == get_waiting_content(t)
 
 
-@pytest.mark.asyncio
 async def test_train_queue_config_change(
     repository: context.Repository, context_getter: conftest.ContextGetterFixture
 ) -> None:
@@ -592,7 +579,6 @@ queue_rules:
     assert [2, 3] == get_waiting_content(t)
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.queue.merge_train.TrainCar._set_creation_failure")
 async def test_train_queue_config_deleted(
     report_failure: mock.Mock,
@@ -627,7 +613,6 @@ queue_rules:
     assert len(report_failure.mock_calls) == 1
 
 
-@pytest.mark.asyncio
 async def test_train_priority_change(
     repository: context.Repository,
     context_getter: conftest.ContextGetterFixture,
@@ -689,7 +674,6 @@ def test_train_batch_split(repository: context.Repository) -> None:
     )
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.queue.merge_train.TrainCar._set_creation_failure")
 async def test_train_queue_splitted_on_failure_1x2(
     report_failure: mock.Mock,
@@ -739,7 +723,6 @@ async def test_train_queue_splitted_on_failure_1x2(
     assert t._cars[0].creation_state == "created"  # type: ignore[comparison-overlap]
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.queue.merge_train.TrainCar._set_creation_failure")
 async def test_train_queue_splitted_on_failure_1x5(
     report_failure: mock.Mock,
@@ -831,7 +814,6 @@ async def test_train_queue_splitted_on_failure_1x5(
     assert t._cars[0].creation_state == "created"
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.queue.merge_train.TrainCar._set_creation_failure")
 async def test_train_queue_splitted_on_failure_2x5(
     report_failure: mock.Mock,
@@ -934,7 +916,6 @@ async def test_train_queue_splitted_on_failure_2x5(
     assert t._cars[1].creation_state == "created"
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.queue.merge_train.TrainCar._set_creation_failure")
 async def test_train_queue_splitted_on_failure_5x3(
     report_failure: mock.Mock,
@@ -1069,7 +1050,6 @@ async def test_train_queue_splitted_on_failure_5x3(
     assert [] == get_waiting_content(t)
 
 
-@pytest.mark.asyncio
 async def test_train_no_interrupt_add_pull(
     repository: context.Repository, context_getter: conftest.ContextGetterFixture
 ) -> None:
@@ -1101,7 +1081,6 @@ async def test_train_no_interrupt_add_pull(
     assert [4, 3] == get_waiting_content(t)
 
 
-@pytest.mark.asyncio
 async def test_train_batch_max_wait_time(
     repository: context.Repository, context_getter: conftest.ContextGetterFixture
 ) -> None:

--- a/mergify_engine/tests/unit/test_user_tokens.py
+++ b/mergify_engine/tests/unit/test_user_tokens.py
@@ -7,7 +7,6 @@ from mergify_engine.clients import http
 from mergify_engine.dashboard import user_tokens
 
 
-@pytest.mark.asyncio
 async def test_init(redis_cache):
     user_tokens.UserTokens(redis_cache, 123, [])
 
@@ -28,7 +27,6 @@ async def test_init(redis_cache):
         ],
     ),
 )
-@pytest.mark.asyncio
 async def test_save_ut(users, redis_cache):
     owner_id = 1234
     ut = user_tokens.UserTokens(
@@ -42,7 +40,6 @@ async def test_save_ut(users, redis_cache):
     assert ut == rut
 
 
-@pytest.mark.asyncio
 @mock.patch.object(user_tokens.UserTokens, "_retrieve_from_db")
 async def test_user_tokens_db_unavailable(retrieve_from_db_mock, redis_cache):
     owner_id = 1234
@@ -91,13 +88,11 @@ async def test_user_tokens_db_unavailable(retrieve_from_db_mock, redis_cache):
     retrieve_from_db_mock.assert_called_once()
 
 
-@pytest.mark.asyncio
 async def test_unknown_ut(redis_cache):
     tokens = await user_tokens.UserTokens._retrieve_from_cache(redis_cache, 98732189)
     assert tokens is None
 
 
-@pytest.mark.asyncio
 async def test_user_tokens_tokens_via_env(monkeypatch, redis_cache):
     ut = await user_tokens.UserTokensOnPremise.get(redis_cache, 123)
 

--- a/mergify_engine/tests/unit/test_utils.py
+++ b/mergify_engine/tests/unit/test_utils.py
@@ -135,7 +135,6 @@ def test_split_list():
     ]
 
 
-@pytest.mark.asyncio
 async def test_refresh_with_pull_request_number(
     redis_stream: utils.RedisStream,
     redis_cache: utils.RedisCache,

--- a/mergify_engine/tests/unit/test_worker.py
+++ b/mergify_engine/tests/unit/test_worker.py
@@ -136,7 +136,6 @@ class InstallationMatcher:
         return self.owner == installation.owner_login
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 @mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
 @mock.patch("mergify_engine.worker.run_engine")
@@ -241,7 +240,6 @@ async def test_worker_legacy_push(
     )
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 @mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
 @mock.patch("mergify_engine.worker.run_engine")
@@ -324,7 +322,6 @@ async def test_worker_with_waiting_tasks(
     )
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 @mock.patch("mergify_engine.worker.run_engine")
 @mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
@@ -460,7 +457,6 @@ async def test_worker_expanded_events(
     )
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 @mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
 @mock.patch("mergify_engine.worker.run_engine")
@@ -532,7 +528,6 @@ async def test_worker_with_one_task(
     )
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 @mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
 @mock.patch("mergify_engine.worker.run_engine")
@@ -551,7 +546,6 @@ async def test_consume_unexisting_stream(
     assert len(run_engine.mock_calls) == 0
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 @mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
 @mock.patch("mergify_engine.worker.run_engine")
@@ -623,7 +617,6 @@ async def test_consume_good_stream(
     assert 0 == len(await redis_stream.hgetall("attempts"))
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.worker.daiquiri.getLogger")
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 @mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
@@ -758,7 +751,6 @@ async def test_stream_processor_retrying_pull(
     assert 0 == len(await redis_stream.hgetall("attempts"))
 
 
-@pytest.mark.asyncio
 @mock.patch.object(worker, "LOG")
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 @mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
@@ -856,7 +848,6 @@ async def test_stream_processor_retrying_stream_recovered(
     assert logger.info.mock_calls[0].args == ("failed to process org bucket, retrying",)
 
 
-@pytest.mark.asyncio
 @mock.patch.object(worker, "LOG")
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 @mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
@@ -957,7 +948,6 @@ async def test_stream_processor_retrying_stream_failure(
     assert 1 == len(await redis_stream.hgetall("attempts"))
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.worker.daiquiri.getLogger")
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 @mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
@@ -1002,7 +992,6 @@ async def test_stream_processor_pull_unexpected_error(
     assert 0 == len(await redis_stream.hgetall("attempts"))
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 @mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
 @mock.patch("mergify_engine.worker.run_engine")
@@ -1091,7 +1080,6 @@ async def test_stream_processor_date_scheduling(
     assert received == [wanted_owner_id, unwanted_owner_id]
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 async def test_worker_drop_bucket(
     get_subscription, redis_stream, redis_cache, logger_checker
@@ -1138,7 +1126,6 @@ async def test_worker_drop_bucket(
     assert 0 == len(await redis_stream.hgetall("attempts"))
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 async def test_worker_debug_report(
     get_subscription, redis_stream, redis_cache, logger_checker
@@ -1164,7 +1151,6 @@ async def test_worker_debug_report(
     await worker.async_status()
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 @mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
 @mock.patch("mergify_engine.worker.run_engine")
@@ -1196,7 +1182,6 @@ async def test_stream_processor_retrying_after_read_error(
             await worker.run_engine(installation, 123, "repo", 1234, [])
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 @mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
 @mock.patch("mergify_engine.worker.run_engine")
@@ -1239,7 +1224,6 @@ async def test_stream_processor_ignore_503(
     assert 0 == len(await redis_stream.hgetall("attempts"))
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 @mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
 @mock.patch("mergify_engine.worker.run_engine")
@@ -1309,7 +1293,6 @@ async def test_worker_with_multiple_workers(
     assert 200 == len(run_engine.mock_calls)
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 @mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
 @mock.patch("mergify_engine.worker.run_engine")
@@ -1363,7 +1346,6 @@ async def test_worker_reschedule(
     assert planned_for > planned_for_rescheduled
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 @mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
 @mock.patch("mergify_engine.worker.run_engine")
@@ -1395,7 +1377,6 @@ async def test_worker_stuck_shutdown(
     await run_worker(test_timeout=2, shutdown_timeout=1)
 
 
-@pytest.mark.asyncio
 @mock.patch("mergify_engine.worker.subscription.Subscription.get_subscription")
 @mock.patch("mergify_engine.clients.github.get_installation_from_account_id")
 @mock.patch("mergify_engine.worker.run_engine")

--- a/setup.cfg
+++ b/setup.cfg
@@ -143,6 +143,7 @@ plugins = pydantic.mypy
 
 [tool:pytest]
 addopts = --strict-markers
+asyncio_mode = auto
 markers =
   recorder
   subscription


### PR DESCRIPTION
We have to make a choice between auto or strict:

https://github.com/pytest-dev/pytest-asyncio#modes

The current mode is legacy and we have a bit of auto mode and strict
mode.

This change to auto and remove all manual marking.