### PR TITLE
refactor(web): use only one FastAPI app

### DIFF
--- a/mergify_engine/tests/unit/api/test_exceptions.py
+++ b/mergify_engine/tests/unit/api/test_exceptions.py
@@ -22,10 +22,7 @@ import pytest
 
 from mergify_engine.exceptions import RateLimited
 from mergify_engine.tests.functional.api.test_auth import ResponseTest
-from mergify_engine.web import config_validator
-from mergify_engine.web import legacy_badges
 from mergify_engine.web import root as web_root
-from mergify_engine.web import simulator
 from mergify_engine.web.api import root as api_root
 
 
@@ -38,17 +35,14 @@ def create_testing_router() -> None:
         raise RateLimited(datetime.timedelta(seconds=622, microseconds=280475), 0)
 
     api_root.app.include_router(router)
-    config_validator.app.include_router(router)
-    legacy_badges.app.include_router(router)
     web_root.app.include_router(router)
-    simulator.app.include_router(router)
 
 
 async def test_handler_exception_rate_limited(
     mergify_web_client: httpx.AsyncClient,
 ) -> None:
 
-    endpoints = ["/", "/v1/", "/validate/", "/badges/", "/simulator/"]
+    endpoints = ["/", "/v1/"]
 
     for endpoint in endpoints:
         r = await mergify_web_client.get(

--- a/mergify_engine/web/config_validator.py
+++ b/mergify_engine/web/config_validator.py
@@ -19,27 +19,17 @@ import base64
 import hashlib
 
 import fastapi
-from starlette import requests
 from starlette import responses
-from starlette.middleware import cors
 
 from mergify_engine import context
-from mergify_engine import exceptions as engine_exceptions
 from mergify_engine import github_types
 from mergify_engine import rules
 
 
-app = fastapi.FastAPI()
-app.add_middleware(
-    cors.CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+router = fastapi.APIRouter()
 
 
-@app.post("/")
+@router.post("/")
 async def config_validator(
     data: fastapi.UploadFile = fastapi.File(...),  # noqa: B008
 ) -> responses.PlainTextResponse:  # pragma: no cover
@@ -72,13 +62,3 @@ async def config_validator(
         message = "The configuration is valid"
 
     return responses.PlainTextResponse(message, status_code=status)
-
-
-@app.exception_handler(engine_exceptions.RateLimited)
-async def rate_limited_handler(
-    request: requests.Request, exc: engine_exceptions.RateLimited
-) -> responses.JSONResponse:
-    return responses.JSONResponse(
-        status_code=403,
-        content={"message": "Organization or user has hit GitHub API rate limit"},
-    )

--- a/mergify_engine/web/legacy_badges.py
+++ b/mergify_engine/web/legacy_badges.py
@@ -16,13 +16,10 @@
 
 
 import fastapi
-from starlette import requests
 from starlette import responses
 
-from mergify_engine import exceptions as engine_exceptions
 
-
-app = fastapi.FastAPI()
+router = fastapi.APIRouter()
 
 
 def _get_badge_url(
@@ -34,32 +31,22 @@ def _get_badge_url(
     )
 
 
-@app.get("/{owner}/{repo}.png")  # noqa: FS003
+@router.get("/{owner}/{repo}.png")  # noqa: FS003
 async def badge_png(
     owner: str, repo: str, style: str = "flat"
 ) -> responses.RedirectResponse:  # pragma: no cover
     return _get_badge_url(owner, repo, "png", style)
 
 
-@app.get("/{owner}/{repo}.svg")  # noqa: FS003
+@router.get("/{owner}/{repo}.svg")  # noqa: FS003
 async def badge_svg(
     owner: str, repo: str, style: str = "flat"
 ) -> responses.RedirectResponse:  # pragma: no cover
     return _get_badge_url(owner, repo, "svg", style)
 
 
-@app.get("/{owner}/{repo}")  # noqa: FS003
+@router.get("/{owner}/{repo}")  # noqa: FS003
 async def badge(owner: str, repo: str) -> responses.RedirectResponse:
     return responses.RedirectResponse(
         url=f"https://dashboard.mergify.com/badges/{owner}/{repo}"
-    )
-
-
-@app.exception_handler(engine_exceptions.RateLimited)
-async def rate_limited_handler(
-    request: requests.Request, exc: engine_exceptions.RateLimited
-) -> responses.JSONResponse:
-    return responses.JSONResponse(
-        status_code=403,
-        content={"message": "Organization or user has hit GitHub API rate limit"},
     )

--- a/mergify_engine/web/root.py
+++ b/mergify_engine/web/root.py
@@ -20,6 +20,7 @@ from datadog import statsd
 import fastapi
 from starlette import requests
 from starlette import responses
+from starlette.middleware import cors
 import yaaredis
 
 from mergify_engine import exceptions as engine_exceptions
@@ -36,13 +37,21 @@ from mergify_engine.web.api import root as api_root
 LOG = daiquiri.getLogger(__name__)
 
 app = fastapi.FastAPI(openapi_url=None, redoc_url=None, docs_url=None)
+app.add_middleware(
+    cors.CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 app.include_router(dashboard.router)
 app.include_router(github.router)
 app.include_router(refresher.router)
+app.include_router(simulator.router, prefix="/simulator")
+app.include_router(config_validator.router, prefix="/validate")
+app.include_router(legacy_badges.router, prefix="/badges")
 
-app.mount("/simulator", simulator.app)
-app.mount("/validate", config_validator.app)
-app.mount("/badges", legacy_badges.app)
 app.mount("/v1", api_root.app)
 
 


### PR DESCRIPTION
We used one app per sub directories just to not expose CORS everywhere.
It's really useful, so just merge all of them.

Related MRGFY-906

Change-Id: Ia9fa5fac4d8f6889a93f192eb0ac11e902e4a3ed
