### PR TITLE
fix(queue): backward compat of compat allow_checks_interruption

### DIFF
--- a/mergify_engine/queue/merge_train.py
+++ b/mergify_engine/queue/merge_train.py
@@ -250,6 +250,18 @@ class TrainCar:
             ]
             still_queued_embarked_pulls = initial_embarked_pulls.copy()
 
+        # backward compat allow_checks_interruption ->
+        # disallow_checks_interruption_from_queues option migration
+        for ep in initial_embarked_pulls + still_queued_embarked_pulls:
+            ep.config["queue_config"].setdefault(
+                "disallow_checks_interruption_from_queues", []
+            )
+            if "allow_checks_interruption" in ep.config["queue_config"]:
+                ep.config["queue_config"][
+                    "disallow_checks_interruption_from_queues"
+                ].append(ep.config["name"])
+                del ep.config["queue_config"]["allow_checks_interruption"]  # type: ignore[typeddict-item]
+
         if "creation_state" in data:
             creation_state = data["creation_state"]
         else:


### PR DESCRIPTION
Old Redis data must be updated to migrate from allow_checks_interruption
to disallow_checks_interruption_from_queue.

Fixes MERGIFY-ENGINE-2K7

Change-Id: I84e3c7cd6a697c47c55a97c82a2ac322a9fb29e3
