### PR TITLE
ci(semgrep): disable pipenv warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,14 @@ RUN python3 -m pip install wheel
 ADD . /app
 # Just to be able cache a layer with all deps
 ADD requirements.txt /
+
+# NOTE(sileht): We don't use pipenv
+# nosemgrep: generic.ci.security.use-frozen-lockfile.use-frozen-lockfile-pip
 RUN python3 -m pip install --no-cache-dir -r /requirements.txt
 
 WORKDIR /app
+# NOTE(sileht): We don't use pipenv
+# nosemgrep: generic.ci.security.use-frozen-lockfile.use-frozen-lockfile-pip
 RUN python3 -m pip install --no-cache-dir -c ./requirements.txt -e .
 
 ### RUNNER ###

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ setenv =
    PYTEST_TIMEOUT=20
 usedevelop = true
 extras = test
+# nosemgrep generic.ci.security.use-frozen-lockfile.use-frozen-lockfile-pip
 install_command = pip install -c requirements.txt {opts} {packages}
 commands = {toxinidir}/run-tests.sh pytest -v --timeout_method thread {posargs}
 
@@ -63,6 +64,8 @@ commands = pip check
 recreate = true
 skip_install = true
 commands =
+# NOTE(sileht): We don't use pipenv
+# nosemgrep: generic.ci.security.use-frozen-lockfile.use-frozen-lockfile-pip
   pip install -c requirements.txt -e .
   pip uninstall --yes mergify-engine
   bash -c "pip freeze --exclude-editable >| requirements.txt"


### PR DESCRIPTION
This fixes semgrep rule generic.ci.security.use-frozen-lockfile.use-frozen-lockfile-pip

Change-Id: I4ce5952921fc05a1530fa85bbc7d6143c1930fe0
