### PR TITLE
fix(logs): add missing dyno/dynotype to datadog records

### DIFF
--- a/mergify_engine/logs.py
+++ b/mergify_engine/logs.py
@@ -72,6 +72,11 @@ class HerokuDatadogFormatter(daiquiri.formatter.DatadogFormatter):  # type: igno
         if worker_id is not None:
             log_record.update({"worker_id": worker_id})
 
+        dyno = os.getenv("DYNO")
+        if dyno is not None:
+            log_record.update({"dyno": dyno})
+            log_record.update({"dynotype": dyno.rsplit(".", 1)[0]})
+
 
 def config_log() -> None:
     LOG.info("##################### CONFIGURATION ######################")


### PR DESCRIPTION
This attributes are missing in datadog logs.

Change-Id: Iee17592bdc504d9523ee2e6c24b7ca77f3dd6fff
