### PR TITLE
revert: "test: install pytest-profiling (#4547)"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,6 @@ test =
     pytest-asyncio==0.18.3
     pytest-httpserver==1.0.4
     pytest-timeout==2.1.0
-    pytest-profiling==1.7.0
     pytest-github-actions-annotate-failures==0.1.6
     respx==0.19.2
     vcrpy>=4.1.1


### PR DESCRIPTION
This reverts commit d0f087c68c5f906971de1331b2bac4a9da63850e.

This doesn't work as expected, it measures the cpu time, but since we
use asynio we want the wall time of our coroutine, not the cpu time.