### PR TITLE
feat(crypto): Add mechanism to rotate oauth tokens SECRET

### DIFF
--- a/mergify_engine/config.py
+++ b/mergify_engine/config.py
@@ -203,6 +203,9 @@ Schema = voluptuous.Schema(
             "BUCKET_PROCESSING_MAX_SECONDS", default=30
         ): voluptuous.Coerce(int),
         voluptuous.Required("CACHE_TOKEN_SECRET"): str,
+        voluptuous.Required("CACHE_TOKEN_SECRET_OLD", default=None): voluptuous.Any(
+            None, str
+        ),
         voluptuous.Required("CONTEXT", default="mergify"): str,
         voluptuous.Required("GIT_EMAIL", default="noreply@mergify.com"): str,
         voluptuous.Required("WORKER_SHUTDOWN_TIMEOUT", default=10): voluptuous.Coerce(
@@ -261,6 +264,7 @@ API_ENABLE: bool
 SENTRY_URL: str
 SENTRY_ENVIRONMENT: str
 CACHE_TOKEN_SECRET: str
+CACHE_TOKEN_SECRET_OLD: typing.Optional[str]
 PRIVATE_KEY: bytes
 GITHUB_URL: str
 GITHUB_REST_API_URL: str

--- a/mergify_engine/tests/unit/test_crypto.py
+++ b/mergify_engine/tests/unit/test_crypto.py
@@ -13,11 +13,49 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
+import importlib
+import typing
+
+import pytest
+
+from mergify_engine import config
 from mergify_engine import crypto
 
 
-def test_encrypt():
+def test_encrypt() -> None:
     x = "this is an amazing string, right? 🙄".encode()
     assert x == crypto.decrypt(crypto.encrypt(x))
     assert x == crypto.decrypt(crypto.encrypt(x))
     assert x == crypto.decrypt(crypto.encrypt(crypto.decrypt(crypto.encrypt(x))))
+
+
+@pytest.fixture
+def cleanup_secrets() -> typing.Generator[None, None, None]:
+    current_secret = config.CACHE_TOKEN_SECRET
+    try:
+        yield
+    finally:
+        # ensure pytest monkeypatch has revert values and we reload the module
+        assert config.CACHE_TOKEN_SECRET == current_secret
+        assert config.CACHE_TOKEN_SECRET_OLD is None
+        importlib.reload(crypto)  # regen digest with default secrets
+
+
+def test_key_rotation(
+    cleanup_secrets: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    x = "this is an amazing string, right? 🙄".encode()
+
+    monkeypatch.setattr(config, "CACHE_TOKEN_SECRET", "old password")
+    importlib.reload(crypto)  # regen digest with new secret
+    encryped_old = crypto.encrypt(x)
+
+    monkeypatch.setattr(config, "CACHE_TOKEN_SECRET", "new password")
+    monkeypatch.setattr(config, "CACHE_TOKEN_SECRET_OLD", "old password")
+    importlib.reload(crypto)  # regen digest with new secrets
+    encryped_new = crypto.encrypt(x)
+    assert encryped_new != encryped_old
+
+    assert x == crypto.decrypt(encryped_new)
+    assert x == crypto.decrypt(encryped_old)


### PR DESCRIPTION
Crypto in engine is only for encryting data dashboard cached. We can
just temporary try to decode the data with an old key for the rotation.
The whole cache is re-validated every 3600 and the retention is 3 days.
So we just have to wait 3 days and we are sure all encrypted data are
encrypted with the new key.

Fixes MRGFY-956
