### PR TITLE
fix(queue): don't rely on GitHub Check-runs to merge PR

### DIFF
--- a/mergify_engine/actions/queue.py
+++ b/mergify_engine/actions/queue.py
@@ -413,13 +413,7 @@ Then, re-embark the pull request into the merge queue by posting the comment
         if car is None:
             return False
 
-        check = await ctxt.get_engine_check_run(constants.MERGE_QUEUE_SUMMARY_NAME)
-        if check:
-            return (
-                check_api.Conclusion(check["conclusion"])
-                == check_api.Conclusion.SUCCESS
-            )
-        return False
+        return car.checks_conclusion == check_api.Conclusion.SUCCESS
 
     async def _should_be_cancel(
         self, ctxt: context.Context, rule: "rules.EvaluatedRule", q: queue.QueueBase


### PR DESCRIPTION
This should avoid merging PR if summary is out of date.

Fixes MRGFY-902

Change-Id: Ia3f97a5db2da24dc5323f9a34c122d17ded82e54