### PR TITLE
fix(delayed-refresh): decrease priority of delayed-refresh

### DIFF
--- a/mergify_engine/delayed_refresh.py
+++ b/mergify_engine/delayed_refresh.py
@@ -163,6 +163,7 @@ async def send(
                 "ref": None,
                 "source": "delayed-refresh",
             },  # type: ignore[typeddict-item]
+            score=str(worker.get_priority_score(worker.Priority.medium)),
         )
         keys_to_delete.add(subkey)
 


### PR DESCRIPTION
Currently when a time conditions will change its status, we will refresh
all opened pull refresh to reflect that in the Summary.

This meantime that at certain hours Mergify may looks laggy.

Delayed refresh doesn't really need to be on time, we already
document that delayed-refresh can be 5 minutes late, so.

This introduces a new level of priority: medium. By default GitHub events
stay high as before. delayed-refresh are now medium. And pull request
refresh due to push events stay low.

Fixes MRGFY-1234
