### PR TITLE
fix(duplicate): don't retry non-fast-forward update

### DIFF
--- a/mergify_engine/duplicate_pull.py
+++ b/mergify_engine/duplicate_pull.py
@@ -59,6 +59,7 @@ class DuplicateWithMergeFailure(Exception):
 
 
 GIT_MESSAGE_TO_EXCEPTION = {
+    "(non-fast-forward)": DuplicateAlreadyExists,
     "Updates were rejected because the tip of your current branch is behind": DuplicateNeedRetry,
     "Aborting commit due to empty commit message": DuplicateNotNeeded,
     "reference already exists": DuplicateAlreadyExists,


### PR DESCRIPTION
If a backport already exists and the main branch move.
The git complain because update of backport branch is not fast foward.

In such case we should report the backport already exists instead of
retrying for ever.

Fixes MERGIFY-ENGINE-2KJ