### PR TITLE
fix(assign): signal and error handling

### DIFF
--- a/mergify_engine/signals.py
+++ b/mergify_engine/signals.py
@@ -25,8 +25,7 @@ from mergify_engine import context
 LOG = daiquiri.getLogger(__name__)
 
 EventName = typing.Literal[
-    "action.assign.added",
-    "action.assign.removed",
+    "action.assign",
     "action.backport",
     "action.copy",
     "action.close",
@@ -48,7 +47,7 @@ EventName = typing.Literal[
     "action.update",
 ]
 
-SignalMetadata = typing.Dict[str, typing.Union[str, int, float, bool]]
+SignalMetadata = typing.Dict[str, typing.Union[str, int, float, bool, typing.List[str]]]
 SignalT = typing.Callable[
     [context.Context, EventName, typing.Optional[SignalMetadata]],
     typing.Coroutine[None, None, None],


### PR DESCRIPTION
The action does not return error to engine, so error was just ignored.
Signal was unconditionnally send even if the action was doing nothing.

This change fixes that.

Related MRGFY-1142