### PR TITLE
refactor(api): change endpoint url for queue freeze deletion

### DIFF
--- a/mergify_engine/tests/functional/api/test_queue_freeze.py
+++ b/mergify_engine/tests/functional/api/test_queue_freeze.py
@@ -491,7 +491,7 @@ class TestQueueFreeze(base.FunctionalTestBase):
         queue_name = "false_queue_name"
 
         r = await self.app.delete(
-            f"/v1/repos/{config.TESTING_ORGANIZATION_NAME}/{self.RECORD_CONFIG['repository_name']}/queue/{queue_name}/unfreeze",
+            f"/v1/repos/{config.TESTING_ORGANIZATION_NAME}/{self.RECORD_CONFIG['repository_name']}/queue/{queue_name}/freeze",
             headers={
                 "Authorization": f"bearer {self.api_key_admin}",
                 "Content-type": "application/json",
@@ -506,7 +506,7 @@ class TestQueueFreeze(base.FunctionalTestBase):
         queue_name = "default"
 
         r = await self.app.delete(
-            f"/v1/repos/{config.TESTING_ORGANIZATION_NAME}/{self.RECORD_CONFIG['repository_name']}/queue/{queue_name}/unfreeze",
+            f"/v1/repos/{config.TESTING_ORGANIZATION_NAME}/{self.RECORD_CONFIG['repository_name']}/queue/{queue_name}/freeze",
             headers={
                 "Authorization": f"bearer {self.api_key_admin}",
                 "Content-type": "application/json",
@@ -604,7 +604,7 @@ class TestQueueFreeze(base.FunctionalTestBase):
         assert queue_freeze_data_default.reason == "test freeze reason"
 
         r = await self.app.delete(
-            f"/v1/repos/{config.TESTING_ORGANIZATION_NAME}/{self.RECORD_CONFIG['repository_name']}/queue/{queue_name}/unfreeze",
+            f"/v1/repos/{config.TESTING_ORGANIZATION_NAME}/{self.RECORD_CONFIG['repository_name']}/queue/{queue_name}/freeze",
             headers={
                 "Authorization": f"bearer {self.api_key_admin}",
                 "Content-type": "application/json",
@@ -925,7 +925,7 @@ class TestQueueFreeze(base.FunctionalTestBase):
         queue_name = "default"
 
         r = await self.app.delete(
-            f"/v1/repos/{config.TESTING_ORGANIZATION_NAME}/{self.RECORD_CONFIG['repository_name']}/queue/{queue_name}/unfreeze",
+            f"/v1/repos/{config.TESTING_ORGANIZATION_NAME}/{self.RECORD_CONFIG['repository_name']}/queue/{queue_name}/freeze",
             headers={
                 "Authorization": f"bearer {self.api_key_admin}",
                 "Content-type": "application/json",
@@ -958,7 +958,7 @@ class TestQueueFreeze(base.FunctionalTestBase):
         queue_name = "low-priority"
 
         r = await self.app.delete(
-            f"/v1/repos/{config.TESTING_ORGANIZATION_NAME}/{self.RECORD_CONFIG['repository_name']}/queue/{queue_name}/unfreeze",
+            f"/v1/repos/{config.TESTING_ORGANIZATION_NAME}/{self.RECORD_CONFIG['repository_name']}/queue/{queue_name}/freeze",
             headers={
                 "Authorization": f"bearer {self.api_key_admin}",
                 "Content-type": "application/json",

--- a/mergify_engine/web/api/queues.py
+++ b/mergify_engine/web/api/queues.py
@@ -426,7 +426,7 @@ async def create_queue_freeze(
 
 
 @router.delete(
-    "/repos/{owner}/{repository}/queue/{queue_name}/unfreeze",  # noqa: FS003
+    "/repos/{owner}/{repository}/queue/{queue_name}/freeze",  # noqa: FS003
     summary="Unfreeze merge queue",
     description="Unfreeze the specified merge queue",
     status_code=204,


### PR DESCRIPTION
The endpoint was a bit confusing, mentioning `DELETE /unfreeze` where
it should be `DELETE /freeze`.

Fixes MRGFY-1000