### PR TITLE
PoC: refactor(queue): reuse branch prepared in previous car

### DIFF
--- a/mergify_engine/tests/functional/actions/test_queue.py
+++ b/mergify_engine/tests/functional/actions/test_queue.py
@@ -651,7 +651,7 @@ class TestQueueAction(base.FunctionalTestBase):
 
         await self.run_engine()
         await assert_queued()
-        assert tmp_pull["commits"] in (5, 6)
+        assert tmp_pull["commits"] == 4
         assert tmp_pull["changed_files"] == 2
 
         await self.create_status(tmp_pull)


### PR DESCRIPTION
This avoid merging parents pull into the checking branches.

Fixes MRGFY-1004

Change-Id: I47892e1e6e4ecfe7857901da94fb3e2b8673b676
