### PR TITLE
fix(api): return 403 error when github rate limit exception raised

### DIFF
--- a/mergify_engine/tests/unit/api/test_exceptions.py
+++ b/mergify_engine/tests/unit/api/test_exceptions.py
@@ -1,0 +1,60 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright © 2021 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+import datetime
+from typing import Type
+
+import fastapi
+import httpx
+import pytest
+
+from mergify_engine.exceptions import RateLimited
+from mergify_engine.tests.functional.api.test_auth import ResponseTest
+from mergify_engine.web import config_validator
+from mergify_engine.web import legacy_badges
+from mergify_engine.web import root as web_root
+from mergify_engine.web import simulator
+from mergify_engine.web.api import root as api_root
+
+
+@pytest.fixture(scope="module", autouse=True)
+def create_testing_router() -> None:
+    router = fastapi.APIRouter()
+
+    @router.get("/testing-endpoint-exception-rate-limited", response_model=ResponseTest)
+    async def test_exception_rate_limited() -> Type[RateLimited]:
+        raise RateLimited(datetime.timedelta(seconds=622, microseconds=280475), 0)
+
+    api_root.app.include_router(router)
+    config_validator.app.include_router(router)
+    legacy_badges.app.include_router(router)
+    web_root.app.include_router(router)
+    simulator.app.include_router(router)
+
+
+async def test_handler_exception_rate_limited(
+    mergify_web_client: httpx.AsyncClient,
+) -> None:
+
+    endpoints = ["/", "/v1/", "/validate/", "/badges/", "/simulator/"]
+
+    for endpoint in endpoints:
+        r = await mergify_web_client.get(
+            f"{ endpoint }testing-endpoint-exception-rate-limited"
+        )
+        assert r.status_code == 403, r.json()
+        assert (
+            r.json()["message"] == "Organization or user has hit GitHub API rate limit"
+        )

--- a/mergify_engine/web/api/root.py
+++ b/mergify_engine/web/api/root.py
@@ -30,6 +30,7 @@ from starlette.middleware import cors
 
 from mergify_engine import config
 from mergify_engine import context
+from mergify_engine import exceptions as engine_exceptions
 from mergify_engine import github_types
 from mergify_engine import utils
 from mergify_engine.clients import github
@@ -102,3 +103,13 @@ def generate_openapi_spec() -> None:
 
     with open(args.output, "w") as f:
         json.dump(fp=f, obj=app.openapi())
+
+
+@app.exception_handler(engine_exceptions.RateLimited)
+async def rate_limited_handler(
+    request: requests.Request, exc: engine_exceptions.RateLimited
+) -> responses.JSONResponse:
+    return responses.JSONResponse(
+        status_code=403,
+        content={"message": "Organization or user has hit GitHub API rate limit"},
+    )

--- a/mergify_engine/web/config_validator.py
+++ b/mergify_engine/web/config_validator.py
@@ -19,10 +19,12 @@ import base64
 import hashlib
 
 import fastapi
+from starlette import requests
 from starlette import responses
 from starlette.middleware import cors
 
 from mergify_engine import context
+from mergify_engine import exceptions as engine_exceptions
 from mergify_engine import github_types
 from mergify_engine import rules
 
@@ -70,3 +72,13 @@ async def config_validator(
         message = "The configuration is valid"
 
     return responses.PlainTextResponse(message, status_code=status)
+
+
+@app.exception_handler(engine_exceptions.RateLimited)
+async def rate_limited_handler(
+    request: requests.Request, exc: engine_exceptions.RateLimited
+) -> responses.JSONResponse:
+    return responses.JSONResponse(
+        status_code=403,
+        content={"message": "Organization or user has hit GitHub API rate limit"},
+    )

--- a/mergify_engine/web/legacy_badges.py
+++ b/mergify_engine/web/legacy_badges.py
@@ -16,7 +16,10 @@
 
 
 import fastapi
+from starlette import requests
 from starlette import responses
+
+from mergify_engine import exceptions as engine_exceptions
 
 
 app = fastapi.FastAPI()
@@ -49,4 +52,14 @@ async def badge_svg(
 async def badge(owner: str, repo: str) -> responses.RedirectResponse:
     return responses.RedirectResponse(
         url=f"https://dashboard.mergify.com/badges/{owner}/{repo}"
+    )
+
+
+@app.exception_handler(engine_exceptions.RateLimited)
+async def rate_limited_handler(
+    request: requests.Request, exc: engine_exceptions.RateLimited
+) -> responses.JSONResponse:
+    return responses.JSONResponse(
+        status_code=403,
+        content={"message": "Organization or user has hit GitHub API rate limit"},
     )

--- a/mergify_engine/web/root.py
+++ b/mergify_engine/web/root.py
@@ -22,6 +22,7 @@ from starlette import requests
 from starlette import responses
 import yaaredis
 
+from mergify_engine import exceptions as engine_exceptions
 from mergify_engine.web import config_validator
 from mergify_engine.web import dashboard
 from mergify_engine.web import github
@@ -74,3 +75,13 @@ async def index(
             status_code=200,
         )
     return responses.RedirectResponse(url="https://mergify.com")
+
+
+@app.exception_handler(engine_exceptions.RateLimited)
+async def rate_limited_handler(
+    request: requests.Request, exc: engine_exceptions.RateLimited
+) -> responses.JSONResponse:
+    return responses.JSONResponse(
+        status_code=403,
+        content={"message": "Organization or user has hit GitHub API rate limit"},
+    )

--- a/mergify_engine/web/simulator.py
+++ b/mergify_engine/web/simulator.py
@@ -25,6 +25,7 @@ import voluptuous
 
 from mergify_engine import context
 from mergify_engine import exceptions
+from mergify_engine import exceptions as engine_exceptions
 from mergify_engine import github_types
 from mergify_engine import rules
 from mergify_engine import utils
@@ -87,6 +88,16 @@ def voluptuous_error(error: voluptuous.Invalid) -> str:
         if error.path[0] == "mergify.yml":
             error.path.pop(0)
     return str(rules.InvalidRules(error, ""))
+
+
+@app.exception_handler(engine_exceptions.RateLimited)
+async def rate_limited_handler(
+    request: requests.Request, exc: engine_exceptions.RateLimited
+) -> responses.JSONResponse:
+    return responses.JSONResponse(
+        status_code=403,
+        content={"message": "Organization or user has hit GitHub API rate limit"},
+    )
 
 
 @app.exception_handler(voluptuous.Invalid)


### PR DESCRIPTION
The Github rate limit exception was raised by the engine but unhandled by the REST API thus
sending back a code 500. This fix now handles the exception and sends back a 403
code and an error message. 

Fixes MRGFY-882
