### PR TITLE
fix(http): adapt ClientSideError payload format changes

### DIFF
--- a/mergify_engine/actions/delete_head_branch.py
+++ b/mergify_engine/actions/delete_head_branch.py
@@ -80,7 +80,7 @@ class DeleteHeadBranchAction(actions.Action):
             await ctxt.client.delete(f"{ctxt.base_url}/git/refs/heads/{ref_to_delete}")
         except http.HTTPClientSideError as e:
             if e.status_code == 404 or (
-                e.status_code == 422 and e.contains("Reference does not exist")
+                e.status_code == 422 and "Reference does not exist" in e.message
             ):
                 return check_api.Result(
                     check_api.Conclusion.SUCCESS,

--- a/mergify_engine/check_api.py
+++ b/mergify_engine/check_api.py
@@ -173,7 +173,7 @@ async def get_checks_for_ref(
             )
         ]
     except http.HTTPClientSideError as e:
-        if e.status_code == 422 and e.contains("No commit found for SHA"):
+        if e.status_code == 422 and "No commit found for SHA" in e.message:
             return []
         raise
 

--- a/mergify_engine/duplicate_pull.py
+++ b/mergify_engine/duplicate_pull.py
@@ -412,12 +412,12 @@ async def duplicate(
         )
     except http.HTTPClientSideError as e:
         if e.status_code == 422:
-            if e.contains("No commits between"):
+            if "No commits between" in e.message:
                 if cherry_pick_error:
                     raise DuplicateFailed(cherry_pick_error)
                 else:
                     raise DuplicateNotNeeded(e.message)
-            elif e.contains("A pull request already exists"):
+            elif "A pull request already exists" in e.message:
                 raise DuplicateAlreadyExists(e.message)
 
         raise

--- a/mergify_engine/engine/__init__.py
+++ b/mergify_engine/engine/__init__.py
@@ -464,6 +464,6 @@ async def create_initial_summary(
                 json=post_parameters,
             )
         except http.HTTPClientSideError as e:
-            if e.status_code == 422 and e.contains("No commit found for SHA"):
+            if e.status_code == 422 and "No commit found for SHA" in e.message:
                 return
             raise

--- a/mergify_engine/queue/merge_train.py
+++ b/mergify_engine/queue/merge_train.py
@@ -560,7 +560,7 @@ class TrainCar:
             )
         except http.HTTPClientSideError as e:
 
-            if e.contains("A pull request already exists for"):
+            if "A pull request already exists for" in e.message:
                 # NOTE(sileht): filter pull request on head is dangerous.
                 # head must be organization:ref-name, if the left or the right side of the : is empty
                 # all pull requests are returned. So it's better to double checks
@@ -580,7 +580,7 @@ class TrainCar:
                     await self.train._close_pull_request(pull["number"])
                 raise tenacity.TryAgain
 
-            if not e.contains("Draft pull requests are not supported"):
+            if "Draft pull requests are not supported" not in e.message:
                 self.train.log.error(
                     "fail to create a merge-queue pull request",
                     head=branch_name,
@@ -614,7 +614,7 @@ class TrainCar:
                 },
             )
         except http.HTTPClientSideError as exc:
-            if exc.status_code == 422 and exc.contains("Reference already exists"):
+            if exc.status_code == 422 and "Reference already exists" in exc.message:
                 try:
                     await self._delete_branch()
                 except http.HTTPClientSideError as exc_patch:
@@ -668,8 +668,9 @@ class TrainCar:
                     },
                 )
             except http.HTTPClientSideError as e:
-                if e.status_code == 403 and e.contains(
-                    "Resource not accessible by integration"
+                if (
+                    e.status_code == 403
+                    and "Resource not accessible by integration" in e.message
                 ):
                     self.train.log.info(
                         "fail to create the queue pull request due to GitHub App restriction",
@@ -681,7 +682,7 @@ class TrainCar:
                     )
                     await self._delete_branch()
                     raise TrainCarPullRequestCreationPostponed(self) from e
-                elif e.contains("Merge conflict"):
+                elif "Merge conflict" in e.message:
                     pull_requests_ahead = self.parent_pull_request_numbers[:]
                     for ep in self.still_queued_embarked_pulls:
                         if ep.user_pull_request_number == pull_number:
@@ -2168,7 +2169,7 @@ class Train(queue.QueueBase):
             )
         except http.HTTPClientSideError as exc:
             if exc.status_code == 404 or (
-                exc.status_code == 422 and exc.contains("Reference does not exist")
+                exc.status_code == 422 and "Reference does not exist" in exc.message
             ):
                 self.log.warning(
                     "fail to delete merge-queue branch",


### PR DESCRIPTION
It seems like the list of errors in the payload sent from GitHub does only contain
the error's string. Github added new payload format that needs to be handled. 

Fixes MRGFY-1112
Fixes MERGIFY-ENGINE-2N4