### PR TITLE
fix(docs): handle sphinx upgrade with dependabot

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -85,8 +85,8 @@ release_notes =
     reno==3.5.0
 
 docs =
-    sphinx
-    sphinxcontrib-spelling
+    sphinx==4.5.0
+    sphinxcontrib-spelling==7.4.1
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This tags sphinx libs with last known working version.

Sphinx 5.0.0 breaks and complains about missing meta that existing in
the files.