### PR TITLE
fix(worker): keep PR in queue more times

### DIFF
--- a/mergify_engine/tests/unit/test_worker.py
+++ b/mergify_engine/tests/unit/test_worker.py
@@ -694,6 +694,20 @@ async def test_stream_processor_retrying_pull(
         exceptions.MergeableStateUnknown(mock.Mock()),
         exceptions.MergeableStateUnknown(mock.Mock()),
         exceptions.MergeableStateUnknown(mock.Mock()),
+        exceptions.MergeableStateUnknown(mock.Mock()),
+        exceptions.MergeableStateUnknown(mock.Mock()),
+        exceptions.MergeableStateUnknown(mock.Mock()),
+        exceptions.MergeableStateUnknown(mock.Mock()),
+        exceptions.MergeableStateUnknown(mock.Mock()),
+        exceptions.MergeableStateUnknown(mock.Mock()),
+        exceptions.MergeableStateUnknown(mock.Mock()),
+        exceptions.MergeableStateUnknown(mock.Mock()),
+        exceptions.MergeableStateUnknown(mock.Mock()),
+        exceptions.MergeableStateUnknown(mock.Mock()),
+        exceptions.MergeableStateUnknown(mock.Mock()),
+        exceptions.MergeableStateUnknown(mock.Mock()),
+        exceptions.MergeableStateUnknown(mock.Mock()),
+        exceptions.MergeableStateUnknown(mock.Mock()),
     ]
 
     await worker.push(
@@ -791,10 +805,18 @@ async def test_stream_processor_retrying_pull(
     await p.consume("bucket~123", 123, "owner-123")
     await p.consume("bucket~123", 123, "owner-123")
     await p.consume("bucket~123", 123, "owner-123")
-    assert len(run_engine.mock_calls) == 9
+    await p.consume("bucket~123", 123, "owner-123")
+    await p.consume("bucket~123", 123, "owner-123")
+    await p.consume("bucket~123", 123, "owner-123")
+    await p.consume("bucket~123", 123, "owner-123")
+    await p.consume("bucket~123", 123, "owner-123")
+    await p.consume("bucket~123", 123, "owner-123")
+    await p.consume("bucket~123", 123, "owner-123")
+    await p.consume("bucket~123", 123, "owner-123")
+    assert len(run_engine.mock_calls) == 17
 
     # Too many retries, everything is gone
-    assert 7 == len(logger.info.mock_calls)
+    assert 15 == len(logger.info.mock_calls)
     assert 1 == len(logger.error.mock_calls)
     assert logger.info.mock_calls[0].args == (
         "failed to process pull request, retrying",

--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -100,8 +100,8 @@ else:
 
 LOG = daiquiri.getLogger(__name__)
 
-
-MAX_RETRIES: int = 7
+# we keep the PR in queue for ~ 7 minutes (a try == WORKER_PROCESSING_DELAY)
+MAX_RETRIES: int = 15
 WORKER_PROCESSING_DELAY: float = 30
 STREAM_ATTEMPTS_LOGGING_THRESHOLD: int = 20
 


### PR DESCRIPTION
This directly depends on GitHub "mergeable_state" background
computation. Usually it's matter of seconds, but sometimes it could be
more that 3 minutes.

Change-Id: Ie501c70383e8cb0cd7b6eceddeaec39a77ff86c6
