### PR TITLE
ci(updatecli): use /tmp instead of /

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -28,9 +28,9 @@ jobs:
           curl -L -o $dest $url
           echo "$sha $dest" | tee -a /tmp/checksum
           sha256sum -c /tmp/checksum
-          tar -xzf $dest -C /
-          /updatecli --config ./.github/updatecli.yml diff
-          /updatecli --config ./.github/updatecli.yml apply
+          tar -xzf $dest -C /tmp
+          /tmp/updatecli --config ./.github/updatecli.yml diff
+          /tmp/updatecli --config ./.github/updatecli.yml apply
           rm workflow -rf
           echo "::set-output name=PYTHON_VERSION::$(cat runtime.txt | cut -d- -f2)"
         env:


### PR DESCRIPTION
Unlike with the nektos/act testing tool, real GitHub Workflow has / readonly.

Use /tmp instead.

Change-Id: Iadf9448047f722e14b030dabdf7b60155c726d8d