### PR TITLE
fix(queue): fix interruption with high priority queue allow it

### DIFF
--- a/mergify_engine/queue/merge_train.py
+++ b/mergify_engine/queue/merge_train.py
@@ -1305,7 +1305,14 @@ class Train(queue.QueueBase):
 
             car_can_be_interrupted = car is None or (
                 car.checks_conclusion == check_api.Conclusion.PENDING
-                and config["queue_config"]["allow_checks_interruption"]
+                and (
+                    embarked_pull.config["queue_config"]["allow_checks_interruption"]
+                    or (
+                        config["queue_config"]["allow_checks_interruption"]
+                        and embarked_pull.config["queue_config"]["priority"]
+                        < config["queue_config"]["priority"]
+                    )
+                )
             )
 
             if embarked_pull.user_pull_request_number == ctxt.pull["number"]:


### PR DESCRIPTION
This allows different allow_checks_interrupt per queue.

Fixes MRGFY-950

Change-Id: I8bf500347f33e23253fd26d42fa1c6b677944517