### PR TITLE
fix(merge/queue): never report merge failure as failure

### DIFF
--- a/mergify_engine/actions/merge_base.py
+++ b/mergify_engine/actions/merge_base.py
@@ -267,7 +267,7 @@ class MergeBaseAction(actions.Action, abc.ABC):
                 error_message=e.message,
             )
             return check_api.Result(
-                check_api.Conclusion.FAILURE,
+                check_api.Conclusion.CANCELLED,
                 message,
                 f"GitHub error message: `{e.message}`",
             )


### PR DESCRIPTION
We should not return FAILURE, as it means it's fatal for the rule
engine.

This allows the merge to be retried in case of the pull request is
requeued.

Fixes MRGFY-1220

Change-Id: I9561e1bbb145f26d3f4306948d20bf98a7129e08