### PR TITLE
fix(test): remove arguments from pytest requests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,10 +17,10 @@ setenv =
 usedevelop = true
 extras = test
 install_command = pip install -c requirements.txt {opts} {packages}
-commands = {toxinidir}/run-tests.sh pytest -v --timeout_method thread --pyargs mergify_engine {posargs}
+commands = {toxinidir}/run-tests.sh pytest -v --timeout_method thread {posargs}
 
 [testenv:cover]
-commands = {toxinidir}/run-tests.sh pytest -v --pyargs mergify_engine --cov=mergify_engine --cov-config .coveragerc {posargs}
+commands = {toxinidir}/run-tests.sh pytest -v --cov=mergify_engine --cov-config .coveragerc {posargs}
 
 [testenv:record]
 envdir={toxworkdir}/py310


### PR DESCRIPTION
removing "--pyargs mergify_engine" in tox.ini pytest requests

Fixes MRGFY-895

<!--

## Checklists (Just for information, delete me before creating the pull requests)

- [ ]  All checks must pass (Semantic Pull Request, pep8, requirements, unit tests, functional tests, security checks, …)
- [ ]  The code changed/added as part of this pull request must be covered with tests
- [ ]  Hotfixes must have a link to Sentry issue and the `hotfix` label
- [ ]  Features and fixes must have a link to a Linear task
- [ ]  Features must have changes in docs/
- [ ]  Features must have changes in releasenotes/notes/
- [ ]  User facing bug must have changed in releasenotes/nodes/
- [ ]  Pull request must have been reviewed by at least one core reviewer
- [ ]  No pending `requested changes`

-->
