### PR TITLE
feat(worker): preload/reload redis scripts dynamically on client connection

### DIFF
--- a/mergify_engine/tests/conftest.py
+++ b/mergify_engine/tests/conftest.py
@@ -91,7 +91,6 @@ def enable_api() -> None:
 async def redis_links() -> typing.AsyncGenerator[redis_utils.RedisLinks, None]:
     links = redis_utils.RedisLinks(name="global-fixture")
     await links.flushall()
-    await redis_utils.load_scripts(links.cache)
     try:
         yield links
     finally:

--- a/mergify_engine/web/redis.py
+++ b/mergify_engine/web/redis.py
@@ -34,7 +34,6 @@ async def startup() -> None:
         queue_max_connections=config.REDIS_QUEUE_WEB_MAX_CONNECTIONS,
         eventlogs_max_connections=config.REDIS_EVENTLOGS_WEB_MAX_CONNECTIONS,
     )
-    await redis_utils.load_scripts(_REDIS_LINKS.cache)
 
 
 async def shutdown() -> None:

--- a/mergify_engine/worker.py
+++ b/mergify_engine/worker.py
@@ -1186,8 +1186,6 @@ class Worker:
         await ping_redis(self._redis_links.stream, "Stream")
         await ping_redis(self._redis_links.cache, "Cache")
 
-        await redis_utils.load_scripts(self._redis_links.stream)
-
         self._dedicated_workers_syncer_task = self.create_task(
             "dedicated workers cache syncer",
             self.dedicated_workers_syncer_idle_time,


### PR DESCRIPTION
To ensure the good loading of redis scripts all along the engine workflow, at any time,
and avoid worker failures, we needed to setup a way of loading them dynamically.
These changes have also lead to the removing of all migrations scripts and tests.

Fixes MRGFY-1259