### PR TITLE
feat(datadog): add tracer for YAML safe_load

### DIFF
--- a/mergify_engine/rules/__init__.py
+++ b/mergify_engine/rules/__init__.py
@@ -22,6 +22,7 @@ import operator
 import typing
 
 import daiquiri
+from ddtrace import tracer
 import voluptuous
 import yaml
 
@@ -411,6 +412,7 @@ class YAMLInvalid(voluptuous.Invalid):  # type: ignore[misc]
         return []
 
 
+@tracer.wrap("yaml.load")
 def YAML(v: bytes) -> typing.Any:
     try:
         return yaml.safe_load(v)


### PR DESCRIPTION
Sometimes, YAML.safe_load() takes too long to resolve.
In order to monitor which client is impacted, we need to
trace back the runtime of the function by decorating it
with a tracer span.

Fixes MRGFY-922