### PR TITLE
feat(config): cache loaded config in Repository context

### DIFF
--- a/mergify_engine/debug.py
+++ b/mergify_engine/debug.py
@@ -23,7 +23,6 @@ import daiquiri
 
 from mergify_engine import config
 from mergify_engine import context
-from mergify_engine import engine
 from mergify_engine import exceptions
 from mergify_engine import github_types
 from mergify_engine import queue
@@ -268,19 +267,15 @@ async def report(
         print("* CONFIGURATION:")
         mergify_config = None
         config_file = await repository.get_mergify_config_file()
-        if config_file is None:
+        if not config_file:
             print(".mergify.yml is missing")
         else:
             print(f"Config filename: {config_file['path']}")
             print(config_file["decoded_content"].decode())
             try:
-                mergify_config = rules.get_mergify_config(config_file)
+                mergify_config = await repository.get_mergify_config()
             except rules.InvalidRules as e:  # pragma: no cover
                 print(f"configuration is invalid {str(e)}")
-            else:
-                mergify_config["pull_request_rules"].rules.extend(
-                    engine.MERGIFY_BUILTIN_CONFIG["pull_request_rules"].rules
-                )
 
         if pull_number is None:
             async for branch in typing.cast(

--- a/mergify_engine/queue/__init__.py
+++ b/mergify_engine/queue/__init__.py
@@ -22,9 +22,11 @@ import voluptuous
 
 from mergify_engine import context
 from mergify_engine import github_types
-from mergify_engine import rules
 from mergify_engine import utils
 
+
+if typing.TYPE_CHECKING:
+    from mergify_engine import rules
 
 LOG = daiquiri.getLogger(__name__)
 
@@ -61,8 +63,8 @@ class PullQueueConfig(typing.TypedDict):
     effective_priority: int
     bot_account: typing.Optional[github_types.GitHubLogin]
     update_bot_account: typing.Optional[github_types.GitHubLogin]
-    name: rules.QueueName
-    queue_config: rules.QueueConfig
+    name: "rules.QueueName"
+    queue_config: "rules.QueueConfig"
 
 
 QueueT = typing.TypeVar("QueueT", bound="QueueBase")

--- a/mergify_engine/rules/__init__.py
+++ b/mergify_engine/rules/__init__.py
@@ -27,6 +27,7 @@ import voluptuous
 import yaml
 
 from mergify_engine import actions
+from mergify_engine import config
 from mergify_engine import context
 from mergify_engine import date
 from mergify_engine import github_types
@@ -721,3 +722,20 @@ def get_mergify_config(
         return typing.cast(MergifyConfig, final_config)
     except voluptuous.Invalid as e:
         raise InvalidRules(e, config_file["path"])
+
+
+MERGIFY_BUILTIN_CONFIG_YAML = f"""
+pull_request_rules:
+  - name: delete backport/copy branch (Mergify rule)
+    hidden: true
+    conditions:
+      - author={config.BOT_USER_LOGIN}
+      - head~=^mergify/(bp|copy)/
+      - closed
+    actions:
+        delete_head_branch:
+"""
+
+MERGIFY_BUILTIN_CONFIG = UserConfigurationSchema(
+    YamlSchema(MERGIFY_BUILTIN_CONFIG_YAML)
+)

--- a/mergify_engine/rules/live_resolvers.py
+++ b/mergify_engine/rules/live_resolvers.py
@@ -18,10 +18,13 @@ import functools
 import itertools
 import typing
 
-from mergify_engine import context
 from mergify_engine import github_types
 from mergify_engine.clients import http
 from mergify_engine.rules import filter
+
+
+if typing.TYPE_CHECKING:
+    from mergify_engine import context
 
 
 @dataclasses.dataclass
@@ -30,7 +33,7 @@ class LiveResolutionFailure(Exception):
 
 
 async def _resolve_login(
-    repository: context.Repository, name: str
+    repository: "context.Repository", name: str
 ) -> typing.List[github_types.GitHubLogin]:
     if not name:
         return []
@@ -70,7 +73,7 @@ async def _resolve_login(
 
 
 async def teams(
-    repository: context.Repository,
+    repository: "context.Repository",
     values: typing.Optional[typing.Union[typing.List[str], typing.Tuple[str], str]],
 ) -> typing.List[github_types.GitHubLogin]:
 
@@ -98,7 +101,7 @@ _TEAM_ATTRIBUTES = (
 
 
 def configure_filter(
-    repository: context.Repository, f: filter.Filter[filter.FilterResultT]
+    repository: "context.Repository", f: filter.Filter[filter.FilterResultT]
 ) -> None:
     for attrib in _TEAM_ATTRIBUTES:
         f.value_expanders[attrib] = functools.partial(  # type: ignore[assignment]

--- a/mergify_engine/tests/unit/rules/test_rules.py
+++ b/mergify_engine/tests/unit/rules/test_rules.py
@@ -524,7 +524,7 @@ pull_request_rules:
     client.item.return_value = item()
     fake_repository.installation.client = client
 
-    fake_repository._caches.mergify_config.delete()
+    fake_repository._caches.mergify_config_file.delete()
     config_file = await fake_repository.get_mergify_config_file()
     assert config_file is not None
 

--- a/mergify_engine/tests/unit/test_train.py
+++ b/mergify_engine/tests/unit/test_train.py
@@ -588,6 +588,7 @@ queue_rules:
 """,
     ):
         repository._caches.mergify_config.delete()
+        repository._caches.mergify_config_file.delete()
         await t.refresh()
     assert [[1, 2], [1, 2, 3]] == get_cars_content(t)
     assert [4, 5] == get_waiting_content(t)
@@ -618,6 +619,7 @@ queue_rules:
 """,
     ):
         repository._caches.mergify_config.delete()
+        repository._caches.mergify_config_file.delete()
         await t.refresh()
     assert [[1]] == get_cars_content(t)
     assert [2, 3] == get_waiting_content(t)
@@ -651,6 +653,7 @@ queue_rules:
 """,
     ):
         repository._caches.mergify_config.delete()
+        repository._caches.mergify_config_file.delete()
         await t.refresh()
     assert [] == get_cars_content(t)
     assert [1, 2, 3] == get_waiting_content(t)


### PR DESCRIPTION
Loading the yaml and parsing it with voluptuous is slow.

This change cache the configuration in Repository context.

Since Repository context is recreated each 30s, the cached configuration will
stay valid for 30s.

Fixes MRGFY-1071

Change-Id: Ib81251e0f182feb6e31e9e0698cf22e1c0a32014
