### PR TITLE
fix(ghes): is_behind need to wait against background processing

### DIFF
--- a/mergify_engine/tests/functional/test_attributes.py
+++ b/mergify_engine/tests/functional/test_attributes.py
@@ -190,7 +190,9 @@ class TestAttributes(base.FunctionalTestBase):
         await self.run_engine()
 
         p = await self.get_pull(p["number"])
-        ctxt = await context.Context.create(self.repository_ctxt, p)
+        ctxt = await context.Context.create(
+            self.repository_ctxt, p, wait_background_github_processing=True
+        )
         assert await ctxt.is_behind
         assert len(await ctxt.commits_behind) == 3
         assert ctxt.pull["mergeable_state"] == "behind"


### PR DESCRIPTION
As GHES is slower than GitHub.com, we need to wait for the background
processing of mergeable_state for this test.

Change-Id: I65f159d0814802b5cb4308f16113a5f0632db802