### PR TITLE
fix(eventlogs): Don't enforce that all fields should be there

### DIFF
--- a/mergify_engine/signals.py
+++ b/mergify_engine/signals.py
@@ -56,7 +56,7 @@ EventName = typing.Literal[
 ]
 
 
-class EventMetadata(typing.TypedDict):
+class EventMetadata(typing.TypedDict, total=False):
     pass
 
 
@@ -116,7 +116,7 @@ ChecksConclusion = typing.Literal[
 ]
 
 
-class SpeculativeCheckPullRequest(typing.TypedDict):
+class SpeculativeCheckPullRequest(typing.TypedDict, total=False):
     number: int
     in_place: bool
     checks_timed_out: bool


### PR DESCRIPTION
All recorded events may not have all fields we currently have in the
code.

This change makes all of them optional.

Fixes MERGIFY-ENGINE-2R1