### PR TITLE
fix(queue): add message when branch protection is misconfigured

### DIFF
--- a/docs/source/actions/queue.rst
+++ b/docs/source/actions/queue.rst
@@ -186,8 +186,9 @@ disembarked and re-embarked.
 
    With speculative checks, pull requests are tested against the base branch
    within another temporary pull request. This requires the branch protection
-   settings ``Require branches to be up to date before merging`` to be
-   disabled. If you require a linear history, just set the queue option ``merge: rebase``.
+   settings ``Require branches to be up to date before merging`` and ``Require
+   linear history`` to be disabled. If you require a linear history, just set
+   the queue option ``merge: rebase``.
 
 Batch Size
 ----------
@@ -217,8 +218,9 @@ your CI time is 10 min, you can merge those 15 pull requests in only 10 minutes.
 
    With batch mode, pull requests are tested against the base branch
    within another temporary pull request. This requires the branch protection
-   settings ``Require branches to be up to date before merging`` to be
-   disabled. If you require a linear history, just set the queue option ``merge: rebase``.
+   settings ``Require branches to be up to date before merging`` and `` Require
+   linear history`` to be disabled. If you require a linear history, just set
+   the queue option ``merge: rebase``.
 
 Queue Freeze
 ------------

--- a/mergify_engine/actions/queue.py
+++ b/mergify_engine/actions/queue.py
@@ -233,6 +233,24 @@ Then, re-embark the pull request into the merge queue by posting the comment
         )
         if (
             protection
+            and "required_linear_history" in protection
+            and protection["required_linear_history"]["enabled"]
+        ):
+            if self.queue_rule.config["batch_size"] > 1:
+                return check_api.Result(
+                    check_api.Conclusion.FAILURE,
+                    "batch_size > 1 is not compatible with branch protection setting",
+                    "The branch protection setting `Require linear history` must be unset.",
+                )
+            elif self.queue_rule.config["speculative_checks"] > 1:
+                return check_api.Result(
+                    check_api.Conclusion.FAILURE,
+                    "speculative_checks > 1 is not compatible with branch protection setting",
+                    "The branch protection setting `Require linear history` must be unset.",
+                )
+
+        if (
+            protection
             and "required_status_checks" in protection
             and "strict" in protection["required_status_checks"]
             and protection["required_status_checks"]["strict"]


### PR DESCRIPTION
When linear history is required we can't do speculative/batch checks.

Fixes #1176

Change-Id: Icc53f82ed7de63bae22a9b09741cec12e1c0875e