### PR TITLE
ci(docs): fix tmp doc upload trigger

### DIFF
--- a/.github/workflows/docs-upload-gcp-temp.yaml
+++ b/.github/workflows/docs-upload-gcp-temp.yaml
@@ -2,7 +2,7 @@ name: Upload temporary docs to GCP
 
 on:
   workflow_run:
-    workflows: ["Continuous Integration (docs)"]
+    workflows: ["Continuous Integration"]
     types:
       - completed
 


### PR DESCRIPTION
aa61f01287 has changed the name of the job and break this.

This change uses the new name.

Fixes MRGFY-1213