### PR TITLE
fix(branch-protection): don't wrongly inject required_pull_request_reviews

### DIFF
--- a/mergify_engine/rules/conditions.py
+++ b/mergify_engine/rules/conditions.py
@@ -429,7 +429,14 @@ async def get_branch_protection_conditions(
                     for check in protection["required_status_checks"]["contexts"]
                 ]
             )
-        if "required_pull_request_reviews" in protection:
+
+        if (
+            "required_pull_request_reviews" in protection
+            and protection["required_pull_request_reviews"][
+                "required_approving_review_count"
+            ]
+            > 0
+        ):
             conditions.extend(
                 [
                     RuleCondition(


### PR DESCRIPTION
In GitHub branch protection "required_pull_request_reviews" may not
exists or, exist and set 0. It depends of if we get the branch protection from
branch endpoint or branch/protection endpoint.

This change handles the later.

Fixes MRGFY-928

Change-Id: I3c4a1eceeda235d661cd8567b66d1ee367dbf444
