### PR TITLE
fix(queue): add message when branch protection is misconfigured

### DIFF
--- a/docs/source/actions/queue.rst
+++ b/docs/source/actions/queue.rst
@@ -213,6 +213,13 @@ For example, if your queue is 15 pull requests long and you have
 draft pull requests of 5 pull requests each being tested at the same time. If
 your CI time is 10 min, you can merge those 15 pull requests in only 10 minutes.
 
+.. warning::
+
+   With batch mode, pull requests are tested against the base branch
+   within another temporary pull request. This requires the branch protection
+   settings ``Require branches to be up to date before merging`` to be
+   disabled. If you require a linear history, just set the queue option ``merge: rebase``.
+
 Queue Freeze
 ------------
 

--- a/mergify_engine/actions/queue.py
+++ b/mergify_engine/actions/queue.py
@@ -228,6 +228,28 @@ Then, re-embark the pull request into the merge queue by posting the comment
                     "The merge `method` or the queue configuration must be updated.",
                 )
 
+        protection = await ctxt.repository.get_branch_protection(
+            ctxt.pull["base"]["ref"]
+        )
+        if (
+            protection
+            and "required_status_checks" in protection
+            and "strict" in protection["required_status_checks"]
+            and protection["required_status_checks"]["strict"]
+        ):
+            if self.queue_rule.config["batch_size"] > 1:
+                return check_api.Result(
+                    check_api.Conclusion.FAILURE,
+                    "batch_size > 1 is not compatible with branch protection setting",
+                    "The branch protection setting `Require branches to be up to date before merging` must be unset.",
+                )
+            elif self.queue_rule.config["speculative_checks"] > 1:
+                return check_api.Result(
+                    check_api.Conclusion.FAILURE,
+                    "speculative_checks > 1 is not compatible with branch protection setting",
+                    "The branch protection setting `Require branches to be up to date before merging` must be unset.",
+                )
+
         # FIXME(sileht): we should use the computed update_bot_account in TrainCar.update_pull(),
         # not the original one
         try:


### PR DESCRIPTION
batch_size and speculative_checks requires branch protection strict mode
to be disabled.