### PR TITLE
fix(tests): Re-add trailing whitespace for test_merge_commit_message

### DIFF
--- a/mergify_engine/tests/unit/actions/test_merge.py
+++ b/mergify_engine/tests/unit/actions/test_merge.py
@@ -93,7 +93,7 @@ my body""",
 
 # Commit Message
 
-my title
+my title     
 WATCHOUT ^^^ there is empty spaces above for testing ^^^^
 my body""",  # noqa:W293,W291
             "my title",


### PR DESCRIPTION
They were removed by mistake by ac1c10fc291c530745b28a37d452ac6bc14bbc06