### PR TITLE
refactor(queue): change evaluator function name in QueueRule class

### DIFF
--- a/mergify_engine/actions/queue.py
+++ b/mergify_engine/actions/queue.py
@@ -153,7 +153,7 @@ Then, re-embark the pull request into the merge queue by posting the comment
         if car and car.creation_state == "updated" and not ctxt.closed:
             # NOTE(sileht): This car doesn't have tmp pull, so we have the
             # MERGE_QUEUE_SUMMARY and train reset here
-            queue_rule_evaluated = await self.queue_rule.get_pull_request_rule(
+            queue_rule_evaluated = await self.queue_rule.get_evaluated_queue_rule(
                 ctxt.repository,
                 ctxt.pull["base"]["ref"],
                 [ctxt.pull_request],

--- a/mergify_engine/engine/queue_runner.py
+++ b/mergify_engine/engine/queue_runner.py
@@ -95,7 +95,7 @@ async def handle(queue_rules: rules.QueueRules, ctxt: context.Context) -> None:
         return
 
     pull_requests = await car.get_pull_requests_to_evaluate()
-    evaluated_queue_rule = await queue_rule.get_pull_request_rule(
+    evaluated_queue_rule = await queue_rule.get_evaluated_queue_rule(
         ctxt.repository,
         ctxt.pull["base"]["ref"],
         pull_requests,

--- a/mergify_engine/queue/merge_train.py
+++ b/mergify_engine/queue/merge_train.py
@@ -715,7 +715,7 @@ class TrainCar:
         self.queue_pull_request_number = pull_request_number
 
         queue_pull_requests = await self.get_pull_requests_to_evaluate()
-        evaluated_queue_rule = await queue_rule.get_pull_request_rule(
+        evaluated_queue_rule = await queue_rule.get_evaluated_queue_rule(
             self.train.repository,
             self.train.ref,
             queue_pull_requests,

--- a/mergify_engine/rules/__init__.py
+++ b/mergify_engine/rules/__init__.py
@@ -118,7 +118,7 @@ class QueueRule:
 
         return cls(name, conditions, d)
 
-    async def get_pull_request_rule(
+    async def get_evaluated_queue_rule(
         self,
         repository: context.Repository,
         ref: github_types.GitHubRefType,


### PR DESCRIPTION
Name of the function was `get_pull_request_rule` when it was returning
a queue rule under an `EvaluatedQueueRule`, creating confusion.

Fixes MRGFY-1017