### PR TITLE
test: configure only one shared worker

### DIFF
--- a/mergify_engine/tests/functional/base.py
+++ b/mergify_engine/tests/functional/base.py
@@ -558,7 +558,11 @@ class FunctionalTestBase(unittest.IsolatedAsyncioTestCase):
 
     async def run_engine(self) -> None:
         LOG.log(42, "RUNNING ENGINE")
-        w = worker.Worker(enabled_services=set())
+        w = worker.Worker(
+            enabled_services=set(),
+            shared_stream_processes=1,
+            shared_stream_tasks_per_process=1,
+        )
         await w.start()
 
         while w._redis_stream is None or (await w._redis_stream.zcard("streams")) > 0:


### PR DESCRIPTION
GHES owner ids are differents and don't goes through shared-0.

This change changes the worker configuration to ensure everything goes to
shared-0 worker.

Fixes MRGFY-1133
