### PR TITLE
fix(summary): truncate summary correctly

### DIFF
--- a/mergify_engine/check_api.py
+++ b/mergify_engine/check_api.py
@@ -247,9 +247,10 @@ async def set_check_run(
 
     # Maximum output/summary length for Check API is 65535
     summary = post_parameters["output"]["summary"]
-    if summary and len(summary) > 65535:
-        post_parameters["output"]["summary"] = utils.unicode_truncate(summary, 65532)
-        post_parameters["output"]["summary"] += "…"  # this is 3 bytes long
+    if summary:
+        post_parameters["output"]["summary"] = utils.unicode_truncate(
+            summary, 65535, "…"
+        )
 
     if external_id:
         post_parameters["external_id"] = external_id

--- a/mergify_engine/utils.py
+++ b/mergify_engine/utils.py
@@ -131,12 +131,32 @@ async def stop_pending_yaaredis_tasks() -> None:
         await asyncio.wait(tasks)
 
 
-def unicode_truncate(s: str, length: int, encoding: str = "utf-8") -> str:
+def unicode_truncate(
+    s: str,
+    length: int,
+    placeholder: str = "",
+    encoding: str = "utf-8",
+) -> str:
     """Truncate a string to length in bytes.
 
     :param s: The string to truncate.
-    :param length: The length in number of bytes — not characters."""
-    return s.encode(encoding)[:length].decode(encoding, errors="ignore")
+    :param length: The length in number of bytes — not characters (placeholder included).
+    :param placeholder: String that will appear at the end of the output text if it has been truncated.
+    """
+    b = s.encode(encoding)
+    if len(b) > length:
+        placeholder_bytes = placeholder.encode(encoding)
+        placeholder_length = len(placeholder_bytes)
+        if placeholder_length > length:
+            raise ValueError(
+                "`placeholder` length must be greater or equal to `length`"
+            )
+
+        cut_at = length - placeholder_length
+
+        return (b[:cut_at] + placeholder_bytes).decode(encoding, errors="ignore")
+    else:
+        return s
 
 
 def compute_hmac(data: bytes, secret: str) -> str:


### PR DESCRIPTION
The current code was checking the number of char instead bytes length,
before truncating the string.

This change ensures everything is done in bytes.

Fixes MERGIFY-ENGINE-2MQ
Fixes MERGIFY-ENGINE-2J8
Fixes MRGFY-1082
