### PR TITLE
chore(debug): remove useless checks

### DIFF
--- a/mergify_engine/debug.py
+++ b/mergify_engine/debug.py
@@ -75,32 +75,6 @@ async def report_dashboard_synchro(
     print(
         f"* {title} SUB NUMBER OF TOKENS: {len(uts.users)} ({', '.join(u['login'] for u in uts.users)})"
     )
-    for user in uts.users:
-        try:
-            repos = await get_repositories_setuped(
-                user["oauth_access_token"], install_id
-            )
-        except http.HTTPNotFound:
-            print(f"* {title} SUB: MERGIFY SEEMS NOT INSTALLED")
-            return
-        except http.HTTPClientSideError as e:
-            print(
-                f"* {title} SUB: token for {user['login']} is invalid "
-                f"({e.status_code}: {e.message})"
-            )
-        else:
-            if slug is not None:
-                if any((r["full_name"] == slug) for r in repos):
-                    print(
-                        f"* {title} SUB: MERGIFY INSTALLED AND ENABLED ON THIS REPOSITORY"
-                    )
-                else:
-                    print(
-                        f"* {title} SUB: MERGIFY INSTALLED BUT DISABLED ON THIS REPOSITORY"
-                    )
-            break
-    else:
-        print(f"* {title} SUB: MERGIFY DOESN'T HAVE ANY VALID OAUTH TOKENS")
 
 
 async def report_worker_status(owner: github_types.GitHubLogin) -> None:

--- a/mergify_engine/tests/functional/test_debug.py
+++ b/mergify_engine/tests/functional/test_debug.py
@@ -97,10 +97,8 @@ class TestDebugger(base.FunctionalTestBase):
   - show_sponsor
 * ENGINE-CACHE SUB DETAIL: You're not nice
 * ENGINE-CACHE SUB NUMBER OF TOKENS: 2 (mergify-test1, mergify-test4)
-* ENGINE-CACHE SUB: MERGIFY INSTALLED AND ENABLED ON THIS REPOSITORY
 * DASHBOARD SUB DETAIL: You're not nice
 * DASHBOARD SUB NUMBER OF TOKENS: 2 (mergify-test1, mergify-test4)
-* DASHBOARD SUB: MERGIFY INSTALLED AND ENABLED ON THIS REPOSITORY
 * WORKER: Installation not queued to process
 * REPOSITORY IS PUBLIC
 * DEFAULT BRANCH: {self.main_branch_name}


### PR DESCRIPTION
It doesn't make sense to test repository access with a random oauth
token.

Repository is accessed just after with the app and will return 404, if
Mergify is not installed, it's enought to debug.

Fixes MRGFY-1138