### PR TITLE
revert: "fix(queue): report cancelled reason (#4625)"

### DIFF
--- a/mergify_engine/actions/queue.py
+++ b/mergify_engine/actions/queue.py
@@ -416,13 +416,13 @@ Then, re-embark the pull request into the merge queue by posting the comment
         self, ctxt: context.Context, q: queue.QueueT
     ) -> check_api.Result:
         check = await ctxt.get_engine_check_run(constants.MERGE_QUEUE_SUMMARY_NAME)
-        if (
+        manually_unqueued = (
             check
             and check_api.Conclusion(check["conclusion"])
             == check_api.Conclusion.CANCELLED
-        ):
-            # NOTE(sileht): already cancelled, keep the already reported reason
-            reason = check["output"]["summary"]
+        )
+        if manually_unqueued:
+            reason = "The pull request has been manually removed from the queue by an `unqueue` command."
         else:
             reason = (
                 "The queue conditions cannot be satisfied due to failing checks or checks timeout. "


### PR DESCRIPTION
The test_queue tests don't passed anymore since this change, the
reported summary is empty.

This reverts commit 7dd9ead2e701aab8ddd8aa7c9bce58a905286f66.