### PR TITLE
fix(installer): use npm ci, instead of npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM node:16-buster-slim as js-builder
 # Real install that can't be cached
 ADD installer /installer
 WORKDIR /installer
-RUN npm install
+RUN npm ci
 RUN npm run build
 RUN rm -rf node_modules
 


### PR DESCRIPTION
Fixes semgrep generic.ci.security.use-frozen-lockfile.use-frozen-lockfile-npm

Change-Id: I885b26cdcff7bd6757fb57b7aa0cde131ad3ba6f