### PR TITLE
fix(request-reviewers): return ACTION_REQUIRED on team errors

### DIFF
--- a/mergify_engine/actions/request_reviews.py
+++ b/mergify_engine/actions/request_reviews.py
@@ -216,7 +216,7 @@ class RequestReviewsAction(actions.Action):
 
         if team_errors:
             return check_api.Result(
-                check_api.Conclusion.FAILURE,
+                check_api.Conclusion.ACTION_REQUIRED,
                 "Invalid requested teams",
                 "\n".join(team_errors),
             )

--- a/mergify_engine/tests/unit/actions/test_request_reviews.py
+++ b/mergify_engine/tests/unit/actions/test_request_reviews.py
@@ -202,7 +202,7 @@ async def test_team_permissions_missing(
     ctxt = await context_getter(github_types.GitHubPullRequestNumber(1))
     ctxt.repository.installation.client = client
     result = await action.run(ctxt, None)
-    assert result.conclusion == check_api.Conclusion.FAILURE
+    assert result.conclusion == check_api.Conclusion.ACTION_REQUIRED
     assert result.title == "Invalid requested teams"
     for error in (
         "Team `foobar` does not exist or has not access to this repository",


### PR DESCRIPTION
This makes the engine retrying the action until the error is fixed.

Fixes MRGFY-1212

Change-Id: I2c3a7cb433d1d7472f64d53e59711cf04a5bda51