### PR TITLE
refactor(queue): get_rule_checks_status

### DIFF
--- a/mergify_engine/actions/merge_base.py
+++ b/mergify_engine/actions/merge_base.py
@@ -14,7 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import abc
-import logging
 import re
 import typing
 
@@ -27,81 +26,12 @@ from mergify_engine import queue
 from mergify_engine import rules
 from mergify_engine.clients import http
 from mergify_engine.dashboard import user_tokens
-from mergify_engine.rules import filter
-from mergify_engine.rules import live_resolvers
 
 
 REQUIRED_STATUS_RE = re.compile(r'Required status check "([^"]*)" is expected.')
 FORBIDDEN_MERGE_COMMITS_MSG = "Merge commits are not allowed on this repository."
 FORBIDDEN_SQUASH_MERGE_MSG = "Squash merges are not allowed on this repository."
 FORBIDDEN_REBASE_MERGE_MSG = "Rebase merges are not allowed on this repository."
-
-
-async def get_rule_checks_status(
-    log: "logging.LoggerAdapter[logging.Logger]",
-    repository: context.Repository,
-    pulls: typing.List[context.BasePullRequest],
-    rule: typing.Union["rules.EvaluatedRule", "rules.EvaluatedQueueRule"],
-    *,
-    unmatched_conditions_return_failure: bool = True,
-    use_new_rule_checks_status: bool = True,
-) -> check_api.Conclusion:
-
-    if rule.conditions.match:
-        return check_api.Conclusion.SUCCESS
-
-    conditions_without_checks = rule.conditions.copy()
-    for condition_without_check in conditions_without_checks.walk():
-        attr = condition_without_check.get_attribute_name()
-        if attr.startswith("check-") or attr.startswith("status-"):
-            condition_without_check.update("number>0")
-
-    # NOTE(sileht): Something unrelated to checks unmatch?
-    await conditions_without_checks(pulls)
-    log.debug(
-        "something unrelated to checks doesn't match? %s",
-        conditions_without_checks.get_summary(),
-    )
-    if not conditions_without_checks.match:
-        if unmatched_conditions_return_failure:
-            return check_api.Conclusion.FAILURE
-        else:
-            return check_api.Conclusion.PENDING
-
-    # NOTE(sileht): we replace BinaryFilter by IncompleteChecksFilter to ensure
-    # all required CIs have finished. IncompleteChecksFilter return 3 states
-    # instead of just True/False, this allows us to known if a condition can
-    # change in the future or if its a final state.
-    tree = rule.conditions.extract_raw_filter_tree()
-    results: typing.Dict[int, filter.IncompleteChecksResult] = {}
-
-    for pull in pulls:
-        f = filter.IncompleteChecksFilter(
-            tree,
-            pending_checks=await getattr(pull, "check-pending"),
-            all_checks=await pull.check,  # type: ignore[attr-defined]
-        )
-        live_resolvers.configure_filter(repository, f)
-
-        ret = await f(pull)
-        if ret is filter.IncompleteCheck:
-            log.debug("found an incomplete check")
-            return check_api.Conclusion.PENDING
-
-        pr_number = await pull.number  # type: ignore[attr-defined]
-        results[pr_number] = ret
-
-    if all(results.values()):
-        # This can't occur!, we should have returned SUCCESS earlier.
-        log.error(
-            "filter.IncompleteChecksFilter unexpectly returned true",
-            tree=tree,
-            results=results,
-        )
-        # So don't merge broken stuff
-        return check_api.Conclusion.PENDING
-    else:
-        return check_api.Conclusion.FAILURE
 
 
 class MergeBaseAction(actions.Action, abc.ABC):

--- a/mergify_engine/actions/queue.py
+++ b/mergify_engine/actions/queue.py
@@ -30,6 +30,7 @@ from mergify_engine.actions import utils as action_utils
 from mergify_engine.dashboard import subscription
 from mergify_engine.queue import freeze
 from mergify_engine.queue import merge_train
