### PR TITLE
fix(command): improvement on command loader trigger regex

### DIFF
--- a/mergify_engine/tests/unit/test_command.py
+++ b/mergify_engine/tests/unit/test_command.py
@@ -48,6 +48,9 @@ def test_command_loader() -> None:
     with pytest.raises(commands_runner.CommandInvalid):
         commands_runner.load_command(EMPTY_CONFIG, "@Mergifyio comment foobar\n")
 
+    with pytest.raises(commands_runner.NotACommand):
+        commands_runner.load_command(EMPTY_CONFIG, "comment @Mergifyio test foobar\n")
+
     for message in [
         "@mergify rebase",
         "@mergifyio rebase",


### PR DESCRIPTION
The regex was triggering the command loader for every comment
that contained the "@mergify/io" tag, regardless of its position in the comment.
Now it is only triggered if the tag is placed at the start of the comment.

Fixes MRGFY-797