### PR TITLE
revert: "chore(deps): bump google-github-actions/upload-cloud-storage from 0.9.0 to 0.10.0"

### DIFF
--- a/.github/workflows/docs-upload-gcp-prod.yaml
+++ b/.github/workflows/docs-upload-gcp-prod.yaml
@@ -39,7 +39,7 @@ jobs:
           export_default_credentials: true
 
       - name: Deploy 🚀
-        uses: google-github-actions/upload-cloud-storage@v0.10.0
+        uses: google-github-actions/upload-cloud-storage@v0.9.0
         with:
           path: docs/build
           destination: mergify-docs-prod

--- a/.github/workflows/docs-upload-gcp.yaml
+++ b/.github/workflows/docs-upload-gcp.yaml
@@ -46,7 +46,7 @@ jobs:
           service_account_email: ${{ secrets.GCP_DOCS_EMAIL }}
           service_account_key: ${{ secrets.GCP_DOCS_KEY }}
           export_default_credentials: true
-      - uses: google-github-actions/upload-cloud-storage@v0.10.0
+      - uses: google-github-actions/upload-cloud-storage@v0.9.0
         with:
           path: docs
           destination: mergify-docs-preview/${{steps.download-artifact.outputs.result}}


### PR DESCRIPTION
Looks like it brokes content-type 

Reverts Mergifyio/mergify-engine#4572