### PR TITLE
test: fix Redis connection shutdown

### DIFF
--- a/mergify_engine/utils.py
+++ b/mergify_engine/utils.py
@@ -120,7 +120,7 @@ async def stop_pending_yaaredis_tasks() -> None:
         task
         for task in asyncio.all_tasks()
         if (
-            task.get_coro().__qualname__  # type: ignore[union-attr]
+            getattr(task.get_coro(), "__qualname__", None)
             == "ConnectionPool.disconnect_on_idle_time_exceeded"
         )
     ]


### PR DESCRIPTION
In case of CTRL+C during pytest run, get_coro() may returns an
Generator[Future] instead of an awaitable and they don't have a
__qualname__.