### PR TITLE
fix(queue): add traincar deserialization compat

### DIFF
--- a/mergify_engine/queue/merge_train.py
+++ b/mergify_engine/queue/merge_train.py
@@ -333,6 +333,11 @@ class TrainCar:
         else:
             last_checks = []
 
+        if creation_state == "updated" and data["queue_pull_request_number"] is None:
+            data["queue_pull_request_number"] = still_queued_embarked_pulls[
+                0
+            ].user_pull_request_number
+
         car = cls(
             train,
             initial_embarked_pulls=initial_embarked_pulls,


### PR DESCRIPTION
if a traincar has been created and serialized before we
queue_pull_request on all traincar, we must set it manually.

Fixes MERGIFY-ENGINE-2M5
Fixes MERGIFY-ENGINE-2M6

Change-Id: Iac7fe64b94592f176484fb19f0d74e66adb99148