### PR TITLE
fix(worker): ignore pull request on archived repo

### DIFF
--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -243,6 +243,10 @@ async def run_engine(
             logger.debug("pull request doesn't exists, skipping it")
             return None
 
+        if ctxt.repository.repo["archived"]:
+            logger.debug("repository archived, skipping it")
+            return None
+
         result = await engine.run(ctxt, sources)
         if result is not None:
             result.started_at = started_at


### PR DESCRIPTION
When the repository is archived, we ignore new events from GitHub
webhook, but we might have some events on the worker side waiting to be
proceed.

This change drops them.

Fixes MERGIFY-ENGINE-2J0

Change-Id: I63bc2b0ee30cf6cb888cacc459b1e0201ca21c41