### PR TITLE
fix(worker): use blake512 for hashing

### DIFF
--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -1087,10 +1087,7 @@ class Worker:
     def get_shared_worker_id_for(
         owner_id: github_types.GitHubAccountIdType, global_shared_tasks_count: int
     ) -> str:
-        # FIXME(sileht): Maybe change the hash method, since we just use the
-        hashed = hashlib.md5(  # nosemgrep: rule:python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-md5
-            str(owner_id).encode()
-        )
+        hashed = hashlib.blake2s(str(owner_id).encode())
         shared_id = int(hashed.hexdigest(), 16) % global_shared_tasks_count
         return f"shared-{shared_id}"
 


### PR DESCRIPTION
Our worker can use any hash method to shared the load. We don't really
care about the collision, but alot of tooling complain about using md5 for
good reason.

So, I have done a quick and dirty bench to select the new one
and pick blake256 as it's as fast as md5 and tooling will not complain
anymore.

Fixes MRGFY-924

```
import hashlib
import timeit

def t(method):
    for i in range(0, 1000000):
        f = getattr(hashlib, method)
        hashed = f(str(i).encode())
        shared_id = int(hashed.hexdigest(), 16) % 60
        return f"shared-{shared_id}"

def do(method):
    elapsed = timeit.timeit(f"t('{method}')", globals=globals())
    print(f"{method}: {elapsed}s")

do("md5")
do("sha256")
do("sha3_256")
do("sha512")
do("sha3_512")
do("blake2s") # blake256
do("blake2b") # blake512
```

md5: 1.5114598810032476s
sha256: 1.686936591999256s
sha3_256: 2.433680418995209s
sha512: 2.3856778089975705s
sha3_512: 2.566013190007652s
blake2s: 1.4824638799909735s
blake2b: 1.7990422610018868s

Change-Id: I1e4d6e81145618817ebd231385cd6f1b30a7826f
