### PR TITLE
ci: increase allowed time for pep8 target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pep8:
-    timeout-minutes: 5
+    timeout-minutes: 7
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout 🛎️


### PR DESCRIPTION
Since we have semgrep, this target takes around 5 minutes.
A lot of time, GitHub marks it as failed because it takes a couples of
additional seconds to finish.

This change increase the timeout to avoid that.

Change-Id: Id4fd12d242b58180b41258008dddeb36d64ab570