### PR TITLE
chore(tests): start replacing pytest-httpserver by respx

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ test =
     pytest-httpserver==1.0.4
     pytest-timeout==2.1.0
     pytest-github-actions-annotate-failures==0.1.6
+    respx==0.19.2
     vcrpy>=4.1.1
 pep8 =
     flake8==4.0.1


### PR DESCRIPTION
httpserver starts a real http server that is very slow.
respx mock the heart of httpx make tests ran a lot faster.

test_clients takes now ~3s instead of 20s

Change-Id: I376c36c55a30f066b41bc394c210eaea367fde1f
