### PR TITLE
refactor(worker): avoid calling sismembers too many times

### DIFF
--- a/mergify_engine/tests/functional/base.py
+++ b/mergify_engine/tests/functional/base.py
@@ -504,6 +504,7 @@ class FunctionalTestBase(unittest.IsolatedAsyncioTestCase):
             enabled_services={"shared-stream", "dedicated-stream", "delayed-refresh"},
             delayed_refresh_idle_time=0.01,
             dedicated_workers_spawner_idle_time=0.01,
+            dedicated_workers_syncer_idle_time=0.01,
         )
         await w.start()
 


### PR DESCRIPTION
The set DEDICATED_WORKERS_KEY can change only every 1 minute. And it
doesn't change so often in reality.

This change creates an in memory cache of this list in all processes and
sync it from Redis every 30s.

Fixes MRGFY-917

Change-Id: Ic44bfea7bfecafd3b55813c6920a7c78711bdd0a