+from mergify_engine.rules import checks_status
 from mergify_engine.rules import conditions
 from mergify_engine.rules import types
 
@@ -165,6 +166,7 @@ Then, re-embark the pull request into the merge queue by posting the comment
             )
 
             unexpected_changes: typing.Optional[merge_train.UnexpectedChange]
+            status: checks_status.ChecksCombinedStatus
             if await ctxt.has_been_synchronized_by_user() or await ctxt.is_behind:
                 unexpected_changes = merge_train.UnexpectedUpdatedPullRequestChange(
                     ctxt.pull["number"]
@@ -176,7 +178,7 @@ Then, re-embark the pull request into the merge queue by posting the comment
                 await q.reset(unexpected_changes)
             else:
                 unexpected_changes = None
-                status = await merge_base.get_rule_checks_status(
+                status = await checks_status.get_rule_checks_status(
                     ctxt.log,
                     ctxt.repository,
                     [ctxt.pull_request],
@@ -478,7 +480,7 @@ Then, re-embark the pull request into the merge queue by posting the comment
         car = typing.cast(merge_train.Train, q).get_car(ctxt)
         if car and car.creation_state == "updated":
             # NOTE(sileht) check first if PR should be removed from the queue
-            pull_rule_checks_status = await merge_base.get_rule_checks_status(
+            pull_rule_checks_status = await checks_status.get_rule_checks_status(
                 ctxt.log, ctxt.repository, [ctxt.pull_request], rule
             )
             # NOTE(sileht): if the pull request rules are pending we wait their

--- a/mergify_engine/engine/queue_runner.py
+++ b/mergify_engine/engine/queue_runner.py
@@ -19,8 +19,8 @@ from mergify_engine import context
 from mergify_engine import delayed_refresh
 from mergify_engine import github_types
 from mergify_engine import rules
-from mergify_engine.actions import merge_base
 from mergify_engine.queue import merge_train
+from mergify_engine.rules import checks_status
 
 
 async def have_unexpected_draft_pull_request_changes(
@@ -125,7 +125,7 @@ async def handle(queue_rules: rules.QueueRules, ctxt: context.Context) -> None:
             )
 
     if unexpected_changes is None:
-        real_status = status = await merge_base.get_rule_checks_status(
+        real_status = status = await checks_status.get_rule_checks_status(
             ctxt.log,
             ctxt.repository,
             pull_requests,

--- a/mergify_engine/queue/merge_train.py
+++ b/mergify_engine/queue/merge_train.py
@@ -43,6 +43,7 @@ from mergify_engine.dashboard import user_tokens
 
 if typing.TYPE_CHECKING:
     from mergify_engine import rules
+    from mergify_engine.rules import checks_status
 
 
 def build_pr_link(
@@ -884,7 +885,7 @@ You don't need to do anything. Mergify will close this pull request automaticall
 
     async def update_state(
         self,
-        checks_conclusion: check_api.Conclusion,
+        checks_conclusion: "checks_status.ChecksCombinedStatus",
         evaluated_queue_rule: "rules.EvaluatedQueueRule",
     ) -> None:
         self.checks_conclusion = checks_conclusion
@@ -975,8 +976,7 @@ You don't need to do anything. Mergify will close this pull request automaticall
 
     async def update_summaries(
         self,
-        conclusion: check_api.Conclusion,
-        *,
+        conclusion: "checks_status.ChecksCombinedStatus",
         unexpected_change: typing.Optional[UnexpectedChange] = None,
         force_refresh: bool = False,
     ) -> None:

--- a/mergify_engine/rules/checks_status.py
+++ b/mergify_engine/rules/checks_status.py
@@ -1,0 +1,96 @@
+# -*- encoding: utf-8 -*-
+#
+# Copyright © 2022 Mergify SAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+import logging
+import typing
+
+from mergify_engine import check_api
+from mergify_engine import context
+from mergify_engine import rules
+from mergify_engine.rules import filter
+from mergify_engine.rules import live_resolvers
+
+
+ChecksCombinedStatus = typing.Literal[
+    check_api.Conclusion.FAILURE,
+    check_api.Conclusion.SUCCESS,
+    check_api.Conclusion.PENDING,
+]
+
+
+async def get_rule_checks_status(
+    log: "logging.LoggerAdapter[logging.Logger]",
+    repository: context.Repository,
+    pulls: typing.List[context.BasePullRequest],
+    rule: typing.Union["rules.EvaluatedRule", "rules.EvaluatedQueueRule"],
+    *,
+    unmatched_conditions_return_failure: bool = True,
+    use_new_rule_checks_status: bool = True,
+) -> ChecksCombinedStatus:
+    if rule.conditions.match:
+        return check_api.Conclusion.SUCCESS
+
+    conditions_without_checks = rule.conditions.copy()
+    for condition_without_check in conditions_without_checks.walk():
+        attr = condition_without_check.get_attribute_name()
+        if attr.startswith("check-") or attr.startswith("status-"):
+            condition_without_check.update("number>0")
+
+    # NOTE(sileht): Something unrelated to checks unmatch?
+    await conditions_without_checks(pulls)
+    log.debug(
+        "something unrelated to checks doesn't match? %s",
+        conditions_without_checks.get_summary(),
+    )
+    if not conditions_without_checks.match:
+        if unmatched_conditions_return_failure:
+            return check_api.Conclusion.FAILURE
+        else:
+            return check_api.Conclusion.PENDING
+
+    # NOTE(sileht): we replace BinaryFilter by IncompleteChecksFilter to ensure
+    # all required CIs have finished. IncompleteChecksFilter return 3 states
+    # instead of just True/False, this allows us to known if a condition can
+    # change in the future or if its a final state.
+    tree = rule.conditions.extract_raw_filter_tree()
+    results: typing.Dict[int, filter.IncompleteChecksResult] = {}
+
+    for pull in pulls:
+        f = filter.IncompleteChecksFilter(
+            tree,
+            pending_checks=await getattr(pull, "check-pending"),
+            all_checks=await pull.check,  # type: ignore[attr-defined]
+        )
+        live_resolvers.configure_filter(repository, f)
+
+        ret = await f(pull)
+        if ret is filter.IncompleteCheck:
+            log.debug("found an incomplete check")
+            return check_api.Conclusion.PENDING
+
+        pr_number = await pull.number  # type: ignore[attr-defined]
+        results[pr_number] = ret
+
+    if all(results.values()):
+        # This can't occur!, we should have returned SUCCESS earlier.
+        log.error(
+            "filter.IncompleteChecksFilter unexpectly returned true",
+            tree=tree,
+            results=results,
+        )
+        # So don't merge broken stuff
+        return check_api.Conclusion.PENDING
+    else:
+        return check_api.Conclusion.FAILURE

--- a/mergify_engine/tests/unit/actions/test_queue.py
+++ b/mergify_engine/tests/unit/actions/test_queue.py
@@ -22,8 +22,8 @@ import voluptuous
 from mergify_engine import check_api
 from mergify_engine import github_types
 from mergify_engine import rules
-from mergify_engine.actions import merge_base
 from mergify_engine.clients import http
+from mergify_engine.rules import checks_status
 from mergify_engine.tests.unit import conftest
 
 
@@ -274,7 +274,7 @@ async def test_get_rule_checks_status(
     match = await rules.get_pull_request_rule(ctxt)
     evaluated_rule = match.matching_rules[0]
     assert (
-        await merge_base.get_rule_checks_status(
+        await checks_status.get_rule_checks_status(
             ctxt.log, ctxt.repository, [ctxt.pull_request], evaluated_rule
         )
     ) == conclusion


### PR DESCRIPTION
This method does not belong in merge_base.py as it's not used in merge
action anymore.
Since it's just conditions manipulations and assertions, I created a new
module in rules/, the tests was already in unit/rules/.

This also changes to returned type to a more precise one.
