### PR TITLE
ci(tox): disable tracer for tox test target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ commands = mergify-import-check
 setenv =
    PYTHONUNBUFFERED=1
    DD_DOGSTATSD_DISABLE=1
+   DD_TRACE_ENABLED=0
    MERGIFYENGINE_TEST_SETTINGS=test.env
    MERGIFYENGINE_STORAGE_URL=redis://localhost:6363?db=2
    MERGIFYENGINE_STREAM_URL=redis://localhost:6363?db=3


### PR DESCRIPTION
We don't need the tracer for this testing mode.

Currently this just generates a ton of useless warning about agent not
being present.

Change-Id: I982987b25b016fcf876a7b8f11cd221d106062f5