### PR TITLE
fix(date): allow for no space between number and units

### DIFF
--- a/mergify_engine/date.py
+++ b/mergify_engine/date.py
@@ -267,10 +267,10 @@ def pretty_datetime(dt: datetime.datetime) -> str:
 _INTERVAL_RE = re.compile(
     r"""
     (?P<filled>
-        ((?P<days>[-+]?\d+) \s+ d(ays?)? \s* )?
-        ((?P<hours>[-+]?\d+) \s+ h(ours?)? \s* )?
-        ((?P<minutes>[-+]?\d+) \s+ m(inutes?)? \s* )?
-        ((?P<seconds>[-+]?\d+) \s+ s(econds?)? \s* )?
+        ((?P<days>[-+]?\d+)\s*d(ays?)? \s* )?
+        ((?P<hours>[-+]?\d+)\s*h(ours?)? \s* )?
+        ((?P<minutes>[-+]?\d+)\s*m((inutes?|ins?)?)? \s* )?
+        ((?P<seconds>[-+]?\d+)\s*s(econds?)? \s* )?
     )
     """,
     re.VERBOSE,

--- a/mergify_engine/tests/unit/test_date.py
+++ b/mergify_engine/tests/unit/test_date.py
@@ -234,8 +234,13 @@ def test_invalid_date_string(date_type, value, expected_message):
         ("1 seconds", datetime.timedelta(seconds=1)),
         ("1 second", datetime.timedelta(seconds=1)),
         ("1 s", datetime.timedelta(seconds=1)),
+        ("1s", datetime.timedelta(seconds=1)),
         (
             "1 days 15 hours 6 minutes 42 seconds",
+            datetime.timedelta(days=1, hours=15, minutes=6, seconds=42),
+        ),
+        (
+            "1days 15hours 6min 42s",
             datetime.timedelta(days=1, hours=15, minutes=6, seconds=42),
         ),
         (


### PR DESCRIPTION
This allows things like "30s" which are quite natural.
This allows to use mins? for minutes too.