### PR TITLE
fix(merge): handle when branch protection come from old API

### DIFF
--- a/mergify_engine/rules/conditions.py
+++ b/mergify_engine/rules/conditions.py
@@ -435,7 +435,11 @@ async def get_branch_protection_conditions(
                     for check in protection["required_status_checks"]["contexts"]
                 ]
             )
-            if strict and protection["required_status_checks"]["strict"]:
+            if (
+                strict
+                and "strict" in protection["required_status_checks"]
+                and protection["required_status_checks"]["strict"]
+            ):
                 conditions.append(
                     RuleCondition(
                         "#commits-behind=0",


### PR DESCRIPTION
We old branch API to get branch protection strict key is missing.

Fixes MERGIFY-ENGINE-2JV 