### PR TITLE
test: change the way we hide access_tokens from fixtures

### DIFF
--- a/mergify_engine/tests/functional/conftest.py
+++ b/mergify_engine/tests/functional/conftest.py
@@ -246,30 +246,13 @@ def pyvcr_response_filter(response):
         "X-XSS-Protection",
     ]:
         response["headers"].pop(h, None)
-
-    if "body" in response:
-        # Urllib3 vcrpy format
-        try:
-            data = json.loads(response["body"]["string"].decode())
-        except ValueError:
-            data = None
-    else:
-        # httpx vcrpy format
-        try:
-            data = json.loads(response["content"])
-        except ValueError:
-            data = None
-
-    if data and "token" in data:
-        data["token"] = "<TOKEN>"
-        if "body" in response:
-            # Urllib3 vcrpy format
-            response["body"]["string"] = json.dumps(data).encode()
-        else:
-            # httpx vcrpy format
-            response["content"] = json.dumps(data)
-
     return response
+
+
+def pyvcr_request_filter(request):
+    if request.method == "POST" and request.path.endswith("/access_tokens"):
+        return None
+    return request
 
 
 class RecorderFixture(typing.NamedTuple):
@@ -321,6 +304,7 @@ async def recorder(
             ("Connection", None),
         ],
         before_record_response=pyvcr_response_filter,
+        before_record_request=pyvcr_request_filter,
     )
 
     if RECORD:


### PR DESCRIPTION
We can leverage the pyvcr before_record_request to filter out the
requests with access_tokens as there are not reused during replay.

This avoids the need to deserialize all response payloads.