### PR TITLE
fix(queue): don't enforce strict mode for merge-queue

### DIFF
--- a/mergify_engine/rules/__init__.py
+++ b/mergify_engine/rules/__init__.py
@@ -128,7 +128,7 @@ class QueueRule:
         log_schedule_details: bool,
     ) -> EvaluatedQueueRule:
         extra_conditions = await conditions.get_branch_protection_conditions(
-            repository, ref, strict=True
+            repository, ref, strict=False
         )
         if self.config["checks_timeout"] is not None:
             extra_conditions += (


### PR DESCRIPTION
The queue already has code to ensure we are up2date whatever the state
of branch protection.

Injecting #commits-behind=0 may not work when you use batch +
speculative checks as when the first batch is merged, the second because
out of date from GitHub point of view as all sha1 are not the same.

This has not been catched by tests because, this need a certain timing to have #commits-behind=0 evaluated to false before the seconds TrainCar has finished to be tested but before the first one has been merged or half merged.

This change drops this useless restriction.

Change-Id: I1c8153c5729000e57940bcb5e9e5e78ce0fede64
