### PR TITLE
fix(queue): don't wait for mergeable_state to compute the status

### DIFF
--- a/mergify_engine/rules/types.py
+++ b/mergify_engine/rules/types.py
@@ -51,7 +51,7 @@ class DummyContext(context.Context):
             raise context.PullRequestAttributeError(key)
 
     @staticmethod
-    def _ensure_complete():
+    def ensure_complete():
         pass
 
 

--- a/mergify_engine/tests/functional/base.py
+++ b/mergify_engine/tests/functional/base.py
@@ -375,7 +375,7 @@ class FunctionalTestBase(unittest.IsolatedAsyncioTestCase):
         if not RECORD:
             # NOTE(sileht): Don't wait exponentialy during replay
             mock.patch.object(
-                context.Context._ensure_complete.retry, "wait", None  # type: ignore[attr-defined]
+                context.Context.ensure_complete.retry, "wait", None  # type: ignore[attr-defined]
             ).start()
 
         # Web authentification always pass

--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -237,6 +237,7 @@ async def run_engine(
                 # consume_buckets(), so we need to clear the sources/_cache/pull/... to
                 # ensure we get the last snapshot of the pull request
                 force_new=True,
+                wait_background_github_processing=True,
             )
         except http.HTTPNotFound:
             # NOTE(sileht): Don't fail if we received even on repo/pull that doesn't exists anymore


### PR DESCRIPTION
Currently, we use repository.get_pull_request_context() to load context
of pull requests in queue. This method ensures GitHub has finished to
background processing. The background processing is required by
Mergify only for queue/merge actions code and conflict detector, not to
generate the fancy summary of the merge queue.

Waiting on GitHub background processing may fail, Mergify raises
MergeableStateUnknown in such case. When we refresh the train this has a
unwanted side effect:
* We create a draft PR
* fail to generate the merge-queue summary and raise the exception
* Train state is not saved as we fail the creation of the TrainCar.
* The events maybe kept in queue because the worker retry when it sees MergeableStateUnknown
* This Exception land in OrgBucketRetry, so the backoff is increased,
  making Mergify slower and slower. (Fixed by #4136)
* When the queue is long, we may always have one PR with GitHub async
  processing not done yet, and Mergify may never be able to proceed the
  train entirely.

This change allows creating context.Context() without waiting GitHub async
processing and we only need it to evaluate the conditions and a couple of
checks in merge/queue actions.

This change should reduce a lot the number of Mergify retries and allows Mergify
always succeed at generating the merge-queue summary.

Fixes MRGFY-937
Fixes MRGFY-936
Fixes MERGIFY-ENGINE-2JQ