### PR TITLE
test: close idle Redis connections faster

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,8 @@ setenv =
    DD_DOGSTATSD_DISABLE=1
    DD_TRACE_ENABLED=0
    MERGIFYENGINE_TEST_SETTINGS=fake.env
-   MERGIFYENGINE_STORAGE_URL=redis://localhost:6363?db=2
-   MERGIFYENGINE_STREAM_URL=redis://localhost:6363?db=3
+   MERGIFYENGINE_STORAGE_URL=redis://localhost:6363?db=2&idle_check_interval=0
+   MERGIFYENGINE_STREAM_URL=redis://localhost:6363?db=3&idle_check_interval=0
    PYTEST_TIMEOUT=20
 usedevelop = true
 extras = test
@@ -33,8 +33,8 @@ setenv =
    DD_DOGSTATSD_DISABLE=1
    DD_TRACE_ENABLED=0
    MERGIFYENGINE_TEST_SETTINGS=test.env
-   MERGIFYENGINE_STORAGE_URL=redis://localhost:6363?db=2
-   MERGIFYENGINE_STREAM_URL=redis://localhost:6363?db=3
+   MERGIFYENGINE_STORAGE_URL=redis://localhost:6363?db=2&idle_check_interval=0
+   MERGIFYENGINE_STREAM_URL=redis://localhost:6363?db=3&idle_check_interval=0
    PYTEST_TIMEOUT=500
 whitelist_externals =
     git


### PR DESCRIPTION
This saves between 0 and 2 second each time a test teardown.
