### PR TITLE
fix(request-reviewers): support long team names

### DIFF
--- a/mergify_engine/context.py
+++ b/mergify_engine/context.py
@@ -1149,10 +1149,14 @@ class Context(object):
             return [label["name"] for label in self.pull["labels"]]
 
         elif name == "review-requested":
-            return [
-                typing.cast(str, u["login"]) for u in self.pull["requested_reviewers"]
-            ] + ["@" + t["slug"] for t in self.pull["requested_teams"]]
-
+            return (
+                [typing.cast(str, u["login"]) for u in self.pull["requested_reviewers"]]
+                + [f"@{t['slug']}" for t in self.pull["requested_teams"]]
+                + [
+                    f"@{self.repository.installation.owner_login}/{t['slug']}"
+                    for t in self.pull["requested_teams"]
+                ]
+            )
         elif name == "draft":
             return self.pull["draft"]
 


### PR DESCRIPTION
The code was already there for slug only team, but not for fully
qualified teams.

Fixes MRGFY-997

Change-Id: Id33fd3d68b68fc57f9bd905feb998b7b5d7b0077