### PR TITLE
test(tox): use random redis port

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-COMPOSE_PROJECT_NAME=mergify

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,4 @@ services:
   redis:
     image: redis
     ports:
-      - 6363:6379
+      - 0:6379

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,6 @@ setenv =
    DD_DOGSTATSD_DISABLE=1
    DD_TRACE_ENABLED=0
    MERGIFYENGINE_TEST_SETTINGS=fake.env
-   MERGIFYENGINE_STORAGE_URL=redis://localhost:6363?db=2&idle_check_interval=0
-   MERGIFYENGINE_STREAM_URL=redis://localhost:6363?db=3&idle_check_interval=0
    PYTEST_TIMEOUT=20
 usedevelop = true
 extras = test
@@ -33,8 +31,6 @@ setenv =
    DD_DOGSTATSD_DISABLE=1
    DD_TRACE_ENABLED=0
    MERGIFYENGINE_TEST_SETTINGS=test.env
-   MERGIFYENGINE_STORAGE_URL=redis://localhost:6363?db=2&idle_check_interval=0
-   MERGIFYENGINE_STREAM_URL=redis://localhost:6363?db=3&idle_check_interval=0
    PYTEST_TIMEOUT=500
 whitelist_externals =
     git
@@ -53,8 +49,6 @@ setenv =
    DD_TRACE_ENABLED=0
    MERGIFYENGINE_API_ENABLE=1
    MERGIFYENGINE_TEST_SETTINGS=test.env
-   MERGIFYENGINE_STORAGE_URL=redis://localhost:6363?db=2
-   MERGIFYENGINE_STREAM_URL=redis://localhost:6363?db=3
 commands = {toxinidir}/run-tests.sh honcho start --port 8802
 
 [testenv:requirements]


### PR DESCRIPTION
This allows to run multiple dashboard and engine tests in //.
