### PR TITLE
fix(tests): Fix incorrect `pytest.raises(...) as` usage

### DIFF
--- a/mergify_engine/tests/functional/actions/test_queue.py
+++ b/mergify_engine/tests/functional/actions/test_queue.py
@@ -4262,8 +4262,8 @@ class TestTrainApiCalls(base.FunctionalTestBase):
                     config=queue_config,
                 )
             )
-            assert exc_info.value.car == car
-            assert car.queue_pull_request_number is None
+        assert exc_info.value.car == car
+        assert car.queue_pull_request_number is None
 
         p3 = await self.get_pull(p3["number"])
         ctxt_p3 = context.Context(self.repository_ctxt, p3)

--- a/mergify_engine/tests/unit/actions/test_merge.py
+++ b/mergify_engine/tests/unit/actions/test_merge.py
@@ -93,7 +93,7 @@ my body""",
 
 # Commit Message
 
-my title     
+my title
 WATCHOUT ^^^ there is empty spaces above for testing ^^^^
 my body""",  # noqa:W293,W291
             "my title",
@@ -184,30 +184,26 @@ async def test_merge_commit_message_undefined(
     )
     with pytest.raises(context.RenderTemplateFailure) as x:
         await ctxt.pull_request.get_commit_message()
-        assert str(x) == "foobar"
+    assert "foobar" in str(x.value)
 
 
 @pytest.mark.parametrize(
-    "body,error",
+    "body",
     [
-        (
-            """Hello world
+        """Hello world
 
 # Commit Message
 {{title}}
 
 here is my message {{ and broken template
-""",
-            "lol",
-        ),
+"""
     ],
 )
 async def test_merge_commit_message_syntax_error(
-    body: str, error: str, context_getter: conftest.ContextGetterFixture
+    body: str, context_getter: conftest.ContextGetterFixture
 ) -> None:
     ctxt = await context_getter(
         github_types.GitHubPullRequestNumber(43), body=body, title="My PR title"
     )
-    with pytest.raises(context.RenderTemplateFailure) as rmf:
+    with pytest.raises(context.RenderTemplateFailure):
         await ctxt.pull_request.get_commit_message()
-        assert str(rmf) == error


### PR DESCRIPTION
The exception variable used in the `as` should be used outside of the
`with` scope.