### PR TITLE
fix(queue): remove pull requests cleanup

### DIFF
--- a/mergify_engine/queue/merge_train.py
+++ b/mergify_engine/queue/merge_train.py
@@ -1356,7 +1356,8 @@ class Train(queue.QueueBase):
         await self._split_failed_batches(queue_rules)
         await self._populate_cars(queue_rules)
         # FIXME(sileht): we should not ran that on each worker run, once a hour or once a day should be enough
-        await self._clean_unsused_merge_queue_branches()
+        # TODO(sileht): reenable me
+        # await self._clean_unsused_merge_queue_branches()
         await self.save()
 
     async def _clean_unsused_merge_queue_branches(self) -> None:


### PR DESCRIPTION
This adds to much latency, this code has run in production during some
hours, so the previously craps has been cleaned now.

If a bug occurs when TrainCar PR is created or deleted, we still have
_prepare_empty_draft_pr_branch() to ensure the merge-queue will not be
blocked.

Change-Id: I73e150b5787d259b8bebf62634454a8857322605