### PR TITLE
fix(api): don't return 400 but 422

### DIFF
--- a/mergify_engine/tests/functional/api/test_queue_freeze.py
+++ b/mergify_engine/tests/functional/api/test_queue_freeze.py
@@ -89,7 +89,15 @@ class TestQueueFreeze(base.FunctionalTestBase):
             },
         )
         assert r.status_code == 422
-        assert r.json() == {"detail": "Missing request body parameter"}
+        assert r.json() == {
+            "detail": [
+                {
+                    "loc": ["body"],
+                    "msg": "field required",
+                    "type": "value_error.missing",
+                }
+            ]
+        }
 
         freeze_payload = {"false_key": "test freeze reason"}
 
@@ -104,7 +112,13 @@ class TestQueueFreeze(base.FunctionalTestBase):
 
         assert r.status_code == 422
         assert r.json() == {
-            "detail": "Body parameter got an unexpected keyword argument 'false_key'"
+            "detail": [
+                {
+                    "loc": ["body", "reason"],
+                    "msg": "field required",
+                    "type": "value_error.missing",
+                }
+            ]
         }
 
         freeze_payload = {"reason": "test freeze reason"}

--- a/mergify_engine/web/api/queues.py
+++ b/mergify_engine/web/api/queues.py
@@ -139,11 +139,10 @@ class Queues:
     )
 
 
-@pydantic.dataclasses.dataclass
-class QueueFreezePayload:
-    reason: str = dataclasses.field(
-        metadata={"description": "The reason of the queue freeze"}
-    )
+# FIXME(sileht): reuse dataclasses variante once
+# https://github.com/tiangolo/fastapi/issues/4679 is fixed
+class QueueFreezePayload(pydantic.BaseModel):
+    reason: str = pydantic.Field(description="The reason of the queue freeze")
 
 
 @pydantic.dataclasses.dataclass

--- a/mergify_engine/web/utils.py
+++ b/mergify_engine/web/utils.py
@@ -44,29 +44,3 @@ def setup_exception_handlers(app: fastapi.FastAPI) -> None:
             status_code=403,
             content={"message": "Organization or user has hit GitHub API rate limit"},
         )
-
-    @app.exception_handler(fastapi.exceptions.RequestValidationError)
-    async def request_validation_error_handler(
-        request: requests.Request, exc: fastapi.exceptions.RequestValidationError
-    ) -> responses.JSONResponse:
-
-        validation_errors = exc.errors()
-        for err in validation_errors:
-            if err["type"] == "value_error.missing":
-                return responses.JSONResponse(
-                    status_code=422,
-                    content={"detail": "Missing request body parameter"},
-                )
-
-            if err["type"] == "type_error":
-                return responses.JSONResponse(
-                    status_code=422,
-                    content={
-                        "detail": f'Body parameter got an unexpected keyword argument {err["msg"].split(" ")[-1]}'
-                    },
-                )
-
-        return responses.JSONResponse(
-            status_code=400,
-            content={"detail": str(exc.errors())},
-        )


### PR DESCRIPTION
We should not play with how fastapi handle errors.

For example, "value_error.missing" type can be raise for a
fastapi.Path() or fastapi.QueryString(), not only fastapi.Body(). Making
our error message misleading.

We also convert some 422 to 400, while openapi said we only have 422
errors. So just always keep the original 422.

Until the fastapi bug with dataclasses is fixed we should use
pydantic.BaseModel for Body() to have a correct error reported.

Change-Id: I0d2f1d7fca0822f53171eca43eafe3be599e8d22
