### PR TITLE
test(ghes): fix assertion

### DIFF
--- a/mergify_engine/tests/functional/test_attributes.py
+++ b/mergify_engine/tests/functional/test_attributes.py
@@ -120,7 +120,7 @@ class TestAttributes(base.FunctionalTestBase):
         expected = (
             "### Rule: ~~merge (close)~~\n:no_entry_sign: **Disabled: code freeze**\n"
         )
-        assert expected == summary["output"]["summary"][: len(expected)]
+        assert expected in summary["output"]["summary"]
 
     async def test_schedule(self) -> None:
         rules = {


### PR DESCRIPTION
Serialized summary is on top now, we can't use startswith() anymore.