### PR TITLE
fix(tests): change the ways we add additional permissions of testing app

### DIFF
--- a/mergify_engine/clients/github_app.py
+++ b/mergify_engine/clients/github_app.py
@@ -15,6 +15,7 @@
 # under the License.
 
 import dataclasses
+import os
 import threading
 import time
 import typing
@@ -53,6 +54,12 @@ EXPECTED_MINIMAL_PERMISSIONS: typing.Dict[
         "statuses": "read",
     },
 }
+
+
+if os.getenv("MERGIFYENGINE_TEST_SETTINGS") is not None:
+    # NOTE(sileht): Here the permission that's differ from testing app and production app
+    EXPECTED_MINIMAL_PERMISSIONS["User"]["statuses"] = "write"
+    EXPECTED_MINIMAL_PERMISSIONS["Organization"]["statuses"] = "write"
 
 
 @dataclasses.dataclass

--- a/mergify_engine/tests/__init__.py
+++ b/mergify_engine/tests/__init__.py
@@ -20,12 +20,6 @@ from unittest import mock
 from datadog import statsd
 
 from mergify_engine import worker
-from mergify_engine.clients import github_app
-
-
-# NOTE(sileht): Here the permission that's differ from testing app and production app
-github_app.EXPECTED_MINIMAL_PERMISSIONS["User"]["statuses"] = "write"
-github_app.EXPECTED_MINIMAL_PERMISSIONS["Organization"]["statuses"] = "write"
 
 
 statsd.socket = mock.Mock()  # type:ignore[assignment]


### PR DESCRIPTION
Currently, the solution using `__init__.py` works only for `tox -e py310/record`.

This makes it also works for `tox -e test`

Fixes MRGFY-1218

Change-Id: I3e401369ed9f49c347e39f901cbe823e0f793cb8