### PR TITLE
refactor(service): use MERGIFYENGINE_VERSION to detect version

### DIFF
--- a/mergify_engine/clients/http.py
+++ b/mergify_engine/clients/http.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 #
-# Copyright © 2020–2021 Mergify SAS
+# Copyright © 2020–2022 Mergify SAS
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -14,7 +14,6 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import os
 import sys
 import typing
 
@@ -26,12 +25,11 @@ import tenacity.wait
 from werkzeug.http import parse_date
 
 from mergify_engine import date
+from mergify_engine import service
 
 
 LOG = daiquiri.getLogger(__name__)
 
-DEPLOY_VERSION = os.getenv("HEROKU_RELEASE_VERSION", "dev")
-ENGINE_VERSION = os.getenv("HEROKU_SLUG_COMMIT", "dev")[:7]
 PYTHON_VERSION = (
     f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
 )
@@ -39,7 +37,7 @@ HTTPX_VERSION = httpx.__version__
 
 DEFAULT_HEADERS = httpx.Headers(
     {
-        "User-Agent": f"mergify-engine/{ENGINE_VERSION} deploy/{DEPLOY_VERSION} python/{PYTHON_VERSION} httpx/{HTTPX_VERSION}"
+        "User-Agent": f"mergify-engine/{service.VERSION} python/{PYTHON_VERSION} httpx/{HTTPX_VERSION}"
     }
 )
 

--- a/mergify_engine/service.py
+++ b/mergify_engine/service.py
@@ -1,5 +1,7 @@
 # -*- encoding: utf-8 -*-
 #
+# Copyright © 2020–2022 Mergify SAS
+#
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at
@@ -23,19 +25,18 @@ from mergify_engine import logs
 
 
 SERVICE_NAME: str = "engine-<unknown>"
+VERSION: str = os.environ.get("MERGIFYENGINE_VERSION", "unknown")
 
 
 def setup(service_name: str, dump_config: bool = True) -> None:
     global SERVICE_NAME
     SERVICE_NAME = "engine-" + service_name
 
-    _version = os.environ.get("HEROKU_RELEASE_VERSION")
-
     if config.SENTRY_URL:  # pragma: no cover
         sentry_sdk.init(
             config.SENTRY_URL,
             max_breadcrumbs=10,
-            release=_version,
+            release=VERSION,
             environment=config.SENTRY_ENVIRONMENT,
             integrations=[
                 httpx.HttpxIntegration(),
@@ -43,7 +44,7 @@ def setup(service_name: str, dump_config: bool = True) -> None:
         )
         sentry_sdk.utils.MAX_STRING_LENGTH = 2048
 
-    ddtrace.config.version = _version
+    ddtrace.config.version = VERSION
     statsd.constant_tags.append(f"service:{SERVICE_NAME}")
     ddtrace.config.service = SERVICE_NAME
 

--- a/mergify_engine/tests/unit/test_logging.py
+++ b/mergify_engine/tests/unit/test_logging.py
@@ -77,7 +77,7 @@ def test_logging(
             # here we get a random service depending on the order tests are
             # running, so use ANY for now.
             "service": mock.ANY,
-            "version": "",
+            "version": "unknown",
             "env": "",
             "HEROKU_RELEASE_VERSION": "v1234",
             "HEROKU_SLUG_COMMIT": "75a50b499de27757f171bac717c81685d648d3a7",


### PR DESCRIPTION
This must be passed as an environment variable to have the version set.
This removes the dependency on Heroku and leverage something more useful
such as the sha1.

Fixes MRGFY-1206