### PR TITLE
ci(tox): enable pytest github actions annotations

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ skipsdist = true
 [testenv]
 basepython = python3.10
 passenv =
+   GITHUB_ACTIONS
    CI
 setenv =
    PYTHONASYNCIODEBUG=1


### PR DESCRIPTION
GITHUB_ACTIONS must be passed to pytest to get annotations generated.

Change-Id: I68ca73924851bfec56a3e974ffde49ecc33c7b61