### PR TITLE
fix(merge/queue): ensure context is updated on merged PR

### DIFF
--- a/mergify_engine/actions/merge_base.py
+++ b/mergify_engine/actions/merge_base.py
@@ -154,7 +154,7 @@ class MergeBaseAction(actions.Action, abc.ABC, typing.Generic[T]):
                     return await self._handle_merge_error(e, ctxt, rule, queue)
             else:
                 await self.send_signal(ctxt, rule, queue)
-                await ctxt.update()
+                await ctxt.update(wait_merged=True)
                 ctxt.log.info("merged")
 
         result = await self.merge_report(ctxt)


### PR DESCRIPTION
If GitHub is laggy, the next /pull/XXX after a PR get merged may not be
marked as merged. Since the merge queue code relies on this to known if
something unexpectedly merged in meantimes, we must wait the attributes
merged change.

Fixes MRGFY-1272

Change-Id: I9acf4a82732fa28a0aa2c9dc1fd4b123167ec23e