### PR TITLE
chore(mergify): remove approval on new commits

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -113,17 +113,10 @@ pull_request_rules:
         message: "@dependabot recreate"
 
   - name: dismiss reviews except for core devs
-    conditions:
-      - author!=@devs
+    conditions: []
     actions:
       dismiss_reviews: {}
-  - name: dismiss reviews for core devs
-    conditions:
-      - author=@devs
-    actions:
-      dismiss_reviews:
-        # Do not remove approval for core devs
-        approved: False
+
   - name: request review
     conditions:
       - -author=dependabot[bot]


### PR DESCRIPTION
Now that there more regular contributors, there's no need to keep
approval for ever. We can re-request a review.

This should prevent issues where wrong push could be merged by
mistake.