### PR TITLE
ci(dependabot): create PR earlier in the day

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,26 +4,26 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-      time: "09:00"
+      time: "08:00"
       timezone: Europe/Paris
     open-pull-requests-limit: 10
   - package-ecosystem: npm
     directory: "/docs"
     schedule:
       interval: daily
-      time: "09:00"
+      time: "08:00"
       timezone: Europe/Paris
     open-pull-requests-limit: 10
   - package-ecosystem: npm
     directory: "/installer"
     schedule:
       interval: daily
-      time: "09:00"
+      time: "08:00"
       timezone: Europe/Paris
     open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: daily
-      time: "09:00"
+      time: "08:00"
       timezone: Europe/Paris


### PR DESCRIPTION
We now have a schedule to merge this when we want so we can create them
early so we have a chance to prepare the batch before the regular queue
opens.