### PR TITLE
test(pytest): move configuration to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,9 @@ target-version = ['py39']
 [build-system]
 requires = ["setuptools >= 40.6.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--strict-markers"
+asyncio_mode = "auto"
+markers = ["recorder", "subscription"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -150,10 +150,3 @@ disallow_untyped_decorators = true
 show_error_codes = true
 disallow_untyped_calls = true
 plugins = pydantic.mypy
-
-[tool:pytest]
-addopts = --strict-markers
-asyncio_mode = auto
-markers =
-  recorder
-  subscription


### PR DESCRIPTION
This is the new recommended ways because of:

    Usage of setup.cfg is not recommended unless for very simple use cases.
    .cfg files use a different parser than pytest.ini and tox.ini which
    might cause hard to track down problems. When possible, it is
    recommended to use the latter files, or pyproject.toml, to hold your
    pytest configuration.

Change-Id: I923aa6a6f54bfd05a25fea7dd4b831e6a496ae1d